### PR TITLE
Fix sample themes to use OS theme, add VSCode tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,10 +6,10 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build_sandbox",
-            "program": "${workspaceFolder}/src/SandboxApp/bin/Debug/net9.0/SandboxApp.dll",
+            "program": "${workspaceFolder}/samples/SandboxApp/bin/Debug/net9.0/SandboxApp.dll",
             "args": [ 
             ],
-            "cwd": "${workspaceFolder}/src/SandboxApp/bin/Debug/net9.0",
+            "cwd": "${workspaceFolder}/samples/SandboxApp/bin/Debug/net9.0",
             "console": "internalConsole",
             "stopAtEntry": false
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Sandbox",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build_sandbox",
+            "program": "${workspaceFolder}/src/SandboxApp/bin/Debug/net9.0/SandboxApp.dll",
+            "args": [ 
+            ],
+            "cwd": "${workspaceFolder}/src/SandboxApp/bin/Debug/net9.0",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "ControlGallery Desktop",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build_controlgallery_desktop",
+            "program": "${workspaceFolder}/samples/ControlGallery/ControlGallery.Desktop/bin/Debug/net9.0/ControlGallery.Desktop.dll",
+            "args": [ 
+            ],
+            "cwd": "${workspaceFolder}/samples/ControlGallery/ControlGallery.Desktop/bin/Debug/net9.0",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build_sandbox",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/samples/SandboxApp/SandboxApp.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+         {
+            "label": "build_controlgallery_desktop",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/samples/ControlGallery/ControlGallery.Desktop/ControlGallery.Desktop.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+    ]
+}

--- a/samples/ControlGallery/ControlGallery.Desktop/MauiAppStub.xaml
+++ b/samples/ControlGallery/ControlGallery.Desktop/MauiAppStub.xaml
@@ -2,7 +2,6 @@
 <Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:ControlGallery"
-             UserAppTheme="Dark"
              x:Class="ControlGallery.MauiAppStub">
     <Application.Resources>
         <ResourceDictionary>

--- a/samples/SandboxApp/MauiAppStub.xaml
+++ b/samples/SandboxApp/MauiAppStub.xaml
@@ -2,7 +2,6 @@
 <Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:SandboxApp"
-             UserAppTheme="Dark"
              x:Class="SandboxApp.MauiAppStub">
     <Application.Resources>
         <ResourceDictionary>

--- a/samples/SandboxAppWasm/MauiAppStub.xaml
+++ b/samples/SandboxAppWasm/MauiAppStub.xaml
@@ -2,7 +2,6 @@
 <Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:SandboxApp"
-             UserAppTheme="Dark"
              x:Class="SandboxApp.MauiAppStub">
     <Application.Resources>
         <ResourceDictionary>


### PR DESCRIPTION
<img width="1228" height="1108" alt="image" src="https://github.com/user-attachments/assets/1f4dfc7c-15a9-4502-91a7-bd1ecdaf57bf" />

I had hardcoded the theme by mistake for the sandbox and control gallery app. This fixes it so it should now properly use the right theme on the OS level. Later, we can add specific tests and pages for checking switching the theme dynamically.