### PR TITLE
Build against Avalonia 12 Nightly builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
     <PropertyGroup>
         <!-- <AvaloniaVersion>9999.0.0-localbuild</AvaloniaVersion> -->
-        <Version Condition="'$(Version)' == ''">11.3.8</Version>
+        <Version Condition="'$(Version)' == ''">12.0.0</Version>
         <IsPackable>false</IsPackable>
-        <AvaloniaVersion Condition="'$(AvaloniaVersion)' == ''">11.3.8</AvaloniaVersion>
+        <AvaloniaVersion Condition="'$(AvaloniaVersion)' == ''">12.0.999-cibuild0060160-alpha</AvaloniaVersion>
         <DotNetTfm Condition="'$(DotNetTfm)' == ''">net9.0</DotNetTfm>
         <MauiSrcDirectory>$(MSBuildThisFileDirectory)/src/</MauiSrcDirectory>
         <BuildDirectory>$(MSBuildThisFileDirectory)/build/</BuildDirectory>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -12,7 +12,7 @@
   </fallbackPackageFolders>
 
   <packageSourceMapping>
-    <packageSource key="nuget.org">
+    <packageSource key="api.nuget.org">
       <package pattern="*" />
       <package pattern="Avalonia*" />
     </packageSource>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,5 +4,20 @@
   <packageSources>
     <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="avalonia-nightly" value="https://nuget-feed-nightly.avaloniaui.net/v3/index.json" protocolVersion="3" />
   </packageSources>
+
+  <fallbackPackageFolders>
+    <clear />
+  </fallbackPackageFolders>
+
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+      <package pattern="Avalonia*" />
+    </packageSource>
+    <packageSource key="avalonia-nightly">
+      <package pattern="Avalonia*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
This re-adds using Avalonia 12 builds from CI, with the package source mapping, so it shouldn't pull every package from the CI NuGet feeds.