### PR TITLE
Make custom Avalonia controls internal to lock them to MAUI ABI

### DIFF
--- a/src/Avalonia.Controls.Maui.Graphics/Handlers/GraphicsViewHandler.cs
+++ b/src/Avalonia.Controls.Maui.Graphics/Handlers/GraphicsViewHandler.cs
@@ -5,7 +5,7 @@ using PlatformView = System.Object;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-public partial class GraphicsViewHandler : ViewHandler<IGraphicsView, PlatformTouchGraphicsView>, IGraphicsViewHandler
+internal partial class GraphicsViewHandler : ViewHandler<IGraphicsView, PlatformTouchGraphicsView>, IGraphicsViewHandler
 {
     public static IPropertyMapper<IGraphicsView, IGraphicsViewHandler> Mapper = new PropertyMapper<IGraphicsView, IGraphicsViewHandler>(ViewMapper)
     {

--- a/src/Avalonia.Controls.Maui.Graphics/Platform/PlatformGraphicsView.cs
+++ b/src/Avalonia.Controls.Maui.Graphics/Platform/PlatformGraphicsView.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Controls.Maui.Platform;
 /// <summary>
 /// Platform graphics view that integrates Microsoft.Maui.Graphics IDrawable with Avalonia rendering
 /// </summary>
-public class PlatformGraphicsView : Control
+internal class PlatformGraphicsView : Control
 {
     private IGraphicsView? _graphicsView;
     private IDrawable? _drawable;

--- a/src/Avalonia.Controls.Maui.Graphics/Platform/PlatformTouchGraphicsView.cs
+++ b/src/Avalonia.Controls.Maui.Graphics/Platform/PlatformTouchGraphicsView.cs
@@ -9,7 +9,7 @@ namespace Avalonia.Controls.Maui.Platform;
 /// <summary>
 /// Platform touch graphics view that handles pointer interactions for GraphicsView
 /// </summary>
-public class PlatformTouchGraphicsView : UserControl
+internal class PlatformTouchGraphicsView : UserControl
 {
     private IGraphicsView? _graphicsView;
     private readonly PlatformGraphicsView _platformGraphicsView;

--- a/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRing.cs
+++ b/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRing.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Controls.Maui;
 /// Supports both determinate and indeterminate modes.
 /// </summary>
 [PseudoClasses(":active", ":indeterminate", ":determinate")]
-public class ProgressRing : RangeBase
+internal class ProgressRing : RangeBase
 {
     static ProgressRing()
     {

--- a/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRingAutomationPeer.cs
+++ b/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRingAutomationPeer.cs
@@ -5,7 +5,7 @@ namespace Avalonia.Controls.Maui
     /// <summary>
     /// Automation peer for ProgressRing to support screen readers and assistive technologies.
     /// </summary>
-    public class ProgressRingAutomationPeer : RangeBaseAutomationPeer
+    internal class ProgressRingAutomationPeer : RangeBaseAutomationPeer
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ProgressRingAutomationPeer"/> class.

--- a/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRingVisual.cs
+++ b/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRingVisual.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Controls.Maui;
 /// Visual component for rendering the <see cref="ProgressRing"/> animation.
 /// This is a template part that can be replaced for custom visualizations.
 /// </summary>
-public class ProgressRingVisual : Control
+internal class ProgressRingVisual : Control
 {
     private Stopwatch? _animationStopwatch;
     private DispatcherTimer? _animationTimer;

--- a/src/Avalonia.Controls.Maui/Extensions/ActivityIndicatorExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/ActivityIndicatorExtensions.cs
@@ -12,7 +12,7 @@ public static class ActivityIndicatorExtensions
     /// </summary>
     /// <param name="control">The ProgressRing control to update.</param>
     /// <param name="activityIndicator">The .NET MAUI ActivityIndicator providing the state.</param>
-    public static void UpdateIsRunning(this ProgressRing control, IActivityIndicator activityIndicator)
+    internal static void UpdateIsRunning(this ProgressRing control, IActivityIndicator activityIndicator)
     {
         control.IsActive = activityIndicator.IsRunning;
     }
@@ -22,7 +22,7 @@ public static class ActivityIndicatorExtensions
     /// </summary>
     /// <param name="control">The ProgressRing control to update.</param>
     /// <param name="activityIndicator">The .NET MAUI ActivityIndicator providing the color.</param>
-    public static void UpdateColor(this ProgressRing control, IActivityIndicator activityIndicator)
+    internal static void UpdateColor(this ProgressRing control, IActivityIndicator activityIndicator)
     {
         if (activityIndicator.Color != null)
         {

--- a/src/Avalonia.Controls.Maui/Handlers/ActivityIndicatorHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ActivityIndicatorHandler.cs
@@ -5,7 +5,7 @@ using PlatformView = Avalonia.Controls.Maui.ProgressRing;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-public partial class ActivityIndicatorHandler : ViewHandler<IActivityIndicator, ProgressRing>, IActivityIndicatorHandler
+internal partial class ActivityIndicatorHandler : ViewHandler<IActivityIndicator, ProgressRing>, IActivityIndicatorHandler
 {
     public static IPropertyMapper<IActivityIndicator, IActivityIndicatorHandler> Mapper = new PropertyMapper<IActivityIndicator, IActivityIndicatorHandler>(ViewHandler.ViewMapper)
     {

--- a/src/Avalonia.Controls.Maui/Handlers/BorderHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/BorderHandler.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Controls.Maui.Handlers;
 /// <summary>
 /// Handler for MAUI Border control using custom Avalonia BorderView.
 /// </summary>
-public class BorderHandler : ViewHandler<IBorderView, PlatformView>, IBorderHandler
+internal class BorderHandler : ViewHandler<IBorderView, PlatformView>, IBorderHandler
 {
     public static IPropertyMapper<IBorderView, IBorderHandler> Mapper =
         new PropertyMapper<IBorderView, IBorderHandler>(ViewMapper)

--- a/src/Avalonia.Controls.Maui/Handlers/ButtonHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ButtonHandler.cs
@@ -11,7 +11,7 @@ using PlatformView = Avalonia.Controls.Maui.Platform.MauiButton;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-public class ButtonHandler : ViewHandler<IButton, MauiButton>, IButtonHandler
+internal class ButtonHandler : ViewHandler<IButton, MauiButton>, IButtonHandler
 {
     public static IPropertyMapper<ITextButton, IButtonHandler> TextButtonMapper = new PropertyMapper<ITextButton, IButtonHandler>()
     {

--- a/src/Avalonia.Controls.Maui/Handlers/CarouselViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/CarouselViewHandler.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Controls.Maui.Handlers;
 /// <summary>
 /// Handler for MAUI CarouselView to Avalonia Carousel mapping
 /// </summary>
-public partial class CarouselViewHandler : ViewHandler<Microsoft.Maui.Controls.CarouselView, PlatformView>
+internal partial class CarouselViewHandler : ViewHandler<Microsoft.Maui.Controls.CarouselView, PlatformView>
 {
     public static IPropertyMapper<Microsoft.Maui.Controls.CarouselView, CarouselViewHandler> Mapper =
         new PropertyMapper<Microsoft.Maui.Controls.CarouselView, CarouselViewHandler>(ViewHandler.ViewMapper)

--- a/src/Avalonia.Controls.Maui/Handlers/CollectionViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/CollectionViewHandler.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Controls.Maui.Handlers;
 /// <summary>
 /// Handler for MAUI CollectionView to Avalonia MauiCollectionView mapping
 /// </summary>
-public class CollectionViewHandler : ViewHandler<Microsoft.Maui.Controls.CollectionView, MauiCollectionView>
+internal class CollectionViewHandler : ViewHandler<Microsoft.Maui.Controls.CollectionView, MauiCollectionView>
 {
     public static IPropertyMapper<Microsoft.Maui.Controls.ItemsView, CollectionViewHandler> Mapper =
         new PropertyMapper<Microsoft.Maui.Controls.ItemsView, CollectionViewHandler>(ViewHandler.ViewMapper)

--- a/src/Avalonia.Controls.Maui/Handlers/ContentPresenterHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ContentPresenterHandler.cs
@@ -9,7 +9,7 @@ using PlatformView = System.Object;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-public partial class ContentPresenterHandler : ViewHandler<IContentView, Avalonia.Controls.Maui.Platform.MauiContentPresenter>, IContentViewHandler
+internal partial class ContentPresenterHandler : ViewHandler<IContentView, Avalonia.Controls.Maui.Platform.MauiContentPresenter>, IContentViewHandler
 {
     public static IPropertyMapper<IContentView, IContentViewHandler> Mapper =
         new PropertyMapper<IContentView, IContentViewHandler>(ViewMapper)

--- a/src/Avalonia.Controls.Maui/Handlers/ContentViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ContentViewHandler.cs
@@ -11,7 +11,7 @@ using PlatformView = System.Object;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-public partial class ContentViewHandler : ViewHandler<IContentView, Avalonia.Controls.Maui.Platform.ContentView>, IContentViewHandler
+internal partial class ContentViewHandler : ViewHandler<IContentView, Avalonia.Controls.Maui.Platform.ContentView>, IContentViewHandler
 {
     public static IPropertyMapper<IContentView, IContentViewHandler> Mapper =
         new PropertyMapper<IContentView, IContentViewHandler>(ViewMapper)

--- a/src/Avalonia.Controls.Maui/Handlers/FlyoutViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/FlyoutViewHandler.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Controls.Maui.Handlers;
 /// <summary>
 /// Handler for MAUI FlyoutView to Avalonia SplitView mapping
 /// </summary>
-public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, PlatformView>, IFlyoutViewHandler
+internal partial class FlyoutViewHandler : ViewHandler<IFlyoutView, PlatformView>, IFlyoutViewHandler
 {
     // Like IViewHandler.ContainerView, those properties should be set with priority because other mappers depend on them.
     private static readonly IPropertyMapper<IFlyoutView, IFlyoutViewHandler> FlyoutLayoutMapper = new PropertyMapper<IFlyoutView, IFlyoutViewHandler>()

--- a/src/Avalonia.Controls.Maui/Handlers/ImageButtonHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ImageButtonHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Avalonia.Controls.Maui.Platform.MauiImageButton;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-public class ImageButtonHandler : ViewHandler<IImageButton, MauiImageButton>, IImageButtonHandler
+internal class ImageButtonHandler : ViewHandler<IImageButton, MauiImageButton>, IImageButtonHandler
 {
     public static IPropertyMapper<IImage, IImageHandler> ImageMapper = new PropertyMapper<IImage, IImageHandler>(ImageHandler.Mapper);
 

--- a/src/Avalonia.Controls.Maui/Handlers/IndicatorViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/IndicatorViewHandler.cs
@@ -9,7 +9,7 @@ namespace Avalonia.Controls.Maui.Handlers;
 /// <summary>
 /// Handler for MAUI IndicatorView to Avalonia MauiIndicatorView mapping
 /// </summary>
-public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, PlatformView>, IIndicatorViewHandler
+internal partial class IndicatorViewHandler : ViewHandler<IIndicatorView, PlatformView>, IIndicatorViewHandler
 {
     public static IPropertyMapper<IIndicatorView, IIndicatorViewHandler> Mapper =
         new PropertyMapper<IIndicatorView, IIndicatorViewHandler>(ViewHandler.ViewMapper)

--- a/src/Avalonia.Controls.Maui/Handlers/NavigationViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/NavigationViewHandler.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Controls.Maui.Handlers;
 /// Handler for MAUI NavigationPage that uses Avalonia's TransitioningContentControl
 /// to provide animated page navigation.
 /// </summary>
-public partial class NavigationViewHandler : ViewHandler<IStackNavigationView, NavigationView>, INavigationViewHandler
+internal partial class NavigationViewHandler : ViewHandler<IStackNavigationView, NavigationView>, INavigationViewHandler
 {
     private StackNavigationManager? _navigationManager;
     private ILogger<NavigationViewHandler>? _logger;
@@ -128,7 +128,7 @@ public partial class NavigationViewHandler : ViewHandler<IStackNavigationView, N
 /// <summary>
 /// Interface for navigation view handlers.
 /// </summary>
-public partial interface INavigationViewHandler : IViewHandler
+internal partial interface INavigationViewHandler : IViewHandler
 {
     new IStackNavigationView VirtualView { get; }
     new NavigationView PlatformView { get; }

--- a/src/Avalonia.Controls.Maui/Handlers/PageHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/PageHandler.cs
@@ -4,7 +4,7 @@ using AvaloniaPanel = Avalonia.Controls.Panel;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-public partial class PageHandler : ContentViewHandler, IPageHandler
+internal partial class PageHandler : ContentViewHandler, IPageHandler
 {
     public static new IPropertyMapper<IContentView, IPageHandler> Mapper =
         new PropertyMapper<IContentView, IPageHandler>(ContentViewHandler.Mapper)

--- a/src/Avalonia.Controls.Maui/Handlers/SearchBarHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/SearchBarHandler.cs
@@ -14,7 +14,7 @@ namespace Avalonia.Controls.Maui.Handlers;
 /// <summary>
 /// Handler for MAUI SearchBar to Avalonia MauiSearchBar mapping
 /// </summary>
-public partial class SearchBarHandler : ViewHandler<ISearchBar, PlatformView>, ISearchBarHandler
+internal partial class SearchBarHandler : ViewHandler<ISearchBar, PlatformView>, ISearchBarHandler
 {
     public static IPropertyMapper<ISearchBar, ISearchBarHandler> Mapper =
         new PropertyMapper<ISearchBar, ISearchBarHandler>(ViewHandler.ViewMapper)

--- a/src/Avalonia.Controls.Maui/Handlers/Shapes/RoundRectangleHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shapes/RoundRectangleHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Avalonia.Controls.Maui.Platform.MauiRoundRectangle;
 
 namespace Avalonia.Controls.Maui.Handlers.Shapes;
 
-public partial class RoundRectangleHandler : ShapeViewHandler<RoundRectangle, PlatformView>
+internal partial class RoundRectangleHandler : ShapeViewHandler<RoundRectangle, PlatformView>
 {
     public static new IPropertyMapper<RoundRectangle, IShapeViewHandler> Mapper = new PropertyMapper<RoundRectangle, IShapeViewHandler>(ShapeViewHandler.Mapper)
     {

--- a/src/Avalonia.Controls.Maui/Handlers/StepperHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/StepperHandler.cs
@@ -5,7 +5,7 @@ using PlatformView = Avalonia.Controls.Maui.Controls.MauiStepper;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-public partial class StepperHandler : ViewHandler<IStepper, PlatformView>, IStepperHandler
+internal partial class StepperHandler : ViewHandler<IStepper, PlatformView>, IStepperHandler
 {
     public static IPropertyMapper<IStepper, IStepperHandler> Mapper = new PropertyMapper<IStepper, IStepperHandler>(ViewHandler.ViewMapper)
     {

--- a/src/Avalonia.Controls.Maui/Handlers/SwipeItemViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/SwipeItemViewHandler.cs
@@ -9,7 +9,7 @@ namespace Avalonia.Controls.Maui.Handlers;
 /// <summary>
 /// Handler for MAUI SwipeItemView to Avalonia ContentControl mapping
 /// </summary>
-public partial class SwipeItemViewHandler : ContentViewHandler, ISwipeItemViewHandler
+internal partial class SwipeItemViewHandler : ContentViewHandler, ISwipeItemViewHandler
 {
     public static new IPropertyMapper<ISwipeItemView, ISwipeItemViewHandler> Mapper =
         new PropertyMapper<ISwipeItemView, ISwipeItemViewHandler>(ContentViewHandler.Mapper)

--- a/src/Avalonia.Controls.Maui/Handlers/SwipeViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/SwipeViewHandler.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Controls.Maui.Handlers;
 /// <summary>
 /// Handler for MAUI SwipeView to Avalonia MauiSwipeView mapping
 /// </summary>
-public partial class SwipeViewHandler : ViewHandler<ISwipeView, PlatformView>, ISwipeViewHandler
+internal partial class SwipeViewHandler : ViewHandler<ISwipeView, PlatformView>, ISwipeViewHandler
 {
     public static IPropertyMapper<ISwipeView, ISwipeViewHandler> Mapper =
         new PropertyMapper<ISwipeView, ISwipeViewHandler>(ViewHandler.ViewMapper)

--- a/src/Avalonia.Controls.Maui/Handlers/TableViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/TableViewHandler.cs
@@ -9,7 +9,7 @@ namespace Avalonia.Controls.Maui.Handlers;
 /// <summary>
 /// Handler for MAUI TableView to Avalonia MauiTableView mapping
 /// </summary>
-public class TableViewHandler : ViewHandler<Microsoft.Maui.Controls.TableView, MauiTableView>
+internal class TableViewHandler : ViewHandler<Microsoft.Maui.Controls.TableView, MauiTableView>
 {
     public static IPropertyMapper<Microsoft.Maui.Controls.TableView, TableViewHandler> Mapper =
         new PropertyMapper<Microsoft.Maui.Controls.TableView, TableViewHandler>(ViewHandler.ViewMapper)

--- a/src/Avalonia.Controls.Maui/Platform/BorderView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/BorderView.cs
@@ -4,7 +4,7 @@ using MauiGraphics = Microsoft.Maui.Graphics;
 
 namespace Avalonia.Controls.Maui.Platform;
 
-public class BorderView : Decorator
+internal class BorderView : Decorator
 {
     /// <summary>
     /// Defines the <see cref="Background"/> property.

--- a/src/Avalonia.Controls.Maui/Platform/ContentView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/ContentView.cs
@@ -6,6 +6,6 @@ using MauiRect = Microsoft.Maui.Graphics.Rect;
 
 namespace Avalonia.Controls.Maui.Platform;
 
-public class ContentView : MauiView
+internal class ContentView : MauiView
 {
 }

--- a/src/Avalonia.Controls.Maui/Platform/FlyoutContainer.cs
+++ b/src/Avalonia.Controls.Maui/Platform/FlyoutContainer.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Controls.Maui.Platform;
 /// <summary>
 /// Custom flyout container that manages flyout/detail layout without using SplitView
 /// </summary>
-public class FlyoutContainer : Panel
+internal class FlyoutContainer : Panel
 {
     private Control? _flyoutContent;
     private Control? _detailContent;
@@ -517,7 +517,7 @@ public class FlyoutContainer : Panel
 /// <summary>
 /// Flyout behavior that matches MAUI's FlyoutLayoutBehavior enum values
 /// </summary>
-public enum FlyoutBehavior
+internal enum FlyoutBehavior
 {
     /// <summary>
     /// Platform default behavior

--- a/src/Avalonia.Controls.Maui/Platform/LayoutPanel.cs
+++ b/src/Avalonia.Controls.Maui/Platform/LayoutPanel.cs
@@ -6,7 +6,7 @@ using MauiRect = Microsoft.Maui.Graphics.Rect;
 
 namespace Avalonia.Controls.Maui.Platform;
 
-public class LayoutPanel : Panel
+internal class LayoutPanel : Panel
 {
     internal Func<double, double, MauiSize>? CrossPlatformMeasure { get; set; }
     internal Func<MauiRect, MauiSize>? CrossPlatformArrange { get; set; }

--- a/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaContent.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaContent.cs
@@ -7,7 +7,7 @@ namespace Avalonia.Controls.Maui.Platform;
 /// A content container for MAUI applications running in single-view mode (browser, mobile, etc.)
 /// This class doesn't inherit from Window to avoid windowing platform dependencies.
 /// </summary>
-public class MauiAvaloniaContent : ContentControl, IDisposable
+internal class MauiAvaloniaContent : ContentControl, IDisposable
 {
     public MauiAvaloniaContent()
     {

--- a/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaWindow.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaWindow.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Avalonia.Controls.Maui.Platform;
 
-public class MauiAvaloniaWindow : Window, IDisposable
+internal class MauiAvaloniaWindow : Window, IDisposable
 {
     private readonly Stack<Window> _modalWindows = new Stack<Window>();
 

--- a/src/Avalonia.Controls.Maui/Platform/MauiButton.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiButton.cs
@@ -8,7 +8,7 @@ namespace Avalonia.Controls.Maui.Platform;
 /// <summary>
 /// Custom Avalonia Button with Image and Text support for MAUI's Button
 /// </summary>
-public class MauiButton : Button
+internal class MauiButton : Button
 {
     private StackPanel? _contentPanel;
     private TextBlock? _textBlock;

--- a/src/Avalonia.Controls.Maui/Platform/MauiCarouselView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiCarouselView.cs
@@ -16,7 +16,7 @@ namespace Avalonia.Controls.Maui.Platform;
 /// <summary>
 /// Custom Avalonia control for MAUI CarouselView with swipe gesture support
 /// </summary>
-public class MauiCarouselView : ContentControl
+internal class MauiCarouselView : ContentControl
 {
     private Canvas? _containerCanvas;
     private ContentControl? _currentItemContainer;

--- a/src/Avalonia.Controls.Maui/Platform/MauiCollectionView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiCollectionView.cs
@@ -10,7 +10,7 @@ using System.Collections.Specialized;
 
 namespace Avalonia.Controls.Maui.Platform;
 
-public class MauiCollectionView : TemplatedControl
+internal class MauiCollectionView : TemplatedControl
 {
     private ItemsControl? _itemsControl;
     private ScrollViewer? _scrollViewer;

--- a/src/Avalonia.Controls.Maui/Platform/MauiContentPresenter.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiContentPresenter.cs
@@ -6,6 +6,6 @@ namespace Avalonia.Controls.Maui.Platform;
 /// Custom Avalonia ContentPresenter for MAUI's ContentPresenter
 /// This control is used to display content within control templates
 /// </summary>
-public class MauiContentPresenter : MauiView
+internal class MauiContentPresenter : MauiView
 {
 }

--- a/src/Avalonia.Controls.Maui/Platform/MauiImageButton.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiImageButton.cs
@@ -4,7 +4,7 @@ using Avalonia.Media;
 
 namespace Avalonia.Controls.Maui.Platform;
 
-public class MauiImageButton : Button
+internal class MauiImageButton : Button
 {
     private Image? _image;
 

--- a/src/Avalonia.Controls.Maui/Platform/MauiIndicatorView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiIndicatorView.cs
@@ -7,7 +7,7 @@ using Avalonia.Media;
 
 namespace Avalonia.Controls.Maui.Controls;
 
-public class MauiIndicatorView : TemplatedControl
+internal class MauiIndicatorView : TemplatedControl
 {
     private StackPanel? _indicatorPanel;
 

--- a/src/Avalonia.Controls.Maui/Platform/MauiRoundRectangle.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiRoundRectangle.cs
@@ -5,7 +5,7 @@ using global::Avalonia.Media;
 
 namespace Avalonia.Controls.Maui.Platform;
 
-public class MauiRoundRectangle : Shape
+internal class MauiRoundRectangle : Shape
 {
     public static readonly StyledProperty<CornerRadius> CornerRadiusProperty =
         AvaloniaProperty.Register<MauiRoundRectangle, CornerRadius>(nameof(CornerRadius));

--- a/src/Avalonia.Controls.Maui/Platform/MauiSearchBar.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiSearchBar.cs
@@ -7,7 +7,7 @@ using Avalonia.Media;
 
 namespace Avalonia.Controls.Maui.Controls;
 
-public class MauiSearchBar : TemplatedControl
+internal class MauiSearchBar : TemplatedControl
 {
     internal TextBox? _textBox;
     private Button? _clearButton;

--- a/src/Avalonia.Controls.Maui/Platform/MauiStepper.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiStepper.cs
@@ -5,7 +5,7 @@ using Avalonia.Interactivity;
 
 namespace Avalonia.Controls.Maui.Controls;
 
-public class MauiStepper : TemplatedControl
+internal class MauiStepper : TemplatedControl
 {
     private Button? _plusButton;
     private Button? _minusButton;

--- a/src/Avalonia.Controls.Maui/Platform/MauiSwipeView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiSwipeView.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Controls.Maui.Controls;
 /// HACK: This is a simplified implementation of MAUI's SwipeView for Avalonia.
 /// It's here as a placeholder. It doesn't "work" fully, but provides basic structure.
 /// </summary>
-public class MauiSwipeView : TemplatedControl
+internal class MauiSwipeView : TemplatedControl
 {
     private ContentPresenter? _contentPresenter;
     private Panel? _swipeContainer;
@@ -219,7 +219,7 @@ public class MauiSwipeView : TemplatedControl
     }
 }
 
-public class SwipeEventArgs : EventArgs
+internal class SwipeEventArgs : EventArgs
 {
     public Point Position { get; }
 
@@ -229,7 +229,7 @@ public class SwipeEventArgs : EventArgs
     }
 }
 
-public enum SwipeDirection
+internal enum SwipeDirection
 {
     Left,
     Right,

--- a/src/Avalonia.Controls.Maui/Platform/MauiTableView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiTableView.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Controls.Maui.Platform;
 /// <summary>
 /// Avalonia platform control for MAUI TableView
 /// </summary>
-public class MauiTableView : MauiView
+internal class MauiTableView : MauiView
 {
     private readonly ItemsControl _itemsControl;
     private readonly ScrollViewer _scrollViewer;

--- a/src/Avalonia.Controls.Maui/Platform/MauiView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiView.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Avalonia.Controls.Maui.Platform;
 
-public abstract class MauiView : Panel, ICrossPlatformLayoutBacking, IVisualTreeElementProvidable
+internal abstract class MauiView : Panel, ICrossPlatformLayoutBacking, IVisualTreeElementProvidable
 {
     bool _invalidateParentWhenMovedToWindow;
     double _lastMeasureHeight = double.NaN;

--- a/src/Avalonia.Controls.Maui/Platform/NavigationView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/NavigationView.cs
@@ -6,7 +6,7 @@ using Microsoft.Maui;
 
 namespace Avalonia.Controls.Maui.Platform;
 
-public class NavigationView : DockPanel
+internal class NavigationView : DockPanel
 {
     private readonly TransitioningContentControl _contentControl;
     private readonly ContentControl _titleViewContainer;

--- a/src/Avalonia.Controls.Maui/Platform/StackNavigationManager.cs
+++ b/src/Avalonia.Controls.Maui/Platform/StackNavigationManager.cs
@@ -10,7 +10,7 @@ using Microsoft.Maui.Platform;
 
 namespace Avalonia.Controls.Maui.Platform;
 
-public class StackNavigationManager
+internal class StackNavigationManager
 {
     private readonly IMauiContext _mauiContext;
     private IView? _currentPage;


### PR DESCRIPTION
This PR makes all custom Avalonia controls internal to prevent them from being used directly in standard Avalonia projects. These controls should only be accessible through MAUI handlers.

But due to C# accessibility constraints (public classes cannot inherit from generic base classes with internal type arguments), all the handlers using a custom Avalonia control were also made internal.