### PR TITLE
Use net8.0 Avalonia v12 version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
         <!-- <AvaloniaVersion>9999.0.0-localbuild</AvaloniaVersion> -->
         <Version Condition="'$(Version)' == ''">12.0.0</Version>
         <IsPackable>false</IsPackable>
-        <AvaloniaVersion Condition="'$(AvaloniaVersion)' == ''">12.0.999-cibuild0060160-alpha</AvaloniaVersion>
+        <AvaloniaVersion Condition="'$(AvaloniaVersion)' == ''">12.0.999-cibuild0060140-alpha</AvaloniaVersion>
         <DotNetTfm Condition="'$(DotNetTfm)' == ''">net9.0</DotNetTfm>
         <MauiSrcDirectory>$(MSBuildThisFileDirectory)/src/</MauiSrcDirectory>
         <BuildDirectory>$(MSBuildThisFileDirectory)/build/</BuildDirectory>


### PR DESCRIPTION
The newest nightly v12 builds use `net10.0` and don't target any earlier version. We need at least `net9.0` for MAUI support at the moment, so we need to downgrade to an earlier build until we can bump MAUI.