### PR TITLE
Fix ApplicationHandler so it actually gets invoked

### DIFF
--- a/src/Avalonia.Controls.Maui/Extensions/MauiAppBuilderExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/MauiAppBuilderExtensions.cs
@@ -76,7 +76,7 @@ public static class MauiAppBuilderExtensions
         return builder
             .ConfigureMauiHandlers(handlers =>
             {
-                handlers.AddHandler<Microsoft.Maui.IApplication, Avalonia.Controls.Maui.Handlers.ApplicationHandler>();
+                handlers.AddHandler<Microsoft.Maui.Controls.Application, Avalonia.Controls.Maui.Handlers.ApplicationHandler>();
 
                 // Use different window handlers based on the application lifetime
                 if (useSingleViewLifetime)

--- a/src/Avalonia.Controls.Maui/Handlers/ApplicationHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ApplicationHandler.cs
@@ -76,6 +76,9 @@ public partial class ApplicationHandler : ElementHandler<IApplication, Applicati
         {
             var activationState = new ActivationState(mauiContext, request.State ?? new PersistedState());
             var window = application.CreateWindow(activationState);
+
+            // For WASM, this will return as MauiAvaloniaContent from SingleViewWindowHandler, so it will not show.
+            // We don't support multiple windows in WASM in Avalonia currently.
             var avaloniaWindow = window.ToPlatform(mauiContext) as global::Avalonia.Controls.Window;
             avaloniaWindow?.Show();
         }

--- a/src/Avalonia.Controls.Maui/Handlers/ApplicationHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ApplicationHandler.cs
@@ -3,12 +3,13 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
 public partial class ApplicationHandler : ElementHandler<IApplication, Application>
 {
-    internal const string TerminateCommandKey = "Terminate";
+    public const string TerminateCommandKey = "Terminate";
 
     public static IPropertyMapper<IApplication, ApplicationHandler> Mapper = new PropertyMapper<IApplication, ApplicationHandler>(ElementMapper)
     {
@@ -71,8 +72,13 @@ public partial class ApplicationHandler : ElementHandler<IApplication, Applicati
     /// <param name="args">The associated command arguments.</param>
     public static void MapOpenWindow(ApplicationHandler handler, IApplication application, object? args)
     {
-        // Window opening is handled by the WindowHandler
-        // This is called after the window is created
+        if (args is OpenWindowRequest request && handler.MauiContext is IMauiContext mauiContext)
+        {
+            var activationState = new ActivationState(mauiContext, request.State ?? new PersistedState());
+            var window = application.CreateWindow(activationState);
+            var avaloniaWindow = window.ToPlatform(mauiContext) as global::Avalonia.Controls.Window;
+            avaloniaWindow?.Show();
+        }
     }
 
     /// <summary>

--- a/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaApplication.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaApplication.cs
@@ -26,16 +26,33 @@ public abstract class MauiAvaloniaApplication : Application, IPlatformApplicatio
     public IApplication Application { get; protected set; } = null!;
 
 
+    /// <summary>
+    /// The application-scoped MauiContext that contains the Avalonia Application.
+    /// </summary>
+    protected IMauiContext? ApplicationContext { get; private set; }
+
     public override void OnFrameworkInitializationCompleted()
     {
+        IPlatformApplication.Current = this;
+
         var mauiApp = CreateMauiApp();
 
-        Services = mauiApp.Services;
+        var rootContext = new MauiContext(mauiApp.Services);
+
+        // Create application scope and register the Avalonia Application
+        // We need to register with the correct type (Application) since MakeApplicationScope
+        // registers as Object for non-platform builds
+        ApplicationContext = MakeAvaloniaApplicationScope(rootContext, this);
+
+        Services = ApplicationContext.Services;
 
         var args = EventArgs.Empty;
         Services.InvokeLifecycleEvents<AvaloniaLifecycle.OnLaunching>(del => del(this, args));
 
         Application = Services.GetRequiredService<IApplication>();
+
+        // Connect the MAUI Application to its handler
+        this.SetApplicationHandler(Application, ApplicationContext);
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
@@ -89,5 +106,20 @@ public abstract class MauiAvaloniaApplication : Application, IPlatformApplicatio
         Services.InvokeLifecycleEvents<AvaloniaLifecycle.OnWindowCreated>(del => del(avaloniaWindow));
 
         return avaloniaWindow;
+    }
+
+    /// <summary>
+    /// Creates an application-scoped MauiContext and registers the Avalonia Application
+    /// with the correct type so it can be resolved by the ApplicationHandler.
+    /// </summary>
+    private static MauiContext MakeAvaloniaApplicationScope(MauiContext mauiContext, Application avaloniaApplication)
+    {
+        var scopedContext = new MauiContext(mauiContext.Services);
+
+        // Register the Avalonia Application with the correct type
+        // This allows ApplicationHandler.CreatePlatformElement() to resolve it via GetService<Application>()
+        scopedContext.AddSpecific(avaloniaApplication);
+
+        return scopedContext;
     }
 }

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/ApplicationHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/ApplicationHandlerTests.cs
@@ -1,0 +1,229 @@
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Controls.Maui.Tests.Stubs;
+using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Hosting;
+using NSubstitute;
+using MauiApplicationHandler = Avalonia.Controls.Maui.Handlers.ApplicationHandler;
+
+namespace Avalonia.Controls.Maui.Tests.Handlers;
+
+public class ApplicationHandlerTests : HandlerTestBase
+{
+    [AvaloniaFact(DisplayName = "Default Constructor Creates Handler")]
+    public async Task DefaultConstructorCreatesHandler()
+    {
+        var handler = new MauiApplicationHandler();
+
+        Assert.NotNull(handler);
+    }
+
+    [AvaloniaFact(DisplayName = "Constructor With Mapper Creates Handler")]
+    public async Task ConstructorWithMapperCreatesHandler()
+    {
+        var customMapper = new PropertyMapper<IApplication, MauiApplicationHandler>();
+        var handler = new MauiApplicationHandler(customMapper);
+
+        Assert.NotNull(handler);
+    }
+
+    [AvaloniaFact(DisplayName = "Constructor With Null Mapper Uses Default")]
+    public async Task ConstructorWithNullMapperUsesDefault()
+    {
+        var handler = new MauiApplicationHandler(null);
+
+        Assert.NotNull(handler);
+    }
+
+    [AvaloniaFact(DisplayName = "Constructor With Mapper And CommandMapper Creates Handler")]
+    public async Task ConstructorWithMapperAndCommandMapperCreatesHandler()
+    {
+        var customMapper = new PropertyMapper<IApplication, MauiApplicationHandler>();
+        var customCommandMapper = new CommandMapper<IApplication, MauiApplicationHandler>();
+        var handler = new MauiApplicationHandler(customMapper, customCommandMapper);
+
+        Assert.NotNull(handler);
+    }
+
+    [AvaloniaFact(DisplayName = "Constructor With Null Mapper And CommandMapper Uses Defaults")]
+    public async Task ConstructorWithNullMapperAndCommandMapperUsesDefaults()
+    {
+        var handler = new MauiApplicationHandler(null, null);
+
+        Assert.NotNull(handler);
+    }
+
+    [AvaloniaFact(DisplayName = "Handler Has Terminate Command Key")]
+    public void HandlerHasTerminateCommandKey()
+    {
+        Assert.Equal("Terminate", MauiApplicationHandler.TerminateCommandKey);
+    }
+
+    [AvaloniaFact(DisplayName = "Static Mapper Is Not Null")]
+    public void StaticMapperIsNotNull()
+    {
+        Assert.NotNull(MauiApplicationHandler.Mapper);
+    }
+
+    [AvaloniaFact(DisplayName = "Static CommandMapper Is Not Null")]
+    public void StaticCommandMapperIsNotNull()
+    {
+        Assert.NotNull(MauiApplicationHandler.CommandMapper);
+    }
+
+    [AvaloniaFact(DisplayName = "CreatePlatformElement Returns Application From Services")]
+    public async Task CreatePlatformElementReturnsApplicationFromServices()
+    {
+        var application = new ApplicationStub();
+
+        EnsureHandlerCreated(builder =>
+        {
+            builder.Services.AddSingleton<Application>(App.Current!);
+            builder.ConfigureMauiHandlers(handlers =>
+            {
+                handlers.AddHandler<IApplication, MauiApplicationHandler>();
+            });
+        });
+
+        var handler = await CreateHandlerAsync<MauiApplicationHandler>(application);
+
+        Assert.NotNull(handler.PlatformView);
+        Assert.IsType<App>(handler.PlatformView);
+    }
+
+    [AvaloniaFact(DisplayName = "Handler Sets Virtual View Correctly")]
+    public async Task HandlerSetsVirtualViewCorrectly()
+    {
+        var application = new ApplicationStub();
+
+        EnsureHandlerCreated(builder =>
+        {
+            builder.Services.AddSingleton<Application>(App.Current!);
+            builder.ConfigureMauiHandlers(handlers =>
+            {
+                handlers.AddHandler<IApplication, MauiApplicationHandler>();
+            });
+        });
+
+        var handler = await CreateHandlerAsync<MauiApplicationHandler>(application);
+
+        Assert.Same(application, handler.VirtualView);
+    }
+
+    [AvaloniaFact(DisplayName = "MapCloseWindow Does Nothing When Args Is Not IWindow")]
+    public async Task MapCloseWindowDoesNothingWhenArgsIsNotIWindow()
+    {
+        var application = new ApplicationStub();
+
+        EnsureHandlerCreated(builder =>
+        {
+            builder.Services.AddSingleton<Application>(App.Current!);
+            builder.ConfigureMauiHandlers(handlers =>
+            {
+                handlers.AddHandler<IApplication, MauiApplicationHandler>();
+            });
+        });
+
+        var handler = await CreateHandlerAsync<MauiApplicationHandler>(application);
+
+        // Should not throw when args is not IWindow
+        await InvokeOnMainThreadAsync(() =>
+        {
+            MauiApplicationHandler.MapCloseWindow(handler, application, "not a window");
+        });
+    }
+
+    [AvaloniaFact(DisplayName = "MapCloseWindow Does Nothing When Args Is Null")]
+    public async Task MapCloseWindowDoesNothingWhenArgsIsNull()
+    {
+        var application = new ApplicationStub();
+
+        EnsureHandlerCreated(builder =>
+        {
+            builder.Services.AddSingleton<Application>(App.Current!);
+            builder.ConfigureMauiHandlers(handlers =>
+            {
+                handlers.AddHandler<IApplication, MauiApplicationHandler>();
+            });
+        });
+
+        var handler = await CreateHandlerAsync<MauiApplicationHandler>(application);
+
+        // Should not throw when args is null
+        await InvokeOnMainThreadAsync(() =>
+        {
+            MauiApplicationHandler.MapCloseWindow(handler, application, null);
+        });
+    }
+
+    [AvaloniaFact(DisplayName = "MapActivateWindow Does Nothing When Args Is Not IWindow")]
+    public async Task MapActivateWindowDoesNothingWhenArgsIsNotIWindow()
+    {
+        var application = new ApplicationStub();
+
+        EnsureHandlerCreated(builder =>
+        {
+            builder.Services.AddSingleton<Application>(App.Current!);
+            builder.ConfigureMauiHandlers(handlers =>
+            {
+                handlers.AddHandler<IApplication, MauiApplicationHandler>();
+            });
+        });
+
+        var handler = await CreateHandlerAsync<MauiApplicationHandler>(application);
+
+        // Should not throw when args is not IWindow
+        await InvokeOnMainThreadAsync(() =>
+        {
+            MauiApplicationHandler.MapActivateWindow(handler, application, "not a window");
+        });
+    }
+
+    [AvaloniaFact(DisplayName = "MapActivateWindow Does Nothing When Args Is Null")]
+    public async Task MapActivateWindowDoesNothingWhenArgsIsNull()
+    {
+        var application = new ApplicationStub();
+
+        EnsureHandlerCreated(builder =>
+        {
+            builder.Services.AddSingleton<Application>(App.Current!);
+            builder.ConfigureMauiHandlers(handlers =>
+            {
+                handlers.AddHandler<IApplication, MauiApplicationHandler>();
+            });
+        });
+
+        var handler = await CreateHandlerAsync<MauiApplicationHandler>(application);
+
+        // Should not throw when args is null
+        await InvokeOnMainThreadAsync(() =>
+        {
+            MauiApplicationHandler.MapActivateWindow(handler, application, null);
+        });
+    }
+
+    [AvaloniaFact(DisplayName = "MapOpenWindow Does Not Throw")]
+    public async Task MapOpenWindowDoesNotThrow()
+    {
+        var application = new ApplicationStub();
+        var windowStub = new WindowStub();
+
+        EnsureHandlerCreated(builder =>
+        {
+            builder.Services.AddSingleton<Application>(App.Current!);
+            builder.ConfigureMauiHandlers(handlers =>
+            {
+                handlers.AddHandler<IApplication, MauiApplicationHandler>();
+            });
+        });
+
+        var handler = await CreateHandlerAsync<MauiApplicationHandler>(application);
+
+        await InvokeOnMainThreadAsync(() =>
+        {
+            MauiApplicationHandler.MapOpenWindow(handler, application, windowStub);
+        });
+    }
+}

--- a/tests/Avalonia.Controls.Maui.Tests/Stubs/ApplicationStub.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Stubs/ApplicationStub.cs
@@ -1,0 +1,71 @@
+using Microsoft.Maui;
+using Microsoft.Maui.ApplicationModel;
+using System.Collections.Generic;
+
+namespace Avalonia.Controls.Maui.Tests.Stubs;
+
+public class ApplicationStub : ElementStub, IApplication
+{
+    private readonly List<IWindow> _windows = new();
+
+    public IReadOnlyList<IWindow> Windows => _windows.AsReadOnly();
+
+    public AppTheme UserAppTheme { get; set; } = AppTheme.Unspecified;
+
+    public bool ThemeChangedCalled { get; private set; }
+
+    public int OpenWindowCallCount { get; private set; }
+
+    public int CloseWindowCallCount { get; private set; }
+
+    public int ActivateWindowCallCount { get; private set; }
+
+    public IWindow? LastOpenedWindow { get; private set; }
+
+    public IWindow? LastClosedWindow { get; private set; }
+
+    public IWindow? LastActivatedWindow { get; private set; }
+
+    public IWindow CreateWindow(IActivationState? activationState)
+    {
+        var window = new WindowStub();
+        _windows.Add(window);
+        return window;
+    }
+
+    public void OpenWindow(IWindow window)
+    {
+        OpenWindowCallCount++;
+        LastOpenedWindow = window;
+        if (!_windows.Contains(window))
+        {
+            _windows.Add(window);
+        }
+    }
+
+    public void CloseWindow(IWindow window)
+    {
+        CloseWindowCallCount++;
+        LastClosedWindow = window;
+        _windows.Remove(window);
+    }
+
+    public void ActivateWindow(IWindow window)
+    {
+        ActivateWindowCallCount++;
+        LastActivatedWindow = window;
+    }
+
+    public void ThemeChanged()
+    {
+        ThemeChangedCalled = true;
+    }
+
+    public void AddWindow(IWindow window)
+    {
+        if (!_windows.Contains(window))
+        {
+            _windows.Add(window);
+        }
+    }
+}

--- a/tests/Avalonia.Controls.Maui.Tests/Stubs/WindowStub.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Stubs/WindowStub.cs
@@ -1,0 +1,70 @@
+using Microsoft.Maui;
+using Microsoft.Maui.Graphics;
+using System.Collections.Generic;
+using MauiRect = Microsoft.Maui.Graphics.Rect;
+
+namespace Avalonia.Controls.Maui.Tests.Stubs;
+
+public class WindowStub : ElementStub, IWindow
+{
+    private readonly List<IWindowOverlay> _overlays = new();
+
+    public IView? Content { get; set; }
+
+    public IVisualDiagnosticsOverlay VisualDiagnosticsOverlay => null!;
+
+    public IReadOnlyCollection<IWindowOverlay> Overlays => _overlays.AsReadOnly();
+
+    public double X { get; set; }
+
+    public double Y { get; set; }
+
+    public double Width { get; set; } = 800;
+
+    public double MinimumWidth { get; set; }
+
+    public double MaximumWidth { get; set; } = double.PositiveInfinity;
+
+    public double Height { get; set; } = 600;
+
+    public double MinimumHeight { get; set; }
+
+    public double MaximumHeight { get; set; } = double.PositiveInfinity;
+
+    public string Title { get; set; } = string.Empty;
+
+    public FlowDirection FlowDirection { get; set; } = FlowDirection.LeftToRight;
+
+    public bool AddOverlay(IWindowOverlay overlay)
+    {
+        _overlays.Add(overlay);
+        return true;
+    }
+
+    public bool RemoveOverlay(IWindowOverlay overlay)
+    {
+        return _overlays.Remove(overlay);
+    }
+
+    public void Created() { }
+
+    public void Resumed() { }
+
+    public void Activated() { }
+
+    public void Deactivated() { }
+
+    public void Stopped() { }
+
+    public void Destroying() { }
+
+    public void Backgrounding(IPersistedState state) { }
+
+    public bool BackButtonClicked() => false;
+
+    public void DisplayDensityChanged(float displayDensity) { }
+
+    public void FrameChanged(MauiRect frame) { }
+
+    public float RequestDisplayDensity() => 1.0f;
+}

--- a/tests/Avalonia.Controls.Maui.Tests/TestAppBuilder.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/TestAppBuilder.cs
@@ -23,6 +23,7 @@ public static class MauiTestAppBuilderExtensions
         builder.ConfigureMauiHandlers(handlers =>
         {
             // Register Avalonia handlers
+            handlers.AddHandler<IApplication, Avalonia.Controls.Maui.Handlers.ApplicationHandler>();
             handlers.AddHandler<ILabel, Avalonia.Controls.Maui.Handlers.LabelHandler>();
             handlers.AddHandler<IButton, Avalonia.Controls.Maui.Handlers.ButtonHandler>();
             handlers.AddHandler<IBorderView, Avalonia.Controls.Maui.Handlers.BorderHandler>();


### PR DESCRIPTION
This, I _think_ fixes the ApplicationHandler so it can work correctly. If you call `OpenWindow` and `CloseWindow` from `Microsoft.Maui.Controls.Application.Current` they will be respected and managed by the virtual platform view, and created within the app.

For WASM (And other SingleWindowAppLifecycle platforms), calling on OpenWindow and CloseWindow will do nothing.