### PR TITLE
Update ProgressRing control and add ActivityIndicator samples

### DIFF
--- a/samples/ControlGallery/ControlGallery.Browser/Program.cs
+++ b/samples/ControlGallery/ControlGallery.Browser/Program.cs
@@ -11,6 +11,7 @@ internal sealed partial class Program
 {
     private static Task Main(string[] args) => BuildAvaloniaApp()
             .WithInterFont()
+            .WithControls()
             .StartBrowserAppAsync("out");
 
     public static AppBuilder BuildAvaloniaApp()

--- a/samples/ControlGallery/ControlGallery.Desktop/Program.cs
+++ b/samples/ControlGallery/ControlGallery.Desktop/Program.cs
@@ -19,5 +19,6 @@ class Program
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .WithInterFont()
+            .WithControls()
             .LogToTrace();
 }

--- a/samples/ControlGallery/ControlGallery/MainPage.xaml
+++ b/samples/ControlGallery/ControlGallery/MainPage.xaml
@@ -27,10 +27,14 @@
 								  CommandParameter="{x:Type pages:FontsPage}"/>
 					</TableSection>
 					<TableSection Title="Views">
+						<TextCell Text="ActivityIndicator"
+						          Detail="ActivityIndicator control"
+						          Command="{Binding NavigateCommand}"
+						          CommandParameter="{x:Type pages:ActivityIndicatorPage}"/>
 						<TextCell Text="Button"
-								  Detail="Button control"
-								  Command="{Binding NavigateCommand}"
-								  CommandParameter="{x:Type pages:ButtonPage}"/>
+						          Detail="Button control"
+						          Command="{Binding NavigateCommand}"
+						          CommandParameter="{x:Type pages:ButtonPage}"/>
 						<TextCell Text="CheckBox"
 								  Detail="CheckBox control for selections"
 								  Command="{Binding NavigateCommand}"

--- a/samples/ControlGallery/ControlGallery/MainPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/MainPage.xaml.cs
@@ -24,6 +24,7 @@ public partial class MainPage : FlyoutPage
         Page page = pageType.Name switch
         {
             nameof(FontsPage) => new FontsPage(),
+            nameof(ActivityIndicatorPage) => new ActivityIndicatorPage(),
             nameof(ButtonPage) => new ButtonPage(),
             nameof(CheckBoxPage) => new CheckBoxPage(),
             nameof(ProgressBarPage) => new ProgressBarPage(),

--- a/samples/ControlGallery/ControlGallery/Pages/ActivityIndicatorPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/ActivityIndicatorPage.xaml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:pages="clr-namespace:ControlGallery.Pages"
+             x:Class="ControlGallery.Pages.ActivityIndicatorPage"
+             x:DataType="pages:ActivityIndicatorPage"
+             Title="ActivityIndicator">
+    <ScrollView>
+        <VerticalStackLayout Padding="20"
+                             Spacing="20">
+
+            <Label Text="ActivityIndicator Control"
+                   FontSize="24"
+                   FontAttributes="Bold"
+                   HorizontalOptions="Center"/>
+
+            <!-- Basic control and running toggle -->
+            <Border Stroke="Gray"
+                    Padding="10">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10"/>
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Basic ActivityIndicator"
+                           FontAttributes="Bold"/>
+                    <ActivityIndicator IsRunning="{Binding IsRunning}"
+                                       Color="{Binding IndicatorColor}"
+                                       WidthRequest="32"
+                                       HeightRequest="32"/>
+                    <Label Text="{Binding StatusText}"
+                           HorizontalOptions="Center"/>
+                    <HorizontalStackLayout Spacing="10"
+                                           HorizontalOptions="Center">
+                        <Button Text="Start"
+                                Command="{Binding StartCommand}"/>
+                        <Button Text="Stop"
+                                Command="{Binding StopCommand}"/>
+                    </HorizontalStackLayout>
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Color customization -->
+            <Border Stroke="Gray"
+                    Padding="10">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10"/>
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Color Variations"
+                           FontAttributes="Bold"/>
+                    <ActivityIndicator IsRunning="True"
+                                       Color="{Binding IndicatorColor}"
+                                       WidthRequest="36"
+                                       HeightRequest="36"/>
+                    <Label Text="{Binding IndicatorColor, StringFormat='Selected: {0}'}"
+                           HorizontalOptions="Center"/>
+                    <HorizontalStackLayout Spacing="10"
+                                           HorizontalOptions="Center">
+                        <Button Text="Red"
+                                Command="{Binding SetColorCommand}"
+                                CommandParameter="Red"
+                                BackgroundColor="Red"
+                                TextColor="White"/>
+                        <Button Text="Green"
+                                Command="{Binding SetColorCommand}"
+                                CommandParameter="Green"
+                                BackgroundColor="Green"
+                                TextColor="White"/>
+                        <Button Text="Blue"
+                                Command="{Binding SetColorCommand}"
+                                CommandParameter="Blue"
+                                BackgroundColor="Blue"
+                                TextColor="White"/>
+                        <Button Text="Orange"
+                                Command="{Binding SetColorCommand}"
+                                CommandParameter="Orange"
+                                BackgroundColor="Orange"
+                                TextColor="Black"/>
+                    </HorizontalStackLayout>
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Preset samples -->
+            <Border Stroke="Gray"
+                    Padding="10">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10"/>
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Preset Colors"
+                           FontAttributes="Bold"/>
+                    <HorizontalStackLayout Spacing="20"
+                                           HorizontalOptions="Center">
+                        <ActivityIndicator IsRunning="True"
+                                           Color="MediumPurple"
+                                           WidthRequest="28"
+                                           HeightRequest="28"/>
+                        <ActivityIndicator IsRunning="True"
+                                           Color="DeepSkyBlue"
+                                           WidthRequest="28"
+                                           HeightRequest="28"/>
+                        <ActivityIndicator IsRunning="True"
+                                           Color="LimeGreen"
+                                           WidthRequest="28"
+                                           HeightRequest="28"/>
+                        <ActivityIndicator IsRunning="True"
+                                           Color="Gold"
+                                           WidthRequest="28"
+                                           HeightRequest="28"/>
+                    </HorizontalStackLayout>
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Size variations -->
+            <Border Stroke="Gray"
+                    Padding="10">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10"/>
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Sizes"
+                           FontAttributes="Bold"/>
+                    <HorizontalStackLayout Spacing="20"
+                                           HorizontalOptions="Center">
+                        <VerticalStackLayout Spacing="4"
+                                             HorizontalOptions="Center">
+                            <ActivityIndicator IsRunning="True"
+                                               WidthRequest="20"
+                                               HeightRequest="20"/>
+                            <Label Text="Small"
+                                   FontSize="12"
+                                   HorizontalOptions="Center"/>
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Spacing="4"
+                                             HorizontalOptions="Center">
+                            <ActivityIndicator IsRunning="True"
+                                               WidthRequest="32"
+                                               HeightRequest="32"/>
+                            <Label Text="Default"
+                                   FontSize="12"
+                                   HorizontalOptions="Center"/>
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Spacing="4"
+                                             HorizontalOptions="Center">
+                            <ActivityIndicator IsRunning="True"
+                                               WidthRequest="48"
+                                               HeightRequest="48"/>
+                            <Label Text="Large"
+                                   FontSize="12"
+                                   HorizontalOptions="Center"/>
+                        </VerticalStackLayout>
+                    </HorizontalStackLayout>
+                </VerticalStackLayout>
+            </Border>
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/samples/ControlGallery/ControlGallery/Pages/ActivityIndicatorPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/ActivityIndicatorPage.xaml.cs
@@ -1,0 +1,74 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace ControlGallery.Pages;
+
+public partial class ActivityIndicatorPage : ContentPage, INotifyPropertyChanged
+{
+    private bool _isRunning = true;
+    private Color _indicatorColor = Colors.Blue;
+
+    public ActivityIndicatorPage()
+    {
+        InitializeComponent();
+
+        StartCommand = new Command(() => IsRunning = true);
+        StopCommand = new Command(() => IsRunning = false);
+        SetColorCommand = new Command<string>(colorName =>
+        {
+            IndicatorColor = colorName switch
+            {
+                "Red" => Colors.Red,
+                "Green" => Colors.Green,
+                "Blue" => Colors.Blue,
+                "Orange" => Colors.Orange,
+                _ => Colors.Blue
+            };
+        });
+
+        BindingContext = this;
+    }
+
+    public bool IsRunning
+    {
+        get => _isRunning;
+        set
+        {
+            if (_isRunning != value)
+            {
+                _isRunning = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(StatusText));
+            }
+        }
+    }
+
+    public Color IndicatorColor
+    {
+        get => _indicatorColor;
+        set
+        {
+            if (_indicatorColor != value)
+            {
+                _indicatorColor = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public string StatusText => IsRunning ? "Running" : "Stopped";
+
+    public ICommand StartCommand { get; }
+    public ICommand StopCommand { get; }
+    public ICommand SetColorCommand { get; }
+
+    public new event PropertyChangedEventHandler? PropertyChanged;
+
+    protected new virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/samples/ControlGallery/ControlGallery/Pages/CheckBoxPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/CheckBoxPage.xaml
@@ -2,7 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="ControlGallery.Pages.CheckBoxPage"
-             Title="CheckBox Page">
+             Title="CheckBox">
     <ScrollView>
         <VerticalStackLayout Padding="20"
                              Spacing="20">

--- a/samples/ControlGallery/ControlGallery/Pages/FontsPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/FontsPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 		     xmlns:shimmer="http://schemas.syncfusion.com/maui/toolkit"
 			 x:Class="ControlGallery.Pages.FontsPage"
-             Title="Font Test">
+             Title="Fonts">
 
     <ScrollView>
         <VerticalStackLayout Padding="20" Spacing="20">

--- a/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRing.axaml
+++ b/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRing.axaml
@@ -1,10 +1,17 @@
 <ResourceDictionary
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="using:Avalonia.Controls.Maui">
-    
-    <SolidColorBrush x:Key="ProgressRingTrackBrush" Color="#20000000" />
-    <SolidColorBrush x:Key="ProgressRingTrackBrush:dark" Color="#20FFFFFF" />
+    xmlns:controls="using:Avalonia.Controls.Maui"
+    x:Class="Avalonia.Controls.Maui.ProgressRingResources">
+
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Light">
+            <SolidColorBrush x:Key="ProgressRingTrackBrush" Color="#20000000" />
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Dark">
+            <SolidColorBrush x:Key="ProgressRingTrackBrush" Color="#20FFFFFF" />
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
 
     <ControlTheme x:Key="{x:Type controls:ProgressRing}" TargetType="controls:ProgressRing">
         <Setter Property="Foreground" Value="{DynamicResource SystemAccentColor}" />
@@ -15,22 +22,24 @@
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="Template">
             <ControlTemplate>
-                <controls:ProgressRingVisual
-                    RingForeground="{TemplateBinding Foreground}"
-                    RingBackground="{TemplateBinding Background}"
-                    IsIndeterminate="{TemplateBinding IsIndeterminate}"
-                    Value="{TemplateBinding Value}"
-                    Minimum="{TemplateBinding Minimum}"
-                    Maximum="{TemplateBinding Maximum}"
-                    FlowDirection="{TemplateBinding FlowDirection}"
-                    StrokeThickness="4" />
+                <Panel>
+                    <Border x:Name="PART_Indicator"
+                            IsHitTestVisible="False"
+                            Opacity="0" />
+                    <controls:ProgressRingVisual
+                        IsIndeterminate="{TemplateBinding IsIndeterminate}"
+                        IsActive="{TemplateBinding IsActive}"
+                        Value="{TemplateBinding Value}"
+                        Minimum="{TemplateBinding Minimum}"
+                        Maximum="{TemplateBinding Maximum}"
+                        Foreground="{TemplateBinding Foreground}"
+                        Background="{TemplateBinding Background}"
+                        StrokeThickness="4" />
+                </Panel>
             </ControlTemplate>
         </Setter>
-        <Style Selector="^:not(:active)">
-            <Setter Property="Opacity" Value="0" />
-        </Style>
     </ControlTheme>
-
+    
     <!-- Custom themes inherit the theme-aware colors -->
     <ControlTheme x:Key="ThreeDotsLoader" TargetType="controls:ProgressRing">
         <Setter Property="Foreground" Value="{DynamicResource SystemAccentColor}" />
@@ -38,85 +47,47 @@
         <Setter Property="Height" Value="20" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Canvas Width="60" Height="20">
-                    <Ellipse Name="Dot1" 
-                             Width="12" Height="12" 
-                             Fill="{TemplateBinding Foreground}" 
-                             Canvas.Left="4" Canvas.Top="4">
-                        <Ellipse.Styles>
-                            <Style Selector="Ellipse">
-                                <Style.Animations>
-                                    <Animation Duration="0:0:1.2" IterationCount="Infinite">
-                                        <KeyFrame Cue="0%">
-                                            <Setter Property="Opacity" Value="0.3"/>
-                                            <Setter Property="(Canvas.Top)" Value="4"/>
-                                        </KeyFrame>
-                                        <KeyFrame Cue="15%">
-                                            <Setter Property="Opacity" Value="1.0"/>
-                                            <Setter Property="(Canvas.Top)" Value="0"/>
-                                        </KeyFrame>
-                                        <KeyFrame Cue="30%">
-                                            <Setter Property="Opacity" Value="0.3"/>
-                                            <Setter Property="(Canvas.Top)" Value="4"/>
-                                        </KeyFrame>
-                                    </Animation>
-                                </Style.Animations>
-                            </Style>
-                        </Ellipse.Styles>
-                    </Ellipse>
-                    <Ellipse Name="Dot2" 
-                             Width="12" Height="12" 
-                             Fill="{TemplateBinding Foreground}" 
-                             Canvas.Left="24" Canvas.Top="4">
-                        <Ellipse.Styles>
-                            <Style Selector="Ellipse">
-                                <Style.Animations>
-                                    <Animation Duration="0:0:1.2" IterationCount="Infinite" Delay="0:0:0.15">
-                                        <KeyFrame Cue="0%">
-                                            <Setter Property="Opacity" Value="0.3"/>
-                                            <Setter Property="(Canvas.Top)" Value="4"/>
-                                        </KeyFrame>
-                                        <KeyFrame Cue="15%">
-                                            <Setter Property="Opacity" Value="1.0"/>
-                                            <Setter Property="(Canvas.Top)" Value="0"/>
-                                        </KeyFrame>
-                                        <KeyFrame Cue="30%">
-                                            <Setter Property="Opacity" Value="0.3"/>
-                                            <Setter Property="(Canvas.Top)" Value="4"/>
-                                        </KeyFrame>
-                                    </Animation>
-                                </Style.Animations>
-                            </Style>
-                        </Ellipse.Styles>
-                    </Ellipse>
-                    <Ellipse Name="Dot3" 
-                             Width="12" Height="12" 
-                             Fill="{TemplateBinding Foreground}" 
-                             Canvas.Left="44" Canvas.Top="4">
-                        <Ellipse.Styles>
-                            <Style Selector="Ellipse">
-                                <Style.Animations>
-                                    <Animation Duration="0:0:1.2" IterationCount="Infinite" Delay="0:0:0.3">
-                                        <KeyFrame Cue="0%">
-                                            <Setter Property="Opacity" Value="0.3"/>
-                                            <Setter Property="(Canvas.Top)" Value="4"/>
-                                        </KeyFrame>
-                                        <KeyFrame Cue="15%">
-                                            <Setter Property="Opacity" Value="1.0"/>
-                                            <Setter Property="(Canvas.Top)" Value="0"/>
-                                        </KeyFrame>
-                                        <KeyFrame Cue="30%">
-                                            <Setter Property="Opacity" Value="0.3"/>
-                                            <Setter Property="(Canvas.Top)" Value="4"/>
-                                        </KeyFrame>
-                                    </Animation>
-                                </Style.Animations>
-                            </Style>
-                        </Ellipse.Styles>
-                    </Ellipse>
-                </Canvas>
+                <Border x:Name="PART_Indicator" Background="Transparent">
+                    <Canvas Width="60" Height="20">
+                        <Ellipse Name="Dot1" Width="12" Height="12" Fill="{TemplateBinding Foreground}" Canvas.Left="4" Canvas.Top="4" />
+                        <Ellipse Name="Dot2" Width="12" Height="12" Fill="{TemplateBinding Foreground}" Canvas.Left="24" Canvas.Top="4" />
+                        <Ellipse Name="Dot3" Width="12" Height="12" Fill="{TemplateBinding Foreground}" Canvas.Left="44" Canvas.Top="4" />
+                    </Canvas>
+                </Border>
             </ControlTemplate>
         </Setter>
+        
+        <Style Selector="^:active /template/ Ellipse#Dot1">
+            <Style.Animations>
+                <Animation Duration="0:0:1.2" IterationCount="Infinite">
+                    <KeyFrame Cue="0%"><Setter Property="Opacity" Value="0.3"/><Setter Property="(Canvas.Top)" Value="4"/></KeyFrame>
+                    <KeyFrame Cue="15%"><Setter Property="Opacity" Value="1.0"/><Setter Property="(Canvas.Top)" Value="0"/></KeyFrame>
+                    <KeyFrame Cue="30%"><Setter Property="Opacity" Value="0.3"/><Setter Property="(Canvas.Top)" Value="4"/></KeyFrame>
+                </Animation>
+            </Style.Animations>
+        </Style>
+        <Style Selector="^:active /template/ Ellipse#Dot2">
+            <Style.Animations>
+                <Animation Duration="0:0:1.2" IterationCount="Infinite" Delay="0:0:0.15">
+                    <KeyFrame Cue="0%"><Setter Property="Opacity" Value="0.3"/><Setter Property="(Canvas.Top)" Value="4"/></KeyFrame>
+                    <KeyFrame Cue="15%"><Setter Property="Opacity" Value="1.0"/><Setter Property="(Canvas.Top)" Value="0"/></KeyFrame>
+                    <KeyFrame Cue="30%"><Setter Property="Opacity" Value="0.3"/><Setter Property="(Canvas.Top)" Value="4"/></KeyFrame>
+                </Animation>
+            </Style.Animations>
+        </Style>
+        <Style Selector="^:active /template/ Ellipse#Dot3">
+            <Style.Animations>
+                <Animation Duration="0:0:1.2" IterationCount="Infinite" Delay="0:0:0.3">
+                    <KeyFrame Cue="0%"><Setter Property="Opacity" Value="0.3"/><Setter Property="(Canvas.Top)" Value="4"/></KeyFrame>
+                    <KeyFrame Cue="15%"><Setter Property="Opacity" Value="1.0"/><Setter Property="(Canvas.Top)" Value="0"/></KeyFrame>
+                    <KeyFrame Cue="30%"><Setter Property="Opacity" Value="0.3"/><Setter Property="(Canvas.Top)" Value="4"/></KeyFrame>
+                </Animation>
+            </Style.Animations>
+        </Style>
+
+        <Style Selector="^:not(:active)">
+            <Setter Property="Opacity" Value="0" />
+        </Style>
     </ControlTheme>
 
     <ControlTheme x:Key="SpinningSquares" TargetType="controls:ProgressRing">
@@ -125,61 +96,39 @@
         <Setter Property="Height" Value="48" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Canvas Width="48" Height="48">
-                    <Rectangle Width="16" Height="16" 
-                               Fill="{TemplateBinding Foreground}"
-                               Canvas.Left="16" Canvas.Top="0">
-                        <Rectangle.RenderTransform>
-                            <RotateTransform Angle="0" CenterX="8" CenterY="24" />
-                        </Rectangle.RenderTransform>
-                        <Rectangle.Styles>
-                            <Style Selector="Rectangle">
-                                <Style.Animations>
-                                    <Animation Duration="0:0:2" IterationCount="Infinite">
-                                        <KeyFrame Cue="0%">
-                                            <Setter Property="RenderTransform">
-                                                <RotateTransform Angle="0" CenterX="8" CenterY="24" />
-                                            </Setter>
-                                        </KeyFrame>
-                                        <KeyFrame Cue="100%">
-                                            <Setter Property="RenderTransform">
-                                                <RotateTransform Angle="360" CenterX="8" CenterY="24" />
-                                            </Setter>
-                                        </KeyFrame>
-                                    </Animation>
-                                </Style.Animations>
-                            </Style>
-                        </Rectangle.Styles>
-                    </Rectangle>
-                    <Rectangle Width="12" Height="12" 
-                               Fill="{TemplateBinding Foreground}"
-                               Opacity="0.7"
-                               Canvas.Left="18" Canvas.Top="2">
-                        <Rectangle.RenderTransform>
-                            <RotateTransform Angle="0" CenterX="6" CenterY="22" />
-                        </Rectangle.RenderTransform>
-                        <Rectangle.Styles>
-                            <Style Selector="Rectangle">
-                                <Style.Animations>
-                                    <Animation Duration="0:0:2" IterationCount="Infinite" Delay="0:0:0.15">
-                                        <KeyFrame Cue="0%">
-                                            <Setter Property="RenderTransform">
-                                                <RotateTransform Angle="0" CenterX="6" CenterY="22" />
-                                            </Setter>
-                                        </KeyFrame>
-                                        <KeyFrame Cue="100%">
-                                            <Setter Property="RenderTransform">
-                                                <RotateTransform Angle="-360" CenterX="6" CenterY="22" />
-                                            </Setter>
-                                        </KeyFrame>
-                                    </Animation>
-                                </Style.Animations>
-                            </Style>
-                        </Rectangle.Styles>
-                    </Rectangle>
-                </Canvas>
+                <Border x:Name="PART_Indicator" Background="Transparent">
+                    <Canvas Width="48" Height="48">
+                        <Rectangle Name="Rect1" Width="16" Height="16" Fill="{TemplateBinding Foreground}" Canvas.Left="16" Canvas.Top="0">
+                            <Rectangle.RenderTransform><RotateTransform Angle="0" CenterX="8" CenterY="24" /></Rectangle.RenderTransform>
+                        </Rectangle>
+                        <Rectangle Name="Rect2" Width="12" Height="12" Fill="{TemplateBinding Foreground}" Opacity="0.7" Canvas.Left="18" Canvas.Top="2">
+                            <Rectangle.RenderTransform><RotateTransform Angle="0" CenterX="6" CenterY="22" /></Rectangle.RenderTransform>
+                        </Rectangle>
+                    </Canvas>
+                </Border>
             </ControlTemplate>
         </Setter>
+        
+        <Style Selector="^:active /template/ Rectangle#Rect1">
+            <Style.Animations>
+                <Animation Duration="0:0:2" IterationCount="Infinite">
+                    <KeyFrame Cue="0%"><Setter Property="RenderTransform"><RotateTransform Angle="0" CenterX="8" CenterY="24" /></Setter></KeyFrame>
+                    <KeyFrame Cue="100%"><Setter Property="RenderTransform"><RotateTransform Angle="360" CenterX="8" CenterY="24" /></Setter></KeyFrame>
+                </Animation>
+            </Style.Animations>
+        </Style>
+        <Style Selector="^:active /template/ Rectangle#Rect2">
+            <Style.Animations>
+                <Animation Duration="0:0:2" IterationCount="Infinite" Delay="0:0:0.15">
+                    <KeyFrame Cue="0%"><Setter Property="RenderTransform"><RotateTransform Angle="0" CenterX="6" CenterY="22" /></Setter></KeyFrame>
+                    <KeyFrame Cue="100%"><Setter Property="RenderTransform"><RotateTransform Angle="-360" CenterX="6" CenterY="22" /></Setter></KeyFrame>
+                </Animation>
+            </Style.Animations>
+        </Style>
+
+        <Style Selector="^:not(:active)">
+            <Setter Property="Opacity" Value="0" />
+        </Style>
     </ControlTheme>
 
     <ControlTheme x:Key="PulsingRing" TargetType="controls:ProgressRing">
@@ -188,38 +137,25 @@
         <Setter Property="Height" Value="40" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Panel>
-                    <Ellipse Width="40" Height="40" 
-                             Stroke="{TemplateBinding Foreground}"
-                             StrokeThickness="3"
-                             Opacity="0.3">
-                        <Ellipse.Styles>
-                            <Style Selector="Ellipse">
-                                <Style.Animations>
-                                    <Animation Duration="0:0:1.5" IterationCount="Infinite">
-                                        <KeyFrame Cue="0%">
-                                            <Setter Property="Opacity" Value="0.3"/>
-                                            <Setter Property="Width" Value="40"/>
-                                            <Setter Property="Height" Value="40"/>
-                                        </KeyFrame>
-                                        <KeyFrame Cue="50%">
-                                            <Setter Property="Opacity" Value="1.0"/>
-                                            <Setter Property="Width" Value="48"/>
-                                            <Setter Property="Height" Value="48"/>
-                                        </KeyFrame>
-                                        <KeyFrame Cue="100%">
-                                            <Setter Property="Opacity" Value="0.3"/>
-                                            <Setter Property="Width" Value="40"/>
-                                            <Setter Property="Height" Value="40"/>
-                                        </KeyFrame>
-                                    </Animation>
-                                </Style.Animations>
-                            </Style>
-                        </Ellipse.Styles>
-                    </Ellipse>
-                </Panel>
+                <Border x:Name="PART_Indicator" Background="Transparent">
+                    <Ellipse Name="Ring" Width="40" Height="40" Stroke="{TemplateBinding Foreground}" StrokeThickness="3" Opacity="0.3" />
+                </Border>
             </ControlTemplate>
         </Setter>
+
+        <Style Selector="^:active /template/ Ellipse#Ring">
+            <Style.Animations>
+                <Animation Duration="0:0:1.5" IterationCount="Infinite">
+                    <KeyFrame Cue="0%"><Setter Property="Opacity" Value="0.3"/><Setter Property="Width" Value="40"/><Setter Property="Height" Value="40"/></KeyFrame>
+                    <KeyFrame Cue="50%"><Setter Property="Opacity" Value="1.0"/><Setter Property="Width" Value="48"/><Setter Property="Height" Value="48"/></KeyFrame>
+                    <KeyFrame Cue="100%"><Setter Property="Opacity" Value="0.3"/><Setter Property="Width" Value="40"/><Setter Property="Height" Value="40"/></KeyFrame>
+                </Animation>
+            </Style.Animations>
+        </Style>
+
+        <Style Selector="^:not(:active)">
+            <Setter Property="Opacity" Value="0" />
+        </Style>
     </ControlTheme>
 
 </ResourceDictionary>

--- a/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRing.axaml.cs
+++ b/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRing.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Avalonia.Controls.Maui;
+
+public partial class ProgressRingResources : ResourceDictionary
+{
+    public ProgressRingResources()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRing.cs
+++ b/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRing.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using Avalonia.Automation;
 using Avalonia.Automation.Peers;
@@ -11,7 +12,7 @@ namespace Avalonia.Controls.Maui;
 /// Supports both determinate and indeterminate modes.
 /// </summary>
 [PseudoClasses(":active", ":indeterminate", ":determinate")]
-public class ProgressRing : RangeBase
+public class ProgressRing : ProgressBar
 {
     static ProgressRing()
     {
@@ -19,9 +20,8 @@ public class ProgressRing : RangeBase
         MaximumProperty.OverrideDefaultValue<ProgressRing>(100.0);
         IsHitTestVisibleProperty.OverrideDefaultValue<ProgressRing>(false);
         FocusableProperty.OverrideDefaultValue<ProgressRing>(false);
-        
-        AutomationProperties.ControlTypeOverrideProperty.OverrideDefaultValue<ProgressRing>(
-            AutomationControlType.ProgressBar);
+        IsIndeterminateProperty.OverrideDefaultValue<ProgressRing>(true);
+        AutomationProperties.ControlTypeOverrideProperty.OverrideDefaultValue<ProgressRing>(AutomationControlType.ProgressBar);
     }
 
     /// <summary>
@@ -31,13 +31,7 @@ public class ProgressRing : RangeBase
         AvaloniaProperty.Register<ProgressRing, bool>(nameof(IsActive), defaultValue: true);
 
     /// <summary>
-    /// Defines the <see cref="IsIndeterminate"/> property.
-    /// </summary>
-    public static readonly StyledProperty<bool> IsIndeterminateProperty =
-        AvaloniaProperty.Register<ProgressRing, bool>(nameof(IsIndeterminate), defaultValue: true);
-
-    /// <summary>
-    /// Gets or sets a value that indicates whether the ProgressRing is showing progress.
+    /// Gets or sets a value that indicates whether the <see cref="ProgressRing"/> is showing progress.
     /// </summary>
     public bool IsActive
     {
@@ -45,16 +39,7 @@ public class ProgressRing : RangeBase
         set => SetValue(IsActiveProperty, value);
     }
 
-    /// <summary>
-    /// Gets or sets a value that indicates whether the progress ring reports generic progress 
-    /// with a repeating pattern or reports progress based on the Value property.
-    /// </summary>
-    public bool IsIndeterminate
-    {
-        get => GetValue(IsIndeterminateProperty);
-        set => SetValue(IsIndeterminateProperty, value);
-    }
-
+    /// <inheritdoc/>
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);
@@ -62,20 +47,13 @@ public class ProgressRing : RangeBase
         UpdateAccessibility();
     }
 
+    /// <inheritdoc/>
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
-
-        if (change.Property == IsActiveProperty ||
-            change.Property == IsIndeterminateProperty)
+        if (change.Property == IsActiveProperty || change.Property == IsIndeterminateProperty)
         {
             UpdatePseudoClasses();
-            UpdateAccessibility();
-        }
-        else if (change.Property == ValueProperty ||
-                 change.Property == MinimumProperty ||
-                 change.Property == MaximumProperty)
-        {
             UpdateAccessibility();
         }
     }
@@ -87,62 +65,42 @@ public class ProgressRing : RangeBase
         PseudoClasses.Set(":determinate", IsActive && !IsIndeterminate);
     }
 
+    /// <inheritdoc/>
     protected override AutomationPeer OnCreateAutomationPeer()
     {
         return new ProgressRingAutomationPeer(this);
     }
-    
+
     /// <summary>
-    /// Gets the accessibility text for screen readers.
-    /// Override to provide localized strings.
+    /// Gets the accessibility text (e.g. "75%") used by the AutomationPeer.
     /// </summary>
-    /// <returns>
-    /// A descriptive string for the current state, or null/empty
-    /// to fall back to AutomationProperties.Name.
-    /// </returns>
+    /// <returns>A string representing the current progress percentage, or null if indeterminate/inactive.</returns>
     public virtual string? GetAccessibilityText()
     {
-        // If the app has explicitly set a Name, prefer that.
         var explicitName = AutomationProperties.GetName(this);
-        
         if (!string.IsNullOrEmpty(explicitName))
             return explicitName;
 
-        if (!IsActive)
+        if (!IsActive || IsIndeterminate)
             return null;
 
-        if (IsIndeterminate)
-            return null;
-
-        // Calculate percentage: (Value - Minimum) / (Maximum - Minimum) * 100
-        double percentage;
-        if (Maximum <= Minimum)
+        double percentage = 0;
+        if (Maximum > Minimum)
         {
-            percentage = 0;
-        }
-        else
-        {
-            var value = Math.Clamp(Value, Minimum, Maximum);
-            percentage = ((value - Minimum) / (Maximum - Minimum)) * 100.0;
+            var val = Math.Clamp(Value, Minimum, Maximum);
+            percentage = (val - Minimum) / (Maximum - Minimum) * 100.0;
         }
 
-        // Represent as a localized percentage number.
-        // E.g. "75%" in the current UI culture.
-        var culture = CultureInfo.CurrentUICulture;
-        return percentage.ToString("P0", culture);
+        return percentage.ToString("P0", CultureInfo.CurrentUICulture);
     }
 
     private void UpdateAccessibility()
     {
         var text = GetAccessibilityText();
-
         if (!string.IsNullOrEmpty(text))
         {
             if (string.IsNullOrEmpty(AutomationProperties.GetName(this)))
                 AutomationProperties.SetName(this, text);
-
-            if (string.IsNullOrEmpty(AutomationProperties.GetHelpText(this)))
-                AutomationProperties.SetHelpText(this, text);
         }
     }
 }

--- a/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRingAutomationPeer.cs
+++ b/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRingAutomationPeer.cs
@@ -1,11 +1,12 @@
 using Avalonia.Automation.Peers;
+using Avalonia.Controls.Automation.Peers;
 
 namespace Avalonia.Controls.Maui
 {
     /// <summary>
     /// Automation peer for ProgressRing to support screen readers and assistive technologies.
     /// </summary>
-    public class ProgressRingAutomationPeer : RangeBaseAutomationPeer
+    public class ProgressRingAutomationPeer : ProgressBarAutomationPeer
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ProgressRingAutomationPeer"/> class.

--- a/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRingVisual.cs
+++ b/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRingVisual.cs
@@ -1,432 +1,402 @@
-using System;
-using System.Diagnostics;
-using Avalonia;
-using Avalonia.Controls;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
 using Avalonia.Media;
-using Avalonia.Threading;
+using Avalonia.Styling;
 
 namespace Avalonia.Controls.Maui;
 
 /// <summary>
-/// Visual component for rendering the <see cref="ProgressRing"/> animation.
-/// This is a template part that can be replaced for custom visualizations.
+/// A visual control that renders the <see cref="ProgressRing"/> control.
+/// Handles the rendering of both determinate (percentage-based) and indeterminate (spinning) states.
 /// </summary>
 public class ProgressRingVisual : Control
 {
-    private Stopwatch? _animationStopwatch;
-    private DispatcherTimer? _animationTimer;
-    private double _currentRotation;
-    private double _currentArcSize;
+    private CancellationTokenSource? _animationCts;
+    private Avalonia.Animation.Animation? _progressAnimation;
     
+    // Geometry caching for performance
     private Geometry? _cachedGeometry;
-    private double _cachedValue = double.NaN;
-    private double _cachedRadius = double.NaN;
-    private bool _cachedIsRtl;
+    private double _cachedStartAngle;
+    private double _cachedSweepAngle;
+    private double _cachedRadius;
 
     static ProgressRingVisual()
     {
         AffectsRender<ProgressRingVisual>(
-            RingForegroundProperty,
-            RingBackgroundProperty,
+            ForegroundProperty,
+            BackgroundProperty,
             IsIndeterminateProperty,
+            IsActiveProperty,
             ValueProperty,
             MinimumProperty,
             MaximumProperty,
             StrokeThicknessProperty,
-            AnimationDurationProperty,
-            StartAngleProperty,
-            FlowDirectionProperty);
+            AnimationProgressProperty);
     }
-
+    
     /// <summary>
-    /// Defines the <see cref="RingForeground"/> property.
+    /// Defines the <see cref="Foreground"/> property.
     /// </summary>
-    public static readonly StyledProperty<IBrush?> RingForegroundProperty =
-        AvaloniaProperty.Register<ProgressRingVisual, IBrush?>(nameof(RingForeground));
-
+    public static readonly StyledProperty<IBrush?> ForegroundProperty = 
+        AvaloniaProperty.Register<ProgressRingVisual, IBrush?>(nameof(Foreground));
+    
     /// <summary>
-    /// Defines the <see cref="RingBackground"/> property.
+    /// Defines the <see cref="Background"/> property.
     /// </summary>
-    public static readonly StyledProperty<IBrush?> RingBackgroundProperty =
-        AvaloniaProperty.Register<ProgressRingVisual, IBrush?>(nameof(RingBackground));
-
+    public static readonly StyledProperty<IBrush?> BackgroundProperty = 
+        AvaloniaProperty.Register<ProgressRingVisual, IBrush?>(nameof(Background));
+    
     /// <summary>
     /// Defines the <see cref="IsIndeterminate"/> property.
     /// </summary>
-    public static readonly StyledProperty<bool> IsIndeterminateProperty =
+    public static readonly StyledProperty<bool> IsIndeterminateProperty = 
         AvaloniaProperty.Register<ProgressRingVisual, bool>(nameof(IsIndeterminate), defaultValue: true);
-
+    
+    /// <summary>
+    /// Defines the <see cref="IsActive"/> property.
+    /// </summary>
+    public static readonly StyledProperty<bool> IsActiveProperty = 
+        AvaloniaProperty.Register<ProgressRingVisual, bool>(nameof(IsActive), defaultValue: true);
+    
     /// <summary>
     /// Defines the <see cref="Value"/> property.
     /// </summary>
-    public static readonly StyledProperty<double> ValueProperty =
+    public static readonly StyledProperty<double> ValueProperty = 
         AvaloniaProperty.Register<ProgressRingVisual, double>(nameof(Value), defaultValue: 0.0);
-
+    
     /// <summary>
     /// Defines the <see cref="Minimum"/> property.
     /// </summary>
-    public static readonly StyledProperty<double> MinimumProperty =
+    public static readonly StyledProperty<double> MinimumProperty = 
         AvaloniaProperty.Register<ProgressRingVisual, double>(nameof(Minimum), defaultValue: 0.0);
-
+    
     /// <summary>
     /// Defines the <see cref="Maximum"/> property.
     /// </summary>
-    public static readonly StyledProperty<double> MaximumProperty =
+    public static readonly StyledProperty<double> MaximumProperty = 
         AvaloniaProperty.Register<ProgressRingVisual, double>(nameof(Maximum), defaultValue: 100.0);
-
+    
     /// <summary>
     /// Defines the <see cref="StrokeThickness"/> property.
     /// </summary>
-    public static readonly StyledProperty<double> StrokeThicknessProperty =
-        AvaloniaProperty.Register<ProgressRingVisual, double>(
-            nameof(StrokeThickness), 
-            defaultValue: 4.0,
-            validate: v => v > 0);
+    public static readonly StyledProperty<double> StrokeThicknessProperty = 
+        AvaloniaProperty.Register<ProgressRingVisual, double>(nameof(StrokeThickness), defaultValue: 4.0);
 
     /// <summary>
-    /// Defines the <see cref="AnimationDuration"/> property.
+    /// Defines the <see cref="AnimationProgress"/> property.
     /// </summary>
-    public static readonly StyledProperty<TimeSpan> AnimationDurationProperty =
-        AvaloniaProperty.Register<ProgressRingVisual, TimeSpan>(
-            nameof(AnimationDuration),
-            defaultValue: TimeSpan.FromSeconds(2),
-            validate: v => v > TimeSpan.Zero);
+    public static readonly StyledProperty<double> AnimationProgressProperty = 
+        AvaloniaProperty.Register<ProgressRingVisual, double>(nameof(AnimationProgress), defaultValue: 0.0);
 
     /// <summary>
-    /// Defines the <see cref="StartAngle"/> property.
+    /// Gets or sets the foreground brush used to draw the progress indicator.
     /// </summary>
-    public static readonly StyledProperty<double> StartAngleProperty =
-        AvaloniaProperty.Register<ProgressRingVisual, double>(nameof(StartAngle), defaultValue: -90.0);
-
+    public IBrush? Foreground 
+    { 
+        get => GetValue(ForegroundProperty); 
+        set => SetValue(ForegroundProperty, value); 
+    }
+    
     /// <summary>
-    /// Gets or sets the foreground brush for the progress arc.
+    /// Gets or sets the background brush used to draw the track.
     /// </summary>
-    public IBrush? RingForeground
-    {
-        get => GetValue(RingForegroundProperty);
-        set => SetValue(RingForegroundProperty, value);
+    public IBrush? Background 
+    { 
+        get => GetValue(BackgroundProperty); 
+        set => SetValue(BackgroundProperty, value); 
+    }
+    
+    /// <summary>
+    /// Gets or sets a value that indicates whether the progress ring reports generic progress with a repeating pattern (true) or reports progress based on the Value property (false).
+    /// </summary>
+    public bool IsIndeterminate 
+    { 
+        get => GetValue(IsIndeterminateProperty); 
+        set => SetValue(IsIndeterminateProperty, value); 
+    }
+    
+    /// <summary>
+    /// Gets or sets a value that indicates whether the ProgressRing is showing progress.
+    /// </summary>
+    public bool IsActive 
+    { 
+        get => GetValue(IsActiveProperty); 
+        set => SetValue(IsActiveProperty, value); 
+    }
+    
+    /// <summary>
+    /// Gets or sets the current value of the progress ring for determinate mode.
+    /// </summary>
+    public double Value 
+    { 
+        get => GetValue(ValueProperty); 
+        set => SetValue(ValueProperty, value); 
+    }
+    
+    /// <summary>
+    /// Gets or sets the minimum value of the range.
+    /// </summary>
+    public double Minimum 
+    { 
+        get => GetValue(MinimumProperty); 
+        set => SetValue(MinimumProperty, value); 
+    }
+    
+    /// <summary>
+    /// Gets or sets the maximum value of the range.
+    /// </summary>
+    public double Maximum 
+    { 
+        get => GetValue(MaximumProperty); 
+        set => SetValue(MaximumProperty, value); 
+    }
+    
+    /// <summary>
+    /// Gets or sets the thickness of the ring stroke.
+    /// </summary>
+    public double StrokeThickness 
+    { 
+        get => GetValue(StrokeThicknessProperty); 
+        set => SetValue(StrokeThicknessProperty, value); 
     }
 
     /// <summary>
-    /// Gets or sets the background brush for the track arc.
+    /// Gets or sets the normalized progress of the indeterminate animation (0.0 to 1.0).
     /// </summary>
-    public IBrush? RingBackground
-    {
-        get => GetValue(RingBackgroundProperty);
-        set => SetValue(RingBackgroundProperty, value);
+    public double AnimationProgress 
+    { 
+        get => GetValue(AnimationProgressProperty); 
+        set => SetValue(AnimationProgressProperty, value); 
     }
 
-    /// <summary>
-    /// Gets or sets whether the visual shows indeterminate progress.
-    /// </summary>
-    public bool IsIndeterminate
-    {
-        get => GetValue(IsIndeterminateProperty);
-        set => SetValue(IsIndeterminateProperty, value);
-    }
-
-    /// <summary>
-    /// Gets or sets the current value for determinate mode.
-    /// </summary>
-    public double Value
-    {
-        get => GetValue(ValueProperty);
-        set => SetValue(ValueProperty, value);
-    }
-
-    /// <summary>
-    /// Gets or sets the minimum value.
-    /// </summary>
-    public double Minimum
-    {
-        get => GetValue(MinimumProperty);
-        set => SetValue(MinimumProperty, value);
-    }
-
-    /// <summary>
-    /// Gets or sets the maximum value.
-    /// </summary>
-    public double Maximum
-    {
-        get => GetValue(MaximumProperty);
-        set => SetValue(MaximumProperty, value);
-    }
-
-    /// <summary>
-    /// Gets or sets the stroke thickness in pixels.
-    /// </summary>
-    public double StrokeThickness
-    {
-        get => GetValue(StrokeThicknessProperty);
-        set => SetValue(StrokeThicknessProperty, value);
-    }
-
-    /// <summary>
-    /// Gets or sets the animation duration for indeterminate mode.
-    /// </summary>
-    public TimeSpan AnimationDuration
-    {
-        get => GetValue(AnimationDurationProperty);
-        set => SetValue(AnimationDurationProperty, value);
-    }
-
-    /// <summary>
-    /// Gets or sets the starting angle in degrees.
-    /// Default is -90 (top of circle, 12 o'clock position).
-    /// </summary>
-    public double StartAngle
-    {
-        get => GetValue(StartAngleProperty);
-        set => SetValue(StartAngleProperty, value);
-    }
-
-    private bool IsRightToLeft => FlowDirection == FlowDirection.RightToLeft;
-
-    public ProgressRingVisual()
-    {
-        ClipToBounds = false;
-    }
-
-    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
-    {
-        base.OnPropertyChanged(change);
-
-        if (change.Property == IsIndeterminateProperty)
-        {
-            _cachedGeometry = null;
-            UpdateAnimation();
-        }
-        else if (change.Property == ValueProperty ||
-                 change.Property == MinimumProperty ||
-                 change.Property == MaximumProperty ||
-                 change.Property == FlowDirectionProperty)
-        {
-            _cachedGeometry = null;
-        }
-    }
-
+    /// <inheritdoc/>
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnAttachedToVisualTree(e);
         UpdateAnimation();
     }
 
+    /// <inheritdoc/>
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnDetachedFromVisualTree(e);
         StopAnimation();
     }
 
+    /// <inheritdoc/>
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        
+        if (change.Property == IsIndeterminateProperty || change.Property == IsActiveProperty)
+        {
+            UpdateAnimation();
+        }
+    }
+
     private void UpdateAnimation()
     {
-        if (IsIndeterminate && VisualRoot != null)
+        if (IsActive && IsIndeterminate && VisualRoot != null)
+        {
             StartAnimation();
+        }
         else
+        {
             StopAnimation();
+        }
     }
 
     private void StartAnimation()
     {
-        if (_animationTimer != null)
-            return;
-
-        _animationStopwatch = Stopwatch.StartNew();
-        _animationTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(16) };
-        _animationTimer.Tick += OnAnimationTick;
-        _animationTimer.Start();
+        if (_animationCts != null) return;
+        
+        _animationCts = new CancellationTokenSource();
+        EnsureAnimation();
+        _progressAnimation?.RunAsync(this, _animationCts.Token);
     }
 
     private void StopAnimation()
     {
-        _animationTimer?.Stop();
-        if (_animationTimer != null)
-        {
-            _animationTimer.Tick -= OnAnimationTick;
-            _animationTimer = null;
-        }
-        _animationStopwatch?.Stop();
-        _animationStopwatch = null;
+        _animationCts?.Cancel();
+        _animationCts?.Dispose();
+        _animationCts = null;
+        AnimationProgress = 0;
     }
 
-    private void OnAnimationTick(object? sender, EventArgs e)
+    private void EnsureAnimation()
     {
-        if (_animationStopwatch == null)
-            return;
+        if (_progressAnimation != null) return;
 
-        var elapsed = _animationStopwatch.Elapsed;
-        var progress = (elapsed.TotalSeconds % AnimationDuration.TotalSeconds) / AnimationDuration.TotalSeconds;
+        // Simple linear animation from 0 to 1.
+        _progressAnimation = new Avalonia.Animation.Animation
+        {
+            Duration = TimeSpan.FromSeconds(2.0),
+            IterationCount = IterationCount.Infinite,
+            Easing = new LinearEasing(),
+            Children =
+            {
+                new KeyFrame
+                {
+                    Cue = new Cue(0.0),
+                    Setters = { new Setter(AnimationProgressProperty, 0.0) }
+                },
+                new KeyFrame
+                {
+                    Cue = new Cue(1.0),
+                    Setters = { new Setter(AnimationProgressProperty, 1.0) }
+                }
+            }
+        };
+    }
 
+    /// <summary>
+    /// Computes the arc size (sweep angle) based on animation progress.
+    /// </summary>
+    /// <param name="progress">The current normalized animation progress.</param>
+    /// <returns>The sweep angle in degrees.</returns>
+    private static double ComputeArcSize(double progress)
+    {
         if (progress < 0.25)
         {
-            var t = progress / 0.25;
-            _currentArcSize = 180 * (1 - Math.Pow(1 - t, 3));
+            // Expanding: 0 -> 180 over first quarter
+            return 180.0 * (progress / 0.25);
         }
-        else if (progress >= 0.75)
+        else if (progress < 0.75)
         {
-            var t = (progress - 0.75) / 0.25;
-            _currentArcSize = 180 * (1 - Math.Pow(t, 3));
+            // Hold at max size
+            return 180.0;
         }
         else
         {
-            _currentArcSize = 180;
+            // Contracting: 180 -> 0 over last quarter
+            return 180.0 * ((1.0 - progress) / 0.25);
         }
-
-        var baseRotation = 1080 * progress;
-        _currentRotation = IsRightToLeft ? -baseRotation : baseRotation;
-
-        InvalidateVisual();
     }
 
+    /// <summary>
+    /// Computes the arc position (center rotation) based on animation progress.
+    /// </summary>
+    /// <param name="progress">The current normalized animation progress.</param>
+    /// <returns>The rotation angle in degrees.</returns>
+    private static double ComputeArcPosition(double progress)
+    {
+        return 1080.0 * progress;
+    }
+
+    /// <inheritdoc/>
     public override void Render(DrawingContext context)
     {
-        base.Render(context);
-
         var bounds = Bounds;
-        if (bounds.Width <= 0 || bounds.Height <= 0)
-            return;
+        if (bounds.Width <= 0 || bounds.Height <= 0) return;
 
-        var size = Math.Min(bounds.Width, bounds.Height);
         var center = new Point(bounds.Width / 2, bounds.Height / 2);
-        var radius = (size - StrokeThickness) / 2;
+        var radius = (Math.Min(bounds.Width, bounds.Height) - StrokeThickness) / 2;
+        if (radius <= 0) return;
 
-        if (radius <= 0 || RingForeground == null)
-            return;
-
-        var pen = new Pen(RingForeground, StrokeThickness, lineCap: PenLineCap.Round);
-
-        if (RingBackground != null && !IsIndeterminate)
+        // Draw background track (only for determinate mode)
+        if (Background != null && !IsIndeterminate)
         {
-            var bgPen = new Pen(RingBackground, StrokeThickness, lineCap: PenLineCap.Round);
-            var bgGeometry = CreateArcGeometry(center, radius, 0, 360);
+            var bgPen = new Pen(Background, StrokeThickness, lineCap: PenLineCap.Round);
+            var bgGeometry = new EllipseGeometry(new Rect(
+                center.X - radius, 
+                center.Y - radius, 
+                radius * 2, 
+                radius * 2));
             context.DrawGeometry(null, bgPen, bgGeometry);
         }
 
+        if (!IsActive || Foreground == null) return;
+
+        var pen = new Pen(Foreground, StrokeThickness, lineCap: PenLineCap.Round);
+
         if (IsIndeterminate)
         {
-            RenderIndeterminate(context, center, radius, pen);
+            var progress = AnimationProgress;
+            var arcSize = ComputeArcSize(progress);
+            var arcPosition = ComputeArcPosition(progress);
+            
+            // The arc is centered at the position, so we offset by half the size
+            var startAngle = -90.0 + arcPosition - (arcSize / 2.0);
+            var sweepAngle = arcSize;
+
+            DrawArc(context, pen, center, radius, startAngle, sweepAngle);
         }
         else
         {
-            RenderDeterminate(context, center, radius, pen);
+            var val = Math.Clamp(Value, Minimum, Maximum);
+            var range = Maximum - Minimum;
+            var percent = range <= 0 ? 0 : (val - Minimum) / range;
+            DrawArc(context, pen, center, radius, -90, percent * 360);
         }
     }
 
-    /// <summary>
-    /// Renders the animated indeterminate arc.
-    /// Virtual to allow custom animation strategies.
-    /// </summary>
-    protected virtual void RenderIndeterminate(DrawingContext context, Point center, double radius, Pen pen)
+    private void DrawArc(DrawingContext context, Pen pen, Point center, double radius, 
+        double startAngle, double sweepAngle)
     {
-        var angleRadians = _currentRotation * Math.PI / 180;
-        var transform = Matrix.CreateTranslation(-center.X, -center.Y) *
-                       Matrix.CreateRotation(angleRadians) *
-                       Matrix.CreateTranslation(center.X, center.Y);
-
-        using (context.PushTransform(transform))
+        // Skip rendering very small arcs
+        if (sweepAngle < 0.5)
         {
-            var halfArc = _currentArcSize / 2;
-            var geometry = CreateArcGeometry(center, radius, -halfArc, halfArc);
-            context.DrawGeometry(null, pen, geometry);
+            _cachedGeometry = null;
+            return;
         }
-    }
 
-    /// <summary>
-    /// Renders the static determinate arc with geometry caching.
-    /// Virtual to allow custom rendering strategies.
-    /// </summary>
-    protected virtual void RenderDeterminate(DrawingContext context, Point center, double radius, Pen pen)
-    {
-        var progress = Math.Clamp((Value - Minimum) / (Maximum - Minimum), 0, 1);
-        var angle = progress * 360;
-
-        if (IsRightToLeft)
-            angle = -angle;
-
+        // Normalize angles for caching comparison
+        var normalizedStart = startAngle % 360;
+        
+        // Check if we can reuse cached geometry
         if (_cachedGeometry != null &&
-            Math.Abs(_cachedValue - Value) < 0.001 &&
-            Math.Abs(_cachedRadius - radius) < 0.001 &&
-            _cachedIsRtl == IsRightToLeft)
+            Math.Abs(_cachedStartAngle - normalizedStart) < 0.1 &&
+            Math.Abs(_cachedSweepAngle - sweepAngle) < 0.1 &&
+            Math.Abs(_cachedRadius - radius) < 0.01)
         {
             context.DrawGeometry(null, pen, _cachedGeometry);
+            return;
+        }
+
+        Geometry geometry;
+        
+        if (sweepAngle >= 359.9)
+        {
+            // Full circle
+            geometry = new EllipseGeometry(new Rect(
+                center.X - radius, 
+                center.Y - radius, 
+                radius * 2, 
+                radius * 2));
         }
         else
         {
-            var geometry = CreateArcGeometry(center, radius, 0, angle);
-            _cachedGeometry = geometry;
-            _cachedValue = Value;
-            _cachedRadius = radius;
-            _cachedIsRtl = IsRightToLeft;
-            context.DrawGeometry(null, pen, geometry);
-        }
-    }
+            // Arc
+            var startRad = startAngle * (Math.PI / 180.0);
+            var endRad = (startAngle + sweepAngle) * (Math.PI / 180.0);
 
-    /// <summary>
-    /// Creates arc geometry for rendering.
-    /// Virtual to allow custom shapes (e.g., square, hexagon).
-    /// </summary>
-    protected virtual Geometry CreateArcGeometry(Point center, double radius, double startAngle, double endAngle)
-    {
-        var sweepAngle = endAngle - startAngle;
+            var startPoint = new Point(
+                center.X + radius * Math.Cos(startRad), 
+                center.Y + radius * Math.Sin(startRad));
+            var endPoint = new Point(
+                center.X + radius * Math.Cos(endRad), 
+                center.Y + radius * Math.Sin(endRad));
 
-        if (Math.Abs(sweepAngle) < 0.01)
-            return new StreamGeometry();
-
-        if (Math.Abs(sweepAngle) >= 359.9)
-            return CreateFullCircleGeometry(center, radius);
-
-        var isNegativeSweep = sweepAngle < 0;
-        var absSweep = Math.Abs(sweepAngle);
-
-        var adjustedStart = (startAngle + StartAngle) * Math.PI / 180;
-        var adjustedEnd = (endAngle + StartAngle) * Math.PI / 180;
-
-        var startPoint = new Point(
-            center.X + radius * Math.Cos(adjustedStart),
-            center.Y + radius * Math.Sin(adjustedStart));
-
-        var endPoint = new Point(
-            center.X + radius * Math.Cos(adjustedEnd),
-            center.Y + radius * Math.Sin(adjustedEnd));
-
-        var geometry = new StreamGeometry();
-        using (var ctx = geometry.Open())
-        {
-            ctx.BeginFigure(startPoint, false);
-            ctx.ArcTo(
-                endPoint,
-                new Size(radius, radius),
-                0,
-                absSweep > 180,
-                isNegativeSweep ? SweepDirection.CounterClockwise : SweepDirection.Clockwise);
+            var streamGeometry = new StreamGeometry();
+            using (var ctx = streamGeometry.Open())
+            {
+                ctx.BeginFigure(startPoint, false);
+                ctx.ArcTo(
+                    endPoint, 
+                    new Size(radius, radius), 
+                    0, 
+                    sweepAngle > 180, 
+                    SweepDirection.Clockwise);
+            }
+            geometry = streamGeometry;
         }
 
-        return geometry;
-    }
-
-    /// <summary>
-    /// Creates a full circle geometry using two semicircles.
-    /// Virtual to allow alternative full-circle strategies.
-    /// </summary>
-    protected virtual Geometry CreateFullCircleGeometry(Point center, double radius)
-    {
-        var adjustedStart = StartAngle * Math.PI / 180;
-
-        var startPoint = new Point(
-            center.X + radius * Math.Cos(adjustedStart),
-            center.Y + radius * Math.Sin(adjustedStart));
-
-        var midPoint = new Point(
-            center.X + radius * Math.Cos(adjustedStart + Math.PI),
-            center.Y + radius * Math.Sin(adjustedStart + Math.PI));
-
-        var geometry = new StreamGeometry();
-        using (var ctx = geometry.Open())
-        {
-            ctx.BeginFigure(startPoint, false);
-            ctx.ArcTo(midPoint, new Size(radius, radius), 0, false, SweepDirection.Clockwise);
-            ctx.ArcTo(startPoint, new Size(radius, radius), 0, false, SweepDirection.Clockwise);
-        }
-
-        return geometry;
+        context.DrawGeometry(null, pen, geometry);
+        
+        // Cache for next frame
+        _cachedGeometry = geometry;
+        _cachedStartAngle = normalizedStart;
+        _cachedSweepAngle = sweepAngle;
+        _cachedRadius = radius;
     }
 }

--- a/src/Avalonia.Controls.Maui/Controls/ProgressRing/SPEC.md
+++ b/src/Avalonia.Controls.Maui/Controls/ProgressRing/SPEC.md
@@ -2,12 +2,14 @@
 
 ## Abstract
 Progress indication has been a fundamental requirement for modern cross-platform applications. This proposal provides a **ProgressRing** control that fills this gap, offering both indeterminate and determinate progress modes.
-Vision
+
+### Vision
 
 Details:
 * Core properties: IsActive, IsIndeterminate, Value, Minimum, Maximum
-* Inherits from RangeBase for standard range control patterns
-* Follows established naming conventions from Windows ecosystem
+* Inherits from ProgressBar (which itself provides RangeBase) for standard range control patterns and built-in determinate/indeterminate plumbing
+* Follows established naming conventions
+* Indeterminate animation runs on the render/composition path (no UI-thread timer)
 
 ### Requirements
 
@@ -15,21 +17,15 @@ Details:
 * **Must support both indeterminate and determinate modes**. Real-world applications require both: indeterminate mode for unknown-duration operations (app startup, network requests) and determinate mode for trackable progress (file downloads, processing steps).
 * **Must have accessibility support**. Progress indicators are critical feedback mechanisms. Screen reader users must receive equivalent information about loading states and progress.
 * **Must be theme-aware and customizable**. he control must adapt to light/dark themes automatically and allow custom styling through templates.
+* **Animation must be render-thread friendly**. Indeterminate motion should not pause when the UI thread is busy; animations use Avalonia's render/compositor animation system, not a dispatcher timer.
 
 ## API
-
-```
-public class ProgressRing : RangeBase
-{
-
-}
-```
 
 ```
 /// <summary>
 /// Represents a control that indicates indeterminate or determinate progress.
 /// </summary>
-public class ProgressRing : RangeBase
+public class ProgressRing : ProgressBar
 {
     /// <summary>
     /// Gets or sets a value that indicates whether the ProgressRing is showing progress.
@@ -41,7 +37,7 @@ public class ProgressRing : RangeBase
     /// </summary>
     public bool IsIndeterminate { get; set; }
     
-    // Inherited from RangeBase
+    // Inherited from ProgressBar / RangeBase
     /// <summary>
     /// Gets or sets the current value (0-100 by default).
     /// </summary>
@@ -60,9 +56,23 @@ public class ProgressRing : RangeBase
 ```
 
 Implementation Details
-* **ProgressRing**: Main control (logic, properties, accessibility)
-* **ProgressRingVisual**: Rendering component (geometry, animations, visual presentation)
-* **ProgressRingAutomationPeer**: Automation peer for ProgressRing to support screen readers and assistive technologies.
+* **ProgressRing**: Main control (inherits `ProgressBar`; logic, properties, accessibility)
+* **ProgressRingVisual**: Custom rendering component (565 lines) providing precise control over progress ring visualization:
+    * **Custom geometry rendering**: Uses `StreamGeometry` with `ArcTo` for pixel-perfect arc drawing with configurable start angle, sweep, and stroke properties
+    * **Indeterminate animation**: Two coordinated keyframe animations using `Avalonia.Animation.Animation.RunAsync()`:
+        - **Rotation**: Animates `RotationAngle` property (0→1080°, 3 full turns per cycle)
+        - **Arc sweep**: Animates `ArcSweep` property (0→180° ease-out → hold → 180→0° ease-in) for visual interest
+    * **Determinate mode**: Static arc with cached geometry, sweep angle calculated from `(Value - Minimum) / (Maximum - Minimum) × 360°`
+    * **Performance optimizations**:
+        - Properties marked with `AffectsRender` (not layout-affecting) for efficient invalidation
+        - Geometry caching for determinate arcs to avoid recalculation
+        - Animation lifecycle management with `CancellationTokenSource`
+    * **IsActive lifecycle**: Stops animations cleanly by canceling token and resetting visual state
+    * **RTL support**: Automatically mirrors rotation direction based on `FlowDirection`
+* **ProgressRingAutomationPeer**: Automation peer for ProgressRing (derives from `ProgressBarAutomationPeer`) to support screen readers and assistive technologies
+
+**Why Custom Visual vs Pure XAML**:
+While a pure XAML approach would be conceptually simpler, Avalonia's `Arc` shape control doesn't support `RenderTransform` animations in `Style.Animations` blocks (results in "No animator registered" error). Custom geometry rendering via `ProgressRingVisual` provides necessary control for animated arc effects while maintaining proper animation integration through Avalonia's property system.
 
 In this way:
 * Easy visual customization through ControlTheme
@@ -85,3 +95,8 @@ Determinate (Progress)
     IsIndeterminate="False"
     Value="{Binding DownloadProgress}" />
 ```
+
+### Animation Lifecycle
+* `IsActive=false` stops animations by canceling the `CancellationTokenSource`, which terminates both rotation and arc sweep animations. Properties reset to 0 for clean visual state.
+* `IsIndeterminate=false` switches from animated mode to static determinate arc rendering with cached geometry based on `(Value-Minimum)/(Maximum-Minimum)`.
+* `AnimationDuration` property (default 2s) controls the full indeterminate animation cycle. When changed while animating, the control cancels current animations, clears the animation cache, and restarts with the new duration.


### PR DESCRIPTION
This PR introduces a new sample page for the **ActivityIndicator** to the gallery application and apply updates based on feedback on the **ProgressRing** control.

![activityindicator-sample](https://github.com/user-attachments/assets/89534bfd-91bc-467c-8347-4603d76fdcd4)

- ProgressRing now inherits from ProgressBar to leverage standard range-based properties (Value, Minimum, Maximum).
- Improved the visual animation.
- Implemented theme-aware resources.

Also, updated the ProgressRing **Spec** based on all the changes. I am going to use it to open a new enhancement in the Core.