### PR TITLE
Sync Avalonia and MAUI themes, map background colors correctly

### DIFF
--- a/samples/ControlGallery/ControlGallery/ControlGallery.csproj
+++ b/samples/ControlGallery/ControlGallery/ControlGallery.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>$(DotNetTfm)</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<UseMaui>true</UseMaui>

--- a/samples/ControlGallery/ControlGallery/MainPage.xaml
+++ b/samples/ControlGallery/ControlGallery/MainPage.xaml
@@ -44,6 +44,12 @@
 								  Command="{Binding NavigateCommand}"
 								  CommandParameter="{x:Type pages:ProgressBarPage}"/>
 					</TableSection>
+					<TableSection Title="Settings">
+						<TextCell Text="Theme"
+								  Detail="Theme toggle and AppThemeBinding"
+								  Command="{Binding NavigateCommand}"
+								  CommandParameter="{x:Type pages:ThemePage}"/>
+					</TableSection>
 				</TableRoot>
 			</TableView>
 		</ContentPage>

--- a/samples/ControlGallery/ControlGallery/MainPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/MainPage.xaml.cs
@@ -28,6 +28,7 @@ public partial class MainPage : FlyoutPage
             nameof(ButtonPage) => new ButtonPage(),
             nameof(CheckBoxPage) => new CheckBoxPage(),
             nameof(ProgressBarPage) => new ProgressBarPage(),
+            nameof(ThemePage) => new ThemePage(),
             "MainPage" when pageType.Namespace == "WordPuzzle" => new WordPuzzle.MainPage(),
             _ => throw new ArgumentException($"Unknown page type: {pageType.FullName}", nameof(pageType))
         };

--- a/samples/ControlGallery/ControlGallery/Pages/ThemePage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/ThemePage.xaml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:pages="clr-namespace:ControlGallery.Pages"
+             x:Class="ControlGallery.Pages.ThemePage"
+             x:DataType="pages:ThemePage"
+             Title="Theme"
+             BackgroundColor="{AppThemeBinding Light={StaticResource LightPageBackgroundColor}, Dark={StaticResource DarkPageBackgroundColor}}">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <!-- Page Colors -->
+            <Color x:Key="LightPageBackgroundColor">#F5F5F5</Color>
+            <Color x:Key="DarkPageBackgroundColor">#1a1a1a</Color>
+
+            <!-- Secondary Background Colors -->
+            <Color x:Key="LightSecondaryBackgroundColor">#FFFFFF</Color>
+            <Color x:Key="DarkSecondaryBackgroundColor">#2d2d2d</Color>
+
+            <!-- Primary Text Colors -->
+            <Color x:Key="LightPrimaryTextColor">#1a1a1a</Color>
+            <Color x:Key="DarkPrimaryTextColor">#FFFFFF</Color>
+
+            <!-- Secondary Text Colors -->
+            <Color x:Key="LightSecondaryTextColor">#666666</Color>
+            <Color x:Key="DarkSecondaryTextColor">#AAAAAA</Color>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <ScrollView>
+        <VerticalStackLayout Padding="20" Spacing="20">
+
+            <!-- Theme Toggle Section -->
+            <Border StrokeShape="RoundRectangle 10"
+                    Padding="15">
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Theme Toggle"
+                           FontSize="18"
+                           FontAttributes="Bold"
+                           TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor}, Dark={StaticResource DarkPrimaryTextColor}}" />
+                    <Label Text="Toggle between Light and Dark themes to see AppThemeBinding in action."
+                           TextColor="{AppThemeBinding Light={StaticResource LightSecondaryTextColor}, Dark={StaticResource DarkSecondaryTextColor}}" />
+                    <Button Text="Toggle Theme"
+                            Clicked="OnToggleThemeClicked"
+                            HorizontalOptions="Start" />
+                    <Label Text="{Binding CurrentTheme, StringFormat='Current Theme: {0}'}"
+                           TextColor="{AppThemeBinding Light={StaticResource LightSecondaryTextColor}, Dark={StaticResource DarkSecondaryTextColor}}" />
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- AppThemeBinding Examples Section -->
+            <Border StrokeShape="RoundRectangle 10"
+                    BackgroundColor="{AppThemeBinding Light={StaticResource LightSecondaryBackgroundColor}, Dark={StaticResource DarkSecondaryBackgroundColor}}"
+                    Padding="15">
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="AppThemeBinding Examples"
+                           FontSize="18"
+                           FontAttributes="Bold"
+                           TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor}, Dark={StaticResource DarkPrimaryTextColor}}" />
+
+                    <!-- Text Color Example -->
+                    <Label Text="This label uses AppThemeBinding for TextColor"
+                           TextColor="{AppThemeBinding Light=DarkSlateGray, Dark=LightGray}" />
+
+                    <!-- Background Color Example -->
+                    <Border StrokeShape="RoundRectangle 5"
+                            BackgroundColor="{AppThemeBinding Light=LightBlue, Dark=DarkBlue}"
+                            Padding="10">
+                        <Label Text="This border uses AppThemeBinding for BackgroundColor"
+                               TextColor="{AppThemeBinding Light=Black, Dark=White}" />
+                    </Border>
+
+                    <!-- Multiple Properties Example -->
+                    <Border Stroke="{AppThemeBinding Light=DarkGray, Dark=LightGray}"
+                            StrokeShape="RoundRectangle 5"
+                            BackgroundColor="{AppThemeBinding Light=WhiteSmoke, Dark=#2d2d2d}"
+                            Padding="10">
+                        <Label Text="Border with themed Stroke and BackgroundColor"
+                               TextColor="{AppThemeBinding Light=Black, Dark=White}" />
+                    </Border>
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Color Palette Section -->
+            <Border StrokeShape="RoundRectangle 10"
+                    BackgroundColor="{AppThemeBinding Light={StaticResource LightSecondaryBackgroundColor}, Dark={StaticResource DarkSecondaryBackgroundColor}}"
+                    Padding="15">
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Theme-Aware Color Palette"
+                           FontSize="18"
+                           FontAttributes="Bold"
+                           TextColor="{AppThemeBinding Light={StaticResource LightPrimaryTextColor}, Dark={StaticResource DarkPrimaryTextColor}}" />
+
+                    <Grid ColumnDefinitions="*,*,*" RowDefinitions="Auto,Auto" ColumnSpacing="10" RowSpacing="10">
+                        <BoxView Color="{AppThemeBinding Light=Coral, Dark=DarkRed}" HeightRequest="50" Grid.Row="0" Grid.Column="0" />
+                        <BoxView Color="{AppThemeBinding Light=LightGreen, Dark=DarkGreen}" HeightRequest="50" Grid.Row="0" Grid.Column="1" />
+                        <BoxView Color="{AppThemeBinding Light=LightSkyBlue, Dark=DarkBlue}" HeightRequest="50" Grid.Row="0" Grid.Column="2" />
+                        <Label Text="Red" HorizontalOptions="Center" Grid.Row="1" Grid.Column="0" TextColor="{AppThemeBinding Light={StaticResource LightSecondaryTextColor}, Dark={StaticResource DarkSecondaryTextColor}}" />
+                        <Label Text="Green" HorizontalOptions="Center" Grid.Row="1" Grid.Column="1" TextColor="{AppThemeBinding Light={StaticResource LightSecondaryTextColor}, Dark={StaticResource DarkSecondaryTextColor}}" />
+                        <Label Text="Blue" HorizontalOptions="Center" Grid.Row="1" Grid.Column="2" TextColor="{AppThemeBinding Light={StaticResource LightSecondaryTextColor}, Dark={StaticResource DarkSecondaryTextColor}}" />
+                    </Grid>
+                </VerticalStackLayout>
+            </Border>
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/samples/ControlGallery/ControlGallery/Pages/ThemePage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/ThemePage.xaml.cs
@@ -1,0 +1,70 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls;
+
+namespace ControlGallery.Pages;
+
+public partial class ThemePage : ContentPage, INotifyPropertyChanged
+{
+    private string _currentTheme = "Unknown";
+
+    public ThemePage()
+    {
+        InitializeComponent();
+        BindingContext = this;
+        UpdateCurrentTheme();
+    }
+
+    public string CurrentTheme
+    {
+        get => _currentTheme;
+        set
+        {
+            if (_currentTheme != value)
+            {
+                _currentTheme = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    private void OnToggleThemeClicked(object? sender, EventArgs e)
+    {
+        var app = Application.Current;
+        if (app == null)
+            return;
+
+        // Toggle between Light and Dark themes using MAUI's UserAppTheme
+        app.UserAppTheme = app.UserAppTheme == AppTheme.Light
+            ? AppTheme.Dark
+            : AppTheme.Light;
+
+        UpdateCurrentTheme();
+    }
+
+    private void UpdateCurrentTheme()
+    {
+        var app = Application.Current;
+        if (app == null)
+        {
+            CurrentTheme = "Unknown";
+            return;
+        }
+
+        CurrentTheme = app.UserAppTheme switch
+        {
+            AppTheme.Light => "Light",
+            AppTheme.Dark => "Dark",
+            _ => AppInfo.Current.RequestedTheme.ToString()
+        };
+    }
+
+    public new event PropertyChangedEventHandler? PropertyChanged;
+
+    protected override void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/Avalonia.Controls.Maui/Handlers/ApplicationHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ApplicationHandler.cs
@@ -1,7 +1,9 @@
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Styling;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui;
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 
@@ -13,6 +15,7 @@ public partial class ApplicationHandler : ElementHandler<IApplication, Applicati
 
     public static IPropertyMapper<IApplication, ApplicationHandler> Mapper = new PropertyMapper<IApplication, ApplicationHandler>(ElementMapper)
     {
+        [nameof(IApplication.UserAppTheme)] = MapUserAppTheme,
     };
 
     public static CommandMapper<IApplication, ApplicationHandler> CommandMapper = new(ElementCommandMapper)
@@ -111,6 +114,34 @@ public partial class ApplicationHandler : ElementHandler<IApplication, Applicati
             if (window.Handler?.PlatformView is global::Avalonia.Controls.Window avaloniaWindow)
             {
                 avaloniaWindow.Activate();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Maps the MAUI UserAppTheme property to Avalonia's RequestedThemeVariant.
+    /// This enables setting the Avalonia theme when the MAUI application theme is changed.
+    /// </summary>
+    /// <param name="handler">The associated handler.</param>
+    /// <param name="application">The associated <see cref="IApplication"/> instance.</param>
+    public static void MapUserAppTheme(ApplicationHandler handler, IApplication application)
+    {
+        if (handler.PlatformView is Application avaloniaApp)
+        {
+            var userTheme = application.UserAppTheme;
+
+            ThemeVariant? requestedTheme = userTheme switch
+            {
+                AppTheme.Dark => ThemeVariant.Dark,
+                AppTheme.Light => ThemeVariant.Light,
+                AppTheme.Unspecified => null, // Use system theme
+                _ => null
+            };
+
+            // Only update if different to avoid circular updates
+            if (avaloniaApp.RequestedThemeVariant != requestedTheme)
+            {
+                avaloniaApp.RequestedThemeVariant = requestedTheme;
             }
         }
     }

--- a/src/Avalonia.Controls.Maui/Handlers/CheckBoxHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/CheckBoxHandler.cs
@@ -78,5 +78,5 @@ public class CheckBoxHandler : ViewHandler<ICheckBox, PlatformView>, ICheckBoxHa
         ((PlatformView)handler.PlatformView)?.UpdateForeground(checkBox);
 
     public static void MapColor(ICheckBoxHandler handler, ICheckBox checkBox) =>
-        ((PlatformView)handler.PlatformView)?.UpdateColor(checkBox);
+        handler.UpdateValue(nameof(ICheckBox.Foreground));
 }

--- a/src/Avalonia.Controls.Maui/Handlers/PageHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/PageHandler.cs
@@ -32,8 +32,16 @@ public partial class PageHandler : ContentViewHandler, IPageHandler
     public static void MapBackground(IPageHandler handler, IContentView page)
     {
         var platformView = (AvaloniaPanel)handler.PlatformView;
-        if (platformView == null || page?.Background == null)
+        if (platformView == null)
             return;
-        platformView.Background = page.Background.ToPlatform();
+
+        if (page?.Background != null)
+        {
+            platformView.Background = page.Background.ToPlatform();
+        }
+        else
+        {
+            platformView.ClearValue(AvaloniaPanel.BackgroundProperty);
+        }
     }
 }

--- a/src/Avalonia.Controls.Maui/Handlers/ViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ViewHandler.cs
@@ -26,6 +26,7 @@ public abstract partial class ViewHandler : ElementHandler, IViewHandler
             [nameof(IView.Shadow)] = MapShadow,
             [nameof(IView.Visibility)] = MapVisibility,
             [nameof(IView.Background)] = MapBackground,
+            ["BackgroundColor"] = MapBackgroundColor,
             [nameof(IView.FlowDirection)] = MapFlowDirection,
             [nameof(IView.Width)] = MapWidth,
             [nameof(IView.Height)] = MapHeight,
@@ -312,6 +313,18 @@ public abstract partial class ViewHandler : ElementHandler, IViewHandler
         {
             platformView.UpdateBackground(view);
         }
+    }
+
+    /// <summary>
+    /// Maps the BackgroundColor property to trigger a Background update.
+    /// This mirrors MAUI's VisualElement.MapBackgroundColor behavior where BackgroundColor
+    /// changes are forwarded to the Background property mapper.
+    /// </summary>
+    /// <param name="handler">The associated handler.</param>
+    /// <param name="view">The associated <see cref="IView"/> instance.</param>
+    public static void MapBackgroundColor(IViewHandler handler, IView view)
+    {
+        handler.UpdateValue(nameof(IView.Background));
     }
 
     /// <summary>

--- a/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaApplication.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaApplication.cs
@@ -1,14 +1,14 @@
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Maui.LifecycleEvents;
+using Avalonia.Styling;
 using Microsoft.Maui.LifecycleEvents;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
 using Microsoft.Maui.Hosting;
 using Microsoft.Maui.Platform;
 using System;
-using System.Collections.Generic;
-using System.Text;
+using Microsoft.Maui.ApplicationModel;
 
 namespace Avalonia.Controls.Maui.Platform;
 
@@ -50,6 +50,9 @@ public abstract class MauiAvaloniaApplication : Application, IPlatformApplicatio
         Services.InvokeLifecycleEvents<AvaloniaLifecycle.OnLaunching>(del => del(this, args));
 
         Application = Services.GetRequiredService<IApplication>();
+
+        // Subscribe to Avalonia theme changes to notify MAUI's AppThemeBinding system
+        ActualThemeVariantChanged += OnActualThemeVariantChanged;
 
         // Connect the MAUI Application to its handler
         this.SetApplicationHandler(Application, ApplicationContext);
@@ -121,5 +124,14 @@ public abstract class MauiAvaloniaApplication : Application, IPlatformApplicatio
         scopedContext.AddSpecific(avaloniaApplication);
 
         return scopedContext;
+    }
+
+    /// <summary>
+    /// Handles Avalonia's theme variant changes and notifies MAUI's theme system.
+    /// This enables AppThemeBinding to update when the theme changes.
+    /// </summary>
+    private void OnActualThemeVariantChanged(object? sender, EventArgs e)
+    {
+        Application?.ThemeChanged();
     }
 }

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/ApplicationHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/ApplicationHandlerTests.cs
@@ -1,8 +1,10 @@
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Maui.Tests.Stubs;
 using Avalonia.Headless.XUnit;
+using Avalonia.Styling;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Hosting;
 using NSubstitute;
@@ -225,5 +227,139 @@ public class ApplicationHandlerTests : HandlerTestBase
         {
             MauiApplicationHandler.MapOpenWindow(handler, application, windowStub);
         });
+    }
+
+    [AvaloniaFact(DisplayName = "MapUserAppTheme Sets Avalonia Dark Theme")]
+    public async Task MapUserAppThemeSetsAvaloniaDarkTheme()
+    {
+        var application = new ApplicationStub
+        {
+            UserAppTheme = AppTheme.Dark
+        };
+
+        EnsureHandlerCreated(builder =>
+        {
+            builder.Services.AddSingleton<Application>(App.Current!);
+            builder.ConfigureMauiHandlers(handlers =>
+            {
+                handlers.AddHandler<IApplication, MauiApplicationHandler>();
+            });
+        });
+
+        var handler = await CreateHandlerAsync<MauiApplicationHandler>(application);
+
+        await InvokeOnMainThreadAsync(() =>
+        {
+            MauiApplicationHandler.MapUserAppTheme(handler, application);
+        });
+
+        var avaloniaApp = handler.PlatformView as Application;
+        Assert.NotNull(avaloniaApp);
+        Assert.Equal(ThemeVariant.Dark, avaloniaApp.RequestedThemeVariant);
+    }
+
+    [AvaloniaFact(DisplayName = "MapUserAppTheme Sets Avalonia Light Theme")]
+    public async Task MapUserAppThemeSetsAvaloniaLightTheme()
+    {
+        var application = new ApplicationStub
+        {
+            UserAppTheme = AppTheme.Light
+        };
+
+        EnsureHandlerCreated(builder =>
+        {
+            builder.Services.AddSingleton<Application>(App.Current!);
+            builder.ConfigureMauiHandlers(handlers =>
+            {
+                handlers.AddHandler<IApplication, MauiApplicationHandler>();
+            });
+        });
+
+        var handler = await CreateHandlerAsync<MauiApplicationHandler>(application);
+
+        await InvokeOnMainThreadAsync(() =>
+        {
+            MauiApplicationHandler.MapUserAppTheme(handler, application);
+        });
+
+        var avaloniaApp = handler.PlatformView as Application;
+        Assert.NotNull(avaloniaApp);
+        Assert.Equal(ThemeVariant.Light, avaloniaApp.RequestedThemeVariant);
+    }
+
+    [AvaloniaFact(DisplayName = "MapUserAppTheme Sets Null For Unspecified Theme")]
+    public async Task MapUserAppThemeSetsNullForUnspecifiedTheme()
+    {
+        var application = new ApplicationStub
+        {
+            UserAppTheme = AppTheme.Unspecified
+        };
+
+        EnsureHandlerCreated(builder =>
+        {
+            builder.Services.AddSingleton<Application>(App.Current!);
+            builder.ConfigureMauiHandlers(handlers =>
+            {
+                handlers.AddHandler<IApplication, MauiApplicationHandler>();
+            });
+        });
+
+        var handler = await CreateHandlerAsync<MauiApplicationHandler>(application);
+
+        await InvokeOnMainThreadAsync(() =>
+        {
+            MauiApplicationHandler.MapUserAppTheme(handler, application);
+        });
+
+        var avaloniaApp = handler.PlatformView as Application;
+        Assert.NotNull(avaloniaApp);
+        Assert.Null(avaloniaApp.RequestedThemeVariant);
+    }
+
+    [AvaloniaFact(DisplayName = "MapUserAppTheme Updates Theme When Changed")]
+    public async Task MapUserAppThemeUpdatesThemeWhenChanged()
+    {
+        var application = new ApplicationStub
+        {
+            UserAppTheme = AppTheme.Light
+        };
+
+        EnsureHandlerCreated(builder =>
+        {
+            builder.Services.AddSingleton<Application>(App.Current!);
+            builder.ConfigureMauiHandlers(handlers =>
+            {
+                handlers.AddHandler<IApplication, MauiApplicationHandler>();
+            });
+        });
+
+        var handler = await CreateHandlerAsync<MauiApplicationHandler>(application);
+
+        // First set to Light
+        await InvokeOnMainThreadAsync(() =>
+        {
+            MauiApplicationHandler.MapUserAppTheme(handler, application);
+        });
+
+        var avaloniaApp = handler.PlatformView as Application;
+        Assert.NotNull(avaloniaApp);
+        Assert.Equal(ThemeVariant.Light, avaloniaApp.RequestedThemeVariant);
+
+        // Now change to Dark
+        application.UserAppTheme = AppTheme.Dark;
+
+        await InvokeOnMainThreadAsync(() =>
+        {
+            MauiApplicationHandler.MapUserAppTheme(handler, application);
+        });
+
+        Assert.Equal(ThemeVariant.Dark, avaloniaApp.RequestedThemeVariant);
+    }
+
+    [AvaloniaFact(DisplayName = "Mapper Contains UserAppTheme Key")]
+    public void MapperContainsUserAppThemeKey()
+    {
+        // Verify that UserAppTheme is registered in the mapper
+        Assert.Contains(nameof(IApplication.UserAppTheme), MauiApplicationHandler.Mapper.GetKeys());
     }
 }

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/BoxViewHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/BoxViewHandlerTests.cs
@@ -383,7 +383,66 @@ public partial class BoxViewHandlerTests : HandlerTestBase<MauiBoxViewHandler, B
         Assert.NotNull(handler.PlatformView);
         Assert.IsType<Border>(handler.PlatformView);
     }
-    
+
+    [AvaloniaFact(DisplayName = "BackgroundColor Change Triggers Background Update")]
+    public async Task BackgroundColorChangeTriggerBackgroundUpdate()
+    {
+        // This tests that MapBackgroundColor properly forwards to MapBackground
+        var boxView = new BoxViewStub
+        {
+            BackgroundColor = Colors.Green
+        };
+
+        var handler = await CreateHandlerAsync(boxView);
+
+        // Verify that setting BackgroundColor results in proper Background update
+        var border = handler.PlatformView as Border;
+        Assert.NotNull(border);
+
+        // BackgroundColor should have been mapped to Background
+        if (border.Background is Media.SolidColorBrush brush)
+        {
+            var nativeColor = Color.FromRgba(brush.Color.R, brush.Color.G, brush.Color.B, brush.Color.A);
+            ColorComparisonHelpers.AssertColorsAreEqual(Colors.Green, nativeColor);
+        }
+    }
+
+    [AvaloniaFact(DisplayName = "BackgroundColor Update Via Handler Works")]
+    public async Task BackgroundColorUpdateViaHandlerWorks()
+    {
+        // This tests the MapBackgroundColor behavior when UpdateValue is called
+        var boxView = new BoxViewStub
+        {
+            BackgroundColor = Colors.Blue
+        };
+
+        var handler = await CreateHandlerAsync(boxView);
+
+        // Change BackgroundColor and call UpdateValue with "BackgroundColor"
+        await InvokeOnMainThreadAsync(() =>
+        {
+            boxView.BackgroundColor = Colors.Red;
+            handler.UpdateValue("BackgroundColor");
+        });
+
+        var border = handler.PlatformView as Border;
+        Assert.NotNull(border);
+
+        // Verify that BackgroundColor change was forwarded to Background
+        if (border.Background is Media.SolidColorBrush brush)
+        {
+            var nativeColor = Color.FromRgba(brush.Color.R, brush.Color.G, brush.Color.B, brush.Color.A);
+            ColorComparisonHelpers.AssertColorsAreEqual(Colors.Red, nativeColor);
+        }
+    }
+
+    [AvaloniaFact(DisplayName = "ViewMapper Contains BackgroundColor Key")]
+    public void ViewMapperContainsBackgroundColorKey()
+    {
+        // Verify that BackgroundColor is registered in the ViewMapper
+        Assert.Contains("BackgroundColor", Avalonia.Controls.Maui.Handlers.ViewHandler.ViewMapper.GetKeys());
+    }
+
     Color? GetPlatformColor(MauiBoxViewHandler handler)
     {
         var border = handler.PlatformView as Border;

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/PageHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/PageHandlerTests.cs
@@ -1,0 +1,213 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Controls.Maui.Tests.Stubs;
+using Avalonia.Controls.Maui.Tests.TestUtilities;
+using Microsoft.Maui;
+using Microsoft.Maui.Graphics;
+using AvaloniaPanel = Avalonia.Controls.Panel;
+using MauiPageHandler = Avalonia.Controls.Maui.Handlers.PageHandler;
+
+namespace Avalonia.Controls.Maui.Tests.Handlers;
+
+public partial class PageHandlerTests : HandlerTestBase<MauiPageHandler, PageStub>
+{
+    [AvaloniaFact(DisplayName = "Background Initializes Correctly")]
+    public async Task BackgroundInitializesCorrectly()
+    {
+        var color = Colors.Blue;
+        var page = new PageStub
+        {
+            Background = new SolidPaint(color)
+        };
+
+        var handler = await CreateHandlerAsync(page);
+        var platformColor = GetPlatformBackgroundColor(handler);
+
+        Assert.NotNull(platformColor);
+        ColorComparisonHelpers.AssertColorsAreEqual(color, platformColor);
+    }
+
+    [AvaloniaFact(DisplayName = "Background Updates Correctly")]
+    public async Task BackgroundUpdatesCorrectly()
+    {
+        var page = new PageStub
+        {
+            Background = new SolidPaint(Colors.Blue)
+        };
+
+        var handler = await CreateHandlerAsync(page);
+
+        await InvokeOnMainThreadAsync(() =>
+        {
+            page.Background = new SolidPaint(Colors.Red);
+            handler.UpdateValue(nameof(IContentView.Background));
+        });
+
+        var platformColor = GetPlatformBackgroundColor(handler);
+
+        Assert.NotNull(platformColor);
+        ColorComparisonHelpers.AssertColorsAreEqual(Colors.Red, platformColor);
+    }
+
+    [AvaloniaFact(DisplayName = "Null Background Clears Value")]
+    public async Task NullBackgroundClearsValue()
+    {
+        var page = new PageStub
+        {
+            Background = new SolidPaint(Colors.Green)
+        };
+
+        var handler = await CreateHandlerAsync(page);
+
+        // Verify initial background is set
+        var initialColor = GetPlatformBackgroundColor(handler);
+        Assert.NotNull(initialColor);
+        ColorComparisonHelpers.AssertColorsAreEqual(Colors.Green, initialColor);
+
+        // Set background to null
+        await InvokeOnMainThreadAsync(() =>
+        {
+            page.Background = null;
+            handler.UpdateValue(nameof(IContentView.Background));
+        });
+
+        // Verify background is cleared
+        var panel = handler.PlatformView as AvaloniaPanel;
+        Assert.NotNull(panel);
+        Assert.Null(panel.Background);
+    }
+
+    [AvaloniaFact(DisplayName = "Null Background Does Not Crash")]
+    public async Task NullBackgroundDoesNotCrash()
+    {
+        var page = new PageStub
+        {
+            Background = null
+        };
+
+        // Should not throw
+        await CreateHandlerAsync(page);
+    }
+
+    [AvaloniaFact(DisplayName = "Background Changes From Value To Null")]
+    public async Task BackgroundChangesFromValueToNull()
+    {
+        var page = new PageStub
+        {
+            Background = new SolidPaint(Colors.Purple)
+        };
+
+        var handler = await CreateHandlerAsync(page);
+
+        // Verify initial background
+        var panel = handler.PlatformView as AvaloniaPanel;
+        Assert.NotNull(panel);
+        Assert.NotNull(panel.Background);
+
+        // Change to null
+        await InvokeOnMainThreadAsync(() =>
+        {
+            page.Background = null;
+            MauiPageHandler.MapBackground(handler, page);
+        });
+
+        // Background should be cleared (null)
+        Assert.Null(panel.Background);
+    }
+
+    [AvaloniaFact(DisplayName = "Background Changes From Null To Value")]
+    public async Task BackgroundChangesFromNullToValue()
+    {
+        var page = new PageStub
+        {
+            Background = null
+        };
+
+        var handler = await CreateHandlerAsync(page);
+
+        var panel = handler.PlatformView as AvaloniaPanel;
+        Assert.NotNull(panel);
+
+        // Initially null
+        Assert.Null(panel.Background);
+
+        // Set to a color
+        await InvokeOnMainThreadAsync(() =>
+        {
+            page.Background = new SolidPaint(Colors.Orange);
+            MauiPageHandler.MapBackground(handler, page);
+        });
+
+        // Background should now be set
+        Assert.NotNull(panel.Background);
+        var platformColor = GetPlatformBackgroundColor(handler);
+        Assert.NotNull(platformColor);
+        ColorComparisonHelpers.AssertColorsAreEqual(Colors.Orange, platformColor);
+    }
+
+    [AvaloniaTheory(DisplayName = "Various Colors Work Correctly")]
+    [InlineData(255, 0, 0)]      // Red
+    [InlineData(0, 255, 0)]      // Green
+    [InlineData(0, 0, 255)]      // Blue
+    [InlineData(255, 255, 0)]    // Yellow
+    [InlineData(255, 0, 255)]    // Magenta
+    [InlineData(0, 255, 255)]    // Cyan
+    public async Task VariousColorsWorkCorrectly(byte r, byte g, byte b)
+    {
+        var color = Color.FromRgb(r, g, b);
+        var page = new PageStub
+        {
+            Background = new SolidPaint(color)
+        };
+
+        var handler = await CreateHandlerAsync(page);
+        var platformColor = GetPlatformBackgroundColor(handler);
+
+        Assert.NotNull(platformColor);
+        ColorComparisonHelpers.AssertColorsAreEqual(color, platformColor);
+    }
+
+    [AvaloniaFact(DisplayName = "Transparent Background Works")]
+    public async Task TransparentBackgroundWorks()
+    {
+        var page = new PageStub
+        {
+            Background = new SolidPaint(Colors.Transparent)
+        };
+
+        var handler = await CreateHandlerAsync(page);
+        var platformColor = GetPlatformBackgroundColor(handler);
+
+        Assert.NotNull(platformColor);
+        Assert.Equal(0, platformColor.Alpha, 0.01f);
+    }
+
+    [AvaloniaTheory(DisplayName = "Semi-Transparent Backgrounds Work")]
+    [InlineData(128)] // 50% alpha
+    [InlineData(64)]  // 25% alpha
+    [InlineData(192)] // 75% alpha
+    public async Task SemiTransparentBackgroundsWork(byte alpha)
+    {
+        var color = Color.FromRgba((byte)255, (byte)0, (byte)0, alpha);
+        var page = new PageStub
+        {
+            Background = new SolidPaint(color)
+        };
+
+        var handler = await CreateHandlerAsync(page);
+        var platformColor = GetPlatformBackgroundColor(handler);
+
+        Assert.NotNull(platformColor);
+        Assert.Equal(alpha / 255f, platformColor.Alpha, 0.02f);
+    }
+
+    Color? GetPlatformBackgroundColor(MauiPageHandler handler)
+    {
+        var panel = handler.PlatformView as AvaloniaPanel;
+        if (panel?.Background is Media.SolidColorBrush brush)
+        {
+            var color = brush.Color;
+            return Color.FromRgba(color.R, color.G, color.B, color.A);
+        }
+        return null;
+    }
+}

--- a/tests/Avalonia.Controls.Maui.Tests/Stubs/PageStub.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Stubs/PageStub.cs
@@ -1,0 +1,28 @@
+using Microsoft.Maui;
+using MauiGraphics = Microsoft.Maui.Graphics;
+
+namespace Avalonia.Controls.Maui.Tests.Stubs;
+
+public class PageStub : StubBase, IContentView, IPadding
+{
+    object? IContentView.Content => Content;
+
+    public IView? Content { get; set; }
+
+    public IView? PresentedContent => Content;
+
+    public Microsoft.Maui.Thickness Padding { get; set; }
+
+    public MauiGraphics.Size CrossPlatformMeasure(double widthConstraint, double heightConstraint)
+    {
+        // Return a simple size to avoid infinite recursion
+        return new MauiGraphics.Size(
+            double.IsNaN(widthConstraint) || double.IsInfinity(widthConstraint) ? 100 : widthConstraint,
+            double.IsNaN(heightConstraint) || double.IsInfinity(heightConstraint) ? 100 : heightConstraint);
+    }
+
+    public MauiGraphics.Size CrossPlatformArrange(MauiGraphics.Rect bounds)
+    {
+        return new MauiGraphics.Size(bounds.Width, bounds.Height);
+    }
+}


### PR DESCRIPTION
Fixes #9 

This should sync Avalonia and MAUIs themes to match when they are both set at the OS level and at the UserAppTheme level.

The biggest issue was a VisualElement.MapBackgroundColor not being wrapped, which broke most of the background colors not working except on first load. 

https://github.com/user-attachments/assets/fcc5c31d-6d60-44bb-9aff-72874de29bed

