### PR TITLE
Fix ScrollView Sizing, Default Scrolling

### DIFF
--- a/src/Avalonia.Controls.Maui/Handlers/ScrollViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ScrollViewHandler.cs
@@ -80,7 +80,25 @@ public partial class ScrollViewHandler : ViewHandler<IScrollView, ScrollViewer>,
         if (platformScrollView == null)
             return;
 
-        // TODO: Avalonia ScrollViewer does not have an Orientation property
+        switch (scrollView.Orientation)
+        {
+            case ScrollOrientation.Horizontal:
+                platformScrollView.HorizontalScrollBarVisibility = scrollView.HorizontalScrollBarVisibility.ToAvaloniaScrollBarVisibility();
+                platformScrollView.VerticalScrollBarVisibility = Primitives.ScrollBarVisibility.Disabled;
+                break;
+            case ScrollOrientation.Vertical:
+                platformScrollView.HorizontalScrollBarVisibility = Primitives.ScrollBarVisibility.Disabled;
+                platformScrollView.VerticalScrollBarVisibility = scrollView.VerticalScrollBarVisibility.ToAvaloniaScrollBarVisibility();
+                break;
+            case ScrollOrientation.Both:
+                platformScrollView.HorizontalScrollBarVisibility = scrollView.HorizontalScrollBarVisibility.ToAvaloniaScrollBarVisibility();
+                platformScrollView.VerticalScrollBarVisibility = scrollView.VerticalScrollBarVisibility.ToAvaloniaScrollBarVisibility();
+                break;
+            case ScrollOrientation.Neither:
+                platformScrollView.HorizontalScrollBarVisibility = Primitives.ScrollBarVisibility.Disabled;
+                platformScrollView.VerticalScrollBarVisibility = Primitives.ScrollBarVisibility.Disabled;
+                break;
+        }
     }
 
     public static void MapRequestScrollTo(IScrollViewHandler handler, IScrollView scrollView, object? args)

--- a/src/Avalonia.Controls.Maui/Handlers/ViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ViewHandler.cs
@@ -168,6 +168,7 @@ public abstract partial class ViewHandler : ElementHandler, IViewHandler
     {
         if (PlatformView is null)
             return;
+        PlatformView.Measure(new global::Avalonia.Size(frame.Width, frame.Height));
         PlatformView.Arrange(new global::Avalonia.Rect(frame.X, frame.Y, frame.Width, frame.Height));
     }
 


### PR DESCRIPTION
Avalonia doesn't have an orientation setting for its ScrollViewer, but it _does_ have other settings for setting which ones are shown, which can dictate how it's rendered. So these can be used to get the behavior right for what is shown. Also, the default in MAUI is for a ScrollView to be vertical, so now this should be respected.

Also, as far as I can tell, the size of the view needs to be measured before being arranged for it to be properly laid out when the view is resized so the scrollview doesn't stay static and add or remove width/height to the inner contents. 

Before:
<img width="1455" height="856" alt="スクリーンショット 2025-11-26 19 17 06" src="https://github.com/user-attachments/assets/efaa8eb2-80a6-45c4-a0c3-9c814c30ccbf" />

After:
<img width="1552" height="954" alt="スクリーンショット 2025-11-26 19 17 38" src="https://github.com/user-attachments/assets/b3dee59d-0665-4985-ab78-4d5332b980b4" />
