### PR TITLE
Bump to net10.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,10 +6,10 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build_sandbox",
-            "program": "${workspaceFolder}/samples/SandboxApp/bin/Debug/net9.0/SandboxApp.dll",
+            "program": "${workspaceFolder}/samples/SandboxApp/bin/Debug/net10.0/SandboxApp.dll",
             "args": [ 
             ],
-            "cwd": "${workspaceFolder}/samples/SandboxApp/bin/Debug/net9.0",
+            "cwd": "${workspaceFolder}/samples/SandboxApp/bin/Debug/net10.0",
             "console": "internalConsole",
             "stopAtEntry": false
         },
@@ -18,10 +18,10 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build_controlgallery_desktop",
-            "program": "${workspaceFolder}/samples/ControlGallery/ControlGallery.Desktop/bin/Debug/net9.0/ControlGallery.Desktop.dll",
+            "program": "${workspaceFolder}/samples/ControlGallery/ControlGallery.Desktop/bin/Debug/net10.0/ControlGallery.Desktop.dll",
             "args": [ 
             ],
-            "cwd": "${workspaceFolder}/samples/ControlGallery/ControlGallery.Desktop/bin/Debug/net9.0",
+            "cwd": "${workspaceFolder}/samples/ControlGallery/ControlGallery.Desktop/bin/Debug/net10.0",
             "console": "internalConsole",
             "stopAtEntry": false
         },

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <Version Condition="'$(Version)' == ''">12.0.0</Version>
         <IsPackable>false</IsPackable>
         <AvaloniaVersion Condition="'$(AvaloniaVersion)' == ''">12.0.999-cibuild0060140-alpha</AvaloniaVersion>
-        <DotNetTfm Condition="'$(DotNetTfm)' == ''">net9.0</DotNetTfm>
+        <DotNetTfm Condition="'$(DotNetTfm)' == ''">net10.0</DotNetTfm>
         <MauiSrcDirectory>$(MSBuildThisFileDirectory)/src/</MauiSrcDirectory>
         <BuildDirectory>$(MSBuildThisFileDirectory)/build/</BuildDirectory>
         <DebugType>portable</DebugType>
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(DotNetTfm)' == 'net10.0'">
-        <MauiVersion>10.0.10</MauiVersion>
+        <MauiVersion>10.0.20-ci.main.25602.3</MauiVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(DotNetTfm)' == 'net9.0'">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
         <!-- <AvaloniaVersion>9999.0.0-localbuild</AvaloniaVersion> -->
         <Version Condition="'$(Version)' == ''">12.0.0</Version>
         <IsPackable>false</IsPackable>
-        <AvaloniaVersion Condition="'$(AvaloniaVersion)' == ''">12.0.999-cibuild0060140-alpha</AvaloniaVersion>
+        <AvaloniaVersion Condition="'$(AvaloniaVersion)' == ''">12.0.999-cibuild0060555-alpha</AvaloniaVersion>
         <DotNetTfm Condition="'$(DotNetTfm)' == ''">net10.0</DotNetTfm>
         <MauiSrcDirectory>$(MSBuildThisFileDirectory)/src/</MauiSrcDirectory>
         <BuildDirectory>$(MSBuildThisFileDirectory)/build/</BuildDirectory>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -23,7 +23,7 @@
       <package pattern="Avalonia*" />
     </packageSource>
     <packageSource key="dotnet10">
-      <package pattern="Microsoft.*" />
+      <package pattern="Microsoft.Maui.*" />
     </packageSource>
   </packageSourceMapping>
 </configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,7 +4,10 @@
   <packageSources>
     <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="avalonia-nightly" value="https://nuget-feed-nightly.avaloniaui.net/v3/index.json" protocolVersion="3" />
+    <add key="avalonia-nightly" value="https://nuget-feed-nightly.avaloniaui.net/v3/index.json"
+      protocolVersion="3" />
+    <add key="dotnet10"
+      value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
   </packageSources>
 
   <fallbackPackageFolders>
@@ -18,6 +21,9 @@
     </packageSource>
     <packageSource key="avalonia-nightly">
       <package pattern="Avalonia*" />
+    </packageSource>
+    <packageSource key="dotnet10">
+      <package pattern="Microsoft.*" />
     </packageSource>
   </packageSourceMapping>
 </configuration>

--- a/src/Avalonia.Controls.Maui/Handlers/DatePickerHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/DatePickerHandler.cs
@@ -75,7 +75,14 @@ public class DatePickerHandler : ViewHandler<IDatePicker, AvaloniaDatePicker>, I
             return;
 
         var platformView = (AvaloniaDatePicker)handler.PlatformView;
-        platformView.SelectedDate = new DateTimeOffset(datePicker.Date);
+        if (datePicker.Date is null)
+        {
+            platformView.SelectedDate = null;
+        }
+        else
+        {
+            platformView.SelectedDate = new DateTimeOffset(datePicker.Date.Value);
+        }
     }
 
     public static void MapMinimumDate(IDatePickerHandler handler, IDatePicker datePicker)


### PR DESCRIPTION
Now that my MAUI fix has _finally_ landed in a nightly build, we can bump everything to .NET 10 and bring in newer Avalonia v12 versions. :tada: