### PR TITLE
Fix compiler warnings and samples from the Gallery

### DIFF
--- a/samples/ControlGallery/ControlGallery/Pages/ButtonPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/ButtonPage.xaml.cs
@@ -16,24 +16,24 @@ public partial class ButtonPage : ContentPage
         InitializeComponent();
         
         // Initialize simple command
-        MyCommand = new Command(() => 
+        MyCommand = new Command(async () =>
         {
-            DisplayAlert("Command", "Simple command executed!", "OK");
+            await DisplayAlertAsync("Command", "Simple command executed!", "OK");
             UpdateCommandResult("Simple command executed");
         });
-        
+
         // Initialize command with parameter
-        ParameterizedCommand = new Command<string>(async (parameter) => 
+        ParameterizedCommand = new Command<string>(async (parameter) =>
         {
-            await DisplayAlert("Parameterized Command", $"Executed with parameter: {parameter}", "OK");
+            await DisplayAlertAsync("Parameterized Command", $"Executed with parameter: {parameter}", "OK");
             UpdateCommandResult($"Parameterized command: {parameter}");
         });
-        
+
         // Initialize disabled command (canExecute returns false)
         DisabledCommand = new Command(
-            execute: () => 
+            execute: async () =>
             {
-                DisplayAlert("Disabled Command", "This should not execute!", "OK");
+                await DisplayAlertAsync("Disabled Command", "This should not execute!", "OK");
             },
             canExecute: () => false
         );

--- a/samples/ControlGallery/ControlGallery/Pages/GraphicsViewPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/GraphicsViewPage.xaml.cs
@@ -46,23 +46,17 @@ public partial class GraphicsViewPage : ContentPage
     private void OnStartInteraction(object sender, TouchEventArgs e)
     {
         var point = e.Touches.FirstOrDefault();
-        if (point != null)
-        {
-            InteractiveDrawable.StartDrawing(point);
-            InteractionLabel.Text = $"Start at: ({point.X:F1}, {point.Y:F1})";
-            interactiveGraphicsView.Invalidate();
-        }
+        InteractiveDrawable.StartDrawing(point);
+        InteractionLabel.Text = $"Start at: ({point.X:F1}, {point.Y:F1})";
+        interactiveGraphicsView.Invalidate();
     }
 
     private void OnDragInteraction(object sender, TouchEventArgs e)
     {
         var point = e.Touches.FirstOrDefault();
-        if (point != null)
-        {
-            InteractiveDrawable.AddPoint(point);
-            InteractionLabel.Text = $"Drawing at: ({point.X:F1}, {point.Y:F1})";
-            interactiveGraphicsView.Invalidate();
-        }
+        InteractiveDrawable.AddPoint(point);
+        InteractionLabel.Text = $"Drawing at: ({point.X:F1}, {point.Y:F1})";
+        interactiveGraphicsView.Invalidate();
     }
 
     private void OnEndInteraction(object sender, TouchEventArgs e)

--- a/samples/ControlGallery/ControlGallery/Pages/ImagePage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/ImagePage.xaml
@@ -3,6 +3,51 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="ControlGallery.Pages.ImagePage"
              Title="Image">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <!-- Image Background Colors -->
+            <Color x:Key="LightImageBackground">#F0F0F0</Color>
+            <Color x:Key="DarkImageBackground">#2a2a2a</Color>
+
+            <!-- Colored Image Backgrounds for Aspect Modes -->
+            <Color x:Key="LightGreenTint">#E8F5E9</Color>
+            <Color x:Key="DarkGreenTint">#1b3a1f</Color>
+
+            <Color x:Key="LightOrangeTint">#FFF3E0</Color>
+            <Color x:Key="DarkOrangeTint">#3d2a1a</Color>
+
+            <Color x:Key="LightBlueTint">#E3F2FD</Color>
+            <Color x:Key="DarkBlueTint">#1a2a3d</Color>
+
+            <Color x:Key="LightPurpleTint">#F3E5F5</Color>
+            <Color x:Key="DarkPurpleTint">#2d1a3d</Color>
+
+            <Color x:Key="LightPinkTint">#FCE4EC</Color>
+            <Color x:Key="DarkPinkTint">#3d1a2d</Color>
+
+            <Color x:Key="LightCyanTint">#E0F2F1</Color>
+            <Color x:Key="DarkCyanTint">#1a3d3a</Color>
+
+            <Color x:Key="LightYellowTint">#FFF9C4</Color>
+            <Color x:Key="DarkYellowTint">#3d3a1a</Color>
+
+            <Color x:Key="LightBlueTint2">#E1F5FE</Color>
+            <Color x:Key="DarkBlueTint2">#1a2d3d</Color>
+
+            <!-- Gallery Colors -->
+            <Color x:Key="LightRedTint">#FFEBEE</Color>
+            <Color x:Key="DarkRedTint">#3d1a1a</Color>
+
+            <Color x:Key="LightIndigoTint">#E8EAF6</Color>
+            <Color x:Key="DarkIndigoTint">#1a1a3d</Color>
+
+            <Color x:Key="LightCyanTint2">#E0F7FA</Color>
+            <Color x:Key="DarkCyanTint2">#1a3a3d</Color>
+
+            <Color x:Key="LightLimeTint">#F1F8E9</Color>
+            <Color x:Key="DarkLimeTint">#2a3d1a</Color>
+        </ResourceDictionary>
+    </ContentPage.Resources>
     <ScrollView>
         <VerticalStackLayout Padding="20"
                              Spacing="24">
@@ -28,7 +73,7 @@
                            Source="dotnet_bot.png"
                            Aspect="AspectFit"
                            HeightRequest="200"
-                           BackgroundColor="#F0F0F0" />
+                           BackgroundColor="{AppThemeBinding Light={StaticResource LightImageBackground}, Dark={StaticResource DarkImageBackground}}" />
                 </VerticalStackLayout>
             </Border>
 
@@ -48,7 +93,7 @@
                            Source="https://framerusercontent.com/images/9tXJ0X4yPgCHwR0ZXbMZekNnR18.png"
                            Aspect="AspectFit"
                            HeightRequest="200"
-                           BackgroundColor="#F0F0F0" />
+                           BackgroundColor="{AppThemeBinding Light={StaticResource LightImageBackground}, Dark={StaticResource DarkImageBackground}}" />
                     <Label x:Name="UriStatusLabel"
                            Text="Status: Loading..."
                            FontSize="12"
@@ -70,7 +115,7 @@
                     <Image Source="dotnet_bot.png"
                            Aspect="AspectFit"
                            HeightRequest="150"
-                           BackgroundColor="#E8F5E9" />
+                           BackgroundColor="{AppThemeBinding Light={StaticResource LightGreenTint}, Dark={StaticResource DarkGreenTint}}" />
 
                     <Label Text="AspectFill - Maintains aspect ratio, fills bounds"
                            FontSize="12"
@@ -78,7 +123,7 @@
                     <Image Source="dotnet_bot.png"
                            Aspect="AspectFill"
                            HeightRequest="150"
-                           BackgroundColor="#FFF3E0" />
+                           BackgroundColor="{AppThemeBinding Light={StaticResource LightOrangeTint}, Dark={StaticResource DarkOrangeTint}}" />
 
                     <Label Text="Fill - Stretches to fill bounds"
                            FontSize="12"
@@ -86,7 +131,7 @@
                     <Image Source="dotnet_bot.png"
                            Aspect="Fill"
                            HeightRequest="150"
-                           BackgroundColor="#E3F2FD" />
+                           BackgroundColor="{AppThemeBinding Light={StaticResource LightBlueTint}, Dark={StaticResource DarkBlueTint}}" />
 
                     <Label Text="Center - Centers without scaling"
                            FontSize="12"
@@ -94,7 +139,7 @@
                     <Image Source="dotnet_bot.png"
                            Aspect="Center"
                            HeightRequest="150"
-                           BackgroundColor="#F3E5F5" />
+                           BackgroundColor="{AppThemeBinding Light={StaticResource LightPurpleTint}, Dark={StaticResource DarkPurpleTint}}" />
                 </VerticalStackLayout>
             </Border>
 
@@ -107,25 +152,33 @@
                 <VerticalStackLayout Spacing="8">
                     <Label Text="Interactive Aspect Switcher"
                            FontAttributes="Bold" />
-                    <Picker x:Name="AspectPicker"
-                            Title="Select Aspect"
-                            SelectedIndexChanged="OnAspectChanged">
-                        <Picker.Items>
-                            <x:String>AspectFit</x:String>
-                            <x:String>AspectFill</x:String>
-                            <x:String>Fill</x:String>
-                            <x:String>Center</x:String>
-                        </Picker.Items>
-                    </Picker>
+                    <Label Text="Click buttons to change the aspect mode"
+                           FontSize="12"
+                           TextColor="Gray" />
+                    <HorizontalStackLayout Spacing="8" HorizontalOptions="Center">
+                        <Button Text="AspectFit"
+                                Clicked="OnAspectButtonClicked"
+                                CommandParameter="AspectFit" />
+                        <Button Text="AspectFill"
+                                Clicked="OnAspectButtonClicked"
+                                CommandParameter="AspectFill" />
+                        <Button Text="Fill"
+                                Clicked="OnAspectButtonClicked"
+                                CommandParameter="Fill" />
+                        <Button Text="Center"
+                                Clicked="OnAspectButtonClicked"
+                                CommandParameter="Center" />
+                    </HorizontalStackLayout>
                     <Image x:Name="InteractiveImage"
                            Source="dotnet_bot.png"
                            Aspect="AspectFit"
                            HeightRequest="200"
-                           BackgroundColor="#FCE4EC" />
+                           BackgroundColor="{AppThemeBinding Light={StaticResource LightPinkTint}, Dark={StaticResource DarkPinkTint}}" />
                     <Label x:Name="AspectStatusLabel"
                            Text="Current Aspect: AspectFit"
                            FontAttributes="Italic"
-                           FontSize="12" />
+                           FontSize="12"
+                           HorizontalOptions="Center" />
                 </VerticalStackLayout>
             </Border>
 
@@ -150,7 +203,7 @@
                            Source="dotnet_bot.png"
                            Aspect="AspectFit"
                            HeightRequest="150"
-                           BackgroundColor="#E0F2F1" />
+                           BackgroundColor="{AppThemeBinding Light={StaticResource LightCyanTint}, Dark={StaticResource DarkCyanTint}}" />
                 </VerticalStackLayout>
             </Border>
 
@@ -169,7 +222,7 @@
                     <Image x:Name="DynamicImage"
                            Aspect="AspectFit"
                            HeightRequest="200"
-                           BackgroundColor="#FFF9C4" />
+                           BackgroundColor="{AppThemeBinding Light={StaticResource LightYellowTint}, Dark={StaticResource DarkYellowTint}}" />
                     <Label x:Name="DynamicStatusLabel"
                            FontSize="12"
                            FontAttributes="Italic"
@@ -208,7 +261,7 @@
                            Aspect="AspectFit"
                            HeightRequest="200"
                            IsAnimationPlaying="True"
-                           BackgroundColor="#E1F5FE" />
+                           BackgroundColor="{AppThemeBinding Light={StaticResource LightBlueTint2}, Dark={StaticResource DarkBlueTint2}}" />
                     <HorizontalStackLayout Spacing="12">
                         <Button Text="Toggle Animation"
                                 Clicked="OnToggleGifAnimation" />
@@ -235,22 +288,22 @@
                           RowSpacing="8">
                         <Image Source="https://picsum.photos/200/200?random=1"
                                Aspect="AspectFill"
-                               BackgroundColor="#FFEBEE"
+                               BackgroundColor="{AppThemeBinding Light={StaticResource LightRedTint}, Dark={StaticResource DarkRedTint}}"
                                Grid.Row="0"
                                Grid.Column="0" />
                         <Image Source="https://picsum.photos/200/200?random=2"
                                Aspect="AspectFill"
-                               BackgroundColor="#E8EAF6"
+                               BackgroundColor="{AppThemeBinding Light={StaticResource LightIndigoTint}, Dark={StaticResource DarkIndigoTint}}"
                                Grid.Row="0"
                                Grid.Column="1" />
                         <Image Source="https://picsum.photos/200/200?random=3"
                                Aspect="AspectFill"
-                               BackgroundColor="#E0F7FA"
+                               BackgroundColor="{AppThemeBinding Light={StaticResource LightCyanTint2}, Dark={StaticResource DarkCyanTint2}}"
                                Grid.Row="1"
                                Grid.Column="0" />
                         <Image Source="https://picsum.photos/200/200?random=4"
                                Aspect="AspectFill"
-                               BackgroundColor="#F1F8E9"
+                               BackgroundColor="{AppThemeBinding Light={StaticResource LightLimeTint}, Dark={StaticResource DarkLimeTint}}"
                                Grid.Row="1"
                                Grid.Column="1" />
                     </Grid>

--- a/samples/ControlGallery/ControlGallery/Pages/ImagePage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/ImagePage.xaml.cs
@@ -13,18 +13,6 @@ public partial class ImagePage : ContentPage
 
     private int _currentImageIndex;
 
-    Image? InteractiveImageControl => FindByName("InteractiveImage") as Image;
-    Label? AspectStatusLabelControl => FindByName("AspectStatusLabel") as Label;
-    Picker? AspectPickerControl => FindByName("AspectPicker") as Picker;
-    Image? OpacityImageControl => FindByName("OpacityImage") as Image;
-    Label? OpacityLabelControl => FindByName("OpacityLabel") as Label;
-    Image? DynamicImageControl => FindByName("DynamicImage") as Image;
-    Label? UriStatusLabelControl => FindByName("UriStatusLabel") as Label;
-    Image? GifImageControl => FindByName("GifImage") as Image;
-    Label? GifStatusLabelControl => FindByName("GifStatusLabel") as Label;
-    Image? StreamImageControl => FindByName("StreamImage") as Image;
-    Label? StreamStatusLabelControl => FindByName("StreamStatusLabel") as Label;
-
     public ImagePage()
     {
         InitializeComponent();
@@ -33,63 +21,52 @@ public partial class ImagePage : ContentPage
 
     void InitializeControls()
     {
-        // Set initial aspect picker selection
-        if (AspectPickerControl != null)
-        {
-            AspectPickerControl.SelectedIndex = 0; // AspectFit
-        }
-
         // Update URI status after a delay to simulate loading
         Dispatcher.DispatchDelayed(TimeSpan.FromSeconds(2), () =>
         {
-            if (UriStatusLabelControl != null)
+            if (UriStatusLabel != null)
             {
-                UriStatusLabelControl.Text = "Status: Loaded";
-                UriStatusLabelControl.TextColor = Colors.Green;
+                UriStatusLabel.Text = "Status: Loaded";
+                UriStatusLabel.TextColor = Colors.Green;
             }
         });
     }
 
-    void OnAspectChanged(object? sender, EventArgs e)
+    void OnAspectButtonClicked(object? sender, EventArgs e)
     {
-        if (AspectPickerControl is null || InteractiveImageControl is null || AspectStatusLabelControl is null)
+        if (sender is not Button button)
             return;
 
-        var selectedAspect = AspectPickerControl.SelectedIndex switch
+        if (InteractiveImage is null || AspectStatusLabel is null)
+            return;
+
+        var aspectName = button.CommandParameter as string;
+        var selectedAspect = aspectName switch
         {
-            0 => Aspect.AspectFit,
-            1 => Aspect.AspectFill,
-            2 => Aspect.Fill,
-            3 => Aspect.Center,
+            "AspectFit" => Aspect.AspectFit,
+            "AspectFill" => Aspect.AspectFill,
+            "Fill" => Aspect.Fill,
+            "Center" => Aspect.Center,
             _ => Aspect.AspectFit
         };
 
-        InteractiveImageControl.Aspect = selectedAspect;
-        AspectStatusLabelControl.Text = $"Current Aspect: {GetAspectName(selectedAspect)}";
+        InteractiveImage.Aspect = selectedAspect;
+        AspectStatusLabel.Text = $"Current Aspect: {aspectName}";
     }
-
-    string GetAspectName(Aspect aspect) => aspect switch
-    {
-        Aspect.AspectFit => "AspectFit",
-        Aspect.AspectFill => "AspectFill",
-        Aspect.Fill => "Fill",
-        Aspect.Center => "Center",
-        _ => "Unknown"
-    };
 
     void OnOpacityChanged(object? sender, ValueChangedEventArgs e)
     {
-        if (OpacityImageControl is null || OpacityLabelControl is null)
+        if (OpacityImage is null || OpacityLabel is null)
             return;
 
         var opacity = e.NewValue;
-        OpacityImageControl.Opacity = opacity;
-        OpacityLabelControl.Text = $"Opacity: {opacity:F2}";
+        OpacityImage.Opacity = opacity;
+        OpacityLabel.Text = $"Opacity: {opacity:F2}";
     }
 
     void OnLoadRandomImage(object? sender, EventArgs e)
     {
-        if (DynamicImageControl is null)
+        if (DynamicImage is null)
             return;
 
         // Simply set the source - IsLoading property will automatically update
@@ -97,15 +74,15 @@ public partial class ImagePage : ContentPage
         var imageUrl = _imageUrls[_currentImageIndex];
         _currentImageIndex = (_currentImageIndex + 1) % _imageUrls.Length;
 
-        DynamicImageControl.Source = imageUrl;
+        DynamicImage.Source = imageUrl;
     }
 
     void OnToggleGifAnimation(object? sender, EventArgs e)
     {
-        if (GifImageControl is null || GifStatusLabelControl is null)
+        if (GifImage is null || GifStatusLabel is null)
             return;
 
-        GifImageControl.IsAnimationPlaying = !GifImageControl.IsAnimationPlaying;
-        GifStatusLabelControl.Text = GifImageControl.IsAnimationPlaying ? "Status: Playing" : "Status: Paused";
+        GifImage.IsAnimationPlaying = !GifImage.IsAnimationPlaying;
+        GifStatusLabel.Text = GifImage.IsAnimationPlaying ? "Status: Playing" : "Status: Paused";
     }
 }

--- a/samples/ControlGallery/ControlGallery/Pages/ShadowPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/ShadowPage.xaml
@@ -3,6 +3,19 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="ControlGallery.Pages.ShadowPage"
              Title="Shadow">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <!-- Card Backgrounds -->
+            <Color x:Key="LightBlueCard">#F3F4F6</Color>
+            <Color x:Key="DarkBlueCard">#1e3a5f</Color>
+
+            <Color x:Key="LightYellowCard">#FEF3C7</Color>
+            <Color x:Key="DarkYellowCard">#4a3d1a</Color>
+
+            <Color x:Key="LightCyanCard">#ECFEFF</Color>
+            <Color x:Key="DarkCyanCard">#1a3d3d</Color>
+        </ResourceDictionary>
+    </ContentPage.Resources>
     <ScrollView>
         <VerticalStackLayout Padding="20"
                              Spacing="24">
@@ -22,7 +35,7 @@
                     <Label Text="Soft Card Shadow"
                            FontAttributes="Bold" />
                     <Border HeightRequest="140"
-                            BackgroundColor="#F3F4F6"
+                            BackgroundColor="{AppThemeBinding Light={StaticResource LightBlueCard}, Dark={StaticResource DarkBlueCard}}"
                             Padding="12"
                             Margin="24">
                         <Border.Shadow>
@@ -51,7 +64,7 @@
                     <Label Text="Directional Shadow"
                            FontAttributes="Bold" />
                     <Border HeightRequest="140"
-                            BackgroundColor="#FEF3C7"
+                            BackgroundColor="{AppThemeBinding Light={StaticResource LightYellowCard}, Dark={StaticResource DarkYellowCard}}"
                             Padding="12"
                             Margin="24">
                         <Border.Shadow>
@@ -80,7 +93,7 @@
                     <Label Text="Raised Card"
                            FontAttributes="Bold" />
                     <Border HeightRequest="140"
-                            BackgroundColor="#ECFEFF"
+                            BackgroundColor="{AppThemeBinding Light={StaticResource LightCyanCard}, Dark={StaticResource DarkCyanCard}}"
                             Padding="12"
                             Margin="24">
                         <Border.Shadow>

--- a/samples/ControlGallery/ControlGallery/Pages/SwipeViewPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/SwipeViewPage.xaml.cs
@@ -22,22 +22,22 @@ public partial class SwipeViewPage : ContentPage
 
     private async void OnFavoriteInvoked(object sender, EventArgs e)
     {
-        await DisplayAlert("SwipeView", "Favorite invoked!", "OK");
+        await DisplayAlertAsync("SwipeView", "Favorite invoked!", "OK");
     }
 
     private async void OnDeleteInvoked(object sender, EventArgs e)
     {
-        await DisplayAlert("SwipeView", "Delete invoked!", "OK");
+        await DisplayAlertAsync("SwipeView", "Delete invoked!", "OK");
     }
 
     private async void OnRevealDeleteInvoked(object sender, EventArgs e)
     {
-        await DisplayAlert("SwipeView", "Reveal delete invoked!", "OK");
+        await DisplayAlertAsync("SwipeView", "Reveal delete invoked!", "OK");
     }
 
     private async void OnArchiveInvoked(object sender, EventArgs e)
     {
-        await DisplayAlert("SwipeView", "Archive invoked!", "OK");
+        await DisplayAlertAsync("SwipeView", "Archive invoked!", "OK");
     }
 
     private void OnOpenLeftClicked(object sender, EventArgs e)
@@ -77,7 +77,7 @@ public partial class SwipeViewPage : ContentPage
 
     private async void OnExecuteSwipeInvoked(object sender, EventArgs e)
     {
-        await DisplayAlert("Execute Mode", "Execute mode triggered! SwipeView auto-closed after execution.", "OK");
+        await DisplayAlertAsync("Execute Mode", "Execute mode triggered! SwipeView auto-closed after execution.", "OK");
     }
 
     private void OnOpenRequested(object sender, OpenRequestedEventArgs e)
@@ -97,32 +97,32 @@ public partial class SwipeViewPage : ContentPage
 
     private async void OnCustomActionClicked(object sender, EventArgs e)
     {
-        await DisplayAlert("Custom Action", "Custom button clicked.", "OK");
+        await DisplayAlertAsync("Custom Action", "Custom button clicked.", "OK");
     }
 
     private async void OnRevealInvoked(object sender, EventArgs e)
     {
-        await DisplayAlert("SwipeView", "Reveal item invoked (remain open).", "OK");
+        await DisplayAlertAsync("SwipeView", "Reveal item invoked (remain open).", "OK");
     }
 
     private async void OnExecuteMixedInvoked(object sender, EventArgs e)
     {
-        await DisplayAlert("SwipeView", "Execute item invoked (auto-close).", "OK");
+        await DisplayAlertAsync("SwipeView", "Execute item invoked (auto-close).", "OK");
     }
 
     private async void OnRemainOpenInvoked(object sender, EventArgs e)
     {
-        await DisplayAlert("SwipeView", "RemainOpen invoked (stays open).", "OK");
+        await DisplayAlertAsync("SwipeView", "RemainOpen invoked (stays open).", "OK");
     }
 
     private async void OnAutoCloseInvoked(object sender, EventArgs e)
     {
-        await DisplayAlert("SwipeView", "AutoClose invoked (closes after).", "OK");
+        await DisplayAlertAsync("SwipeView", "AutoClose invoked (closes after).", "OK");
     }
 
     private async void OnAllDirectionsInvoked(object sender, EventArgs e)
     {
-        await DisplayAlert("SwipeView", "All directions item invoked.", "OK");
+        await DisplayAlertAsync("SwipeView", "All directions item invoked.", "OK");
     }
 
     private void OnEventOpenLeftClicked(object sender, EventArgs e)
@@ -139,7 +139,7 @@ public partial class SwipeViewPage : ContentPage
     {
         if (GetSwipeSampleItem(sender) is { } item)
         {
-            await DisplayAlert("Save", $"{item.Title} pinned.", "OK");
+            await DisplayAlertAsync("Save", $"{item.Title} pinned.", "OK");
         }
     }
 
@@ -147,7 +147,7 @@ public partial class SwipeViewPage : ContentPage
     {
         if (GetSwipeSampleItem(sender) is { } item)
         {
-            var confirm = await DisplayAlert("Remove item", $"Remove \"{item.Title}\"?", "Remove", "Cancel");
+            var confirm = await DisplayAlertAsync("Remove item", $"Remove \"{item.Title}\"?", "Remove", "Cancel");
             if (confirm)
             {
                 SwipeItemsCollection.Remove(item);

--- a/samples/ControlGallery/ControlGallery/Pages/ThemePage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/ThemePage.xaml.cs
@@ -36,8 +36,13 @@ public partial class ThemePage : ContentPage, INotifyPropertyChanged
         if (app == null)
             return;
 
+        // Get the current effective theme (considering both UserAppTheme and RequestedTheme)
+        var currentTheme = app.UserAppTheme != AppTheme.Unspecified
+            ? app.UserAppTheme
+            : app.RequestedTheme;
+
         // Toggle between Light and Dark themes using MAUI's UserAppTheme
-        app.UserAppTheme = app.UserAppTheme == AppTheme.Light
+        app.UserAppTheme = currentTheme == AppTheme.Light
             ? AppTheme.Dark
             : AppTheme.Light;
 

--- a/samples/ControlGallery/ControlGallery/Pages/TransformationsPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/TransformationsPage.xaml
@@ -3,6 +3,18 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="ControlGallery.Pages.TransformationsPage"
              Title="Transformations">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <Color x:Key="LightBorderBackground">White</Color>
+            <Color x:Key="DarkBorderBackground">#2a2a2a</Color>
+
+            <Color x:Key="LightStroke">LightGray</Color>
+            <Color x:Key="DarkStroke">#505050</Color>
+
+            <Color x:Key="LightButtonGray">LightGray</Color>
+            <Color x:Key="DarkButtonGray">#404040</Color>
+        </ResourceDictionary>
+    </ContentPage.Resources>
 
     <Grid RowDefinitions="Auto,Auto,Auto,*" Padding="20">
         
@@ -21,11 +33,11 @@
                Margin="0,0,0,30" />
 
         <!-- Transform Target -->
-        <Border Grid.Row="2" 
-                StrokeShape="RoundRectangle" 
-                StrokeThickness="2" 
-                Stroke="LightGray"
-                BackgroundColor="White"
+        <Border Grid.Row="2"
+                StrokeShape="RoundRectangle"
+                StrokeThickness="2"
+                Stroke="{AppThemeBinding Light={StaticResource LightStroke}, Dark={StaticResource DarkStroke}}"
+                BackgroundColor="{AppThemeBinding Light={StaticResource LightBorderBackground}, Dark={StaticResource DarkBorderBackground}}"
                 Padding="20"
                 Margin="0,0,0,30">
             <VerticalStackLayout Spacing="10"
@@ -216,7 +228,7 @@
 
                 <!-- Action Buttons -->
                 <Button Text="Reset All"
-                        BackgroundColor="LightGray"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource LightButtonGray}, Dark={StaticResource DarkButtonGray}}"
                         TextColor="White"
                         Clicked="ResetButton_Clicked" />
 

--- a/samples/ControlGallery/ControlGallery/Pages/TransformationsPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/TransformationsPage.xaml.cs
@@ -73,15 +73,15 @@ public partial class TransformationsPage : ContentPage
     private async void AnimateButton_Clicked(object? sender, EventArgs e)
     {
         // Simple rotation animation
-        await TargetImage.RotateTo(360, 2000);
+        await TargetImage.RotateToAsync(360, 2000);
         TargetImage.Rotation = 0;
 
         // Scale animation
-        await TargetImage.ScaleTo(2.0, 1000);
-        await TargetImage.ScaleTo(1.0, 1000);
+        await TargetImage.ScaleToAsync(2.0, 1000);
+        await TargetImage.ScaleToAsync(1.0, 1000);
 
         // Translation animation
-        await TargetImage.TranslateTo(100, 100, 1000);
-        await TargetImage.TranslateTo(0, 0, 1000);
+        await TargetImage.TranslateToAsync(100, 100, 1000);
+        await TargetImage.TranslateToAsync(0, 0, 1000);
     }
 }

--- a/samples/ControlGallery/ControlGallery/RpnCalculator/RpnCalculatorViewModel.cs
+++ b/samples/ControlGallery/ControlGallery/RpnCalculator/RpnCalculatorViewModel.cs
@@ -9,7 +9,7 @@ public class RpnCalculatorViewModel : INotifyPropertyChanged
     string entry = "0";
     Stack<double> stack = new Stack<double>();
 
-    public event PropertyChangedEventHandler PropertyChanged;
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     public RpnCalculatorViewModel()
     {

--- a/samples/ControlGallery/ControlGallery/SolitaireEncryption/SolitairePage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/SolitaireEncryption/SolitairePage.xaml.cs
@@ -13,7 +13,7 @@ public partial class SolitairePage : ContentPage
     {
         if (!ValidInputs())
         {
-            await DisplayAlert("Missing input", "You must enter plaintext/ciphertext and the key", "OK");
+            await DisplayAlertAsync("Missing input", "You must enter plaintext/ciphertext and the key", "OK");
             return;
         }
         var ps = new PontifexSolitaire(key.Text);
@@ -24,7 +24,7 @@ public partial class SolitairePage : ContentPage
     {
         if (!ValidInputs())
         {
-            await DisplayAlert("Missing input", "You must enter plaintext/ciphertext and the key", "OK");
+            await DisplayAlertAsync("Missing input", "You must enter plaintext/ciphertext and the key", "OK");
             return;
         }
         var ps = new PontifexSolitaire(key.Text);

--- a/samples/ControlGallery/ControlGallery/Weather/FakeWeatherService.cs
+++ b/samples/ControlGallery/ControlGallery/Weather/FakeWeatherService.cs
@@ -22,25 +22,22 @@ public class FakeWeatherService : IWeatherService
         };
     }
 
-    public Task<WeatherData?> GetWeatherData(string query)
+    public async Task<WeatherData?> GetWeatherData(string query)
     {
         // Simulate network delay
-        return Task.Run(async () =>
+        await Task.Delay(500); // Simulate API call delay
+
+        // Extract city name from query (simple parsing)
+        string cityName = ExtractCityFromQuery(query);
+
+        // Return fake data if available, otherwise return default data
+        if (_fakeData.TryGetValue(cityName, out var weatherData))
         {
-            await Task.Delay(500); // Simulate API call delay
+            return weatherData;
+        }
 
-            // Extract city name from query (simple parsing)
-            string cityName = ExtractCityFromQuery(query);
-
-            // Return fake data if available, otherwise return default data
-            if (_fakeData.TryGetValue(cityName, out var weatherData))
-            {
-                return weatherData;
-            }
-
-            // Return default fake data for unknown cities
-            return CreateWeatherData(cityName, 72.0, 8.5, 70, "Clear", "Clear sky", 0.0, 0.0);
-        });
+        // Return default fake data for unknown cities
+        return CreateWeatherData(cityName, 72.0, 8.5, 70, "Clear", "Clear sky", 0.0, 0.0);
     }
 
     private string ExtractCityFromQuery(string query)

--- a/samples/ControlGallery/ControlGallery/Weather/MainPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Weather/MainPage.xaml.cs
@@ -26,7 +26,7 @@ public partial class MainPage : ContentPage
         {
             if (string.IsNullOrWhiteSpace(Constants.OpenWeatherMapAPIKey) || Constants.OpenWeatherMapAPIKey == "YOUR_API_KEY")
             {
-                await DisplayAlert("API Key Missing", "Please set your OpenWeatherMap API key in Constants.OpenWeatherMapAPIKey.", "OK");
+                await DisplayAlertAsync("API Key Missing", "Please set your OpenWeatherMap API key in Constants.OpenWeatherMapAPIKey.", "OK");
                 return;
             }
         }

--- a/samples/ControlGallery/ControlGallery/WordPuzzle/GameSquare.cs
+++ b/samples/ControlGallery/ControlGallery/WordPuzzle/GameSquare.cs
@@ -56,9 +56,9 @@ namespace WordPuzzle
         public async Task AnimateWinAsync(bool isReverse)
         {
             uint length = 150;
-            await Task.WhenAll(this.ScaleTo(3, length), this.RotateTo(180, length));
+            await Task.WhenAll(this.ScaleToAsync(3, length), this.RotateToAsync(180, length));
             label.Text = isReverse ? normText : winText;
-            await Task.WhenAll(this.ScaleTo(1, length), this.RotateTo(360, length));
+            await Task.WhenAll(this.ScaleToAsync(1, length), this.RotateToAsync(360, length));
             this.Rotation = 0;
         }
 

--- a/samples/ControlGallery/ControlGallery/WordPuzzle/MainPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/WordPuzzle/MainPage.xaml.cs
@@ -154,16 +154,23 @@ public partial class MainPage : ContentPage
         // The Square to be animated.
         GameSquare animaSquare = squares[row, col];
 
+        // Calculate translation delta
+        double targetX = squareSize * emptyCol;
+        double targetY = squareSize * emptyRow;
+        double currentX = squareSize * col;
+        double currentY = squareSize * row;
+        double deltaX = targetX - currentX;
+        double deltaY = targetY - currentY;
+
+        // Animate using translation
+        await animaSquare.TranslateToAsync(deltaX, deltaY, length);
+
+        // Reset translation and update layout bounds
+        animaSquare.TranslationX = 0;
+        animaSquare.TranslationY = 0;
+
         // The destination rectangle.
-        Rect rect = new Rect(squareSize * emptyCol,
-                                      squareSize * emptyRow,
-                                      squareSize,
-                                      squareSize);
-
-        // This is the actual animation call.
-        await animaSquare.LayoutTo(rect, length);
-
-        // Set layout bounds to same Rectangle.
+        Rect rect = new Rect(targetX, targetY, squareSize, squareSize);
         AbsoluteLayout.SetLayoutBounds(animaSquare, rect);
 
         // Set several variables and properties for new layout.

--- a/src/Avalonia.Controls.Maui/Handlers/ImageHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ImageHandler.cs
@@ -20,7 +20,6 @@ public partial class ImageHandler : ViewHandler<IImage, AGrid>, IImageHandler
 {
     private readonly AImage _staticImage;
     private GifImage? _gifImage;
-    private bool _isGif;
     private CancellationTokenSource? _loadCts;
 
     private static readonly ConcurrentDictionary<string, Uri?> AssetCache = new();
@@ -220,7 +219,6 @@ public partial class ImageHandler : ViewHandler<IImage, AGrid>, IImageHandler
 
             _staticImage.IsVisible = false;
             _gifImage.IsVisible = true;
-            _isGif = true;
         }
         catch (Exception ex)
         {
@@ -252,11 +250,10 @@ public partial class ImageHandler : ViewHandler<IImage, AGrid>, IImageHandler
 
     private async Task LoadStaticAsync(IImageSource source, CancellationToken token)
     {
-        _isGif = false;
-        if (_gifImage != null) 
+        if (_gifImage != null)
         {
             _gifImage.IsVisible = false;
-            try { _gifImage.Source = null; } catch { }
+            try { _gifImage.Source = null!; } catch { }
         }
 
         var provider = this.GetRequiredService<IImageSourceServiceProvider>();
@@ -292,10 +289,9 @@ public partial class ImageHandler : ViewHandler<IImage, AGrid>, IImageHandler
         _staticImage.IsVisible = false;
         if (_gifImage != null)
         {
-            _gifImage.Source = null;
+            _gifImage.Source = null!;
             _gifImage.IsVisible = false;
         }
-        _isGif = false;
     }
 
     private async Task<Uri?> ResolveGifUriAsync(IImageSource source)
@@ -332,7 +328,7 @@ public partial class ImageHandler : ViewHandler<IImage, AGrid>, IImageHandler
         return null;
     }
 
-    private bool TryFindEmbeddedGif(string fileName, out Uri result)
+    private bool TryFindEmbeddedGif(string fileName, out Uri? result)
     {
         result = null;
         var targetName = Path.GetFileName(fileName);

--- a/src/Avalonia.Controls.Maui/Handlers/ScrollViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ScrollViewHandler.cs
@@ -7,6 +7,7 @@ namespace Avalonia.Controls.Maui.Handlers;
 
 public partial class ScrollViewHandler : ViewHandler<IScrollView, ScrollViewer>, IScrollViewHandler
 {
+    object IScrollViewHandler.PlatformView => PlatformView;
     private EventHandler<ScrollChangedEventArgs>? _scrollChangedHandler;
 
     public static IPropertyMapper<IScrollView, IScrollViewHandler> Mapper = new PropertyMapper<IScrollView, IScrollViewHandler>(ViewMapper)


### PR DESCRIPTION
Noticed compiling compilation warnings:
<img width="3624" height="450" alt="image" src="https://github.com/user-attachments/assets/d939c2d3-2a4f-42d0-ac32-82df5b9da0a7" />

Comes mostly from copy code from official samples, use obsolete APIs or not correctly asynchronous code etc. Applied changes to fix all the warnings.

Also, reviewed the sample and fixed:
- Fixed theme toggle requiring two taps when starting in light mode. Now correctly detects effective theme (considering both UserAppTheme and RequestedTheme)
- Tested everything in light and dark theme. Added theme-aware backgrounds in some pages.

In summary, this PR apply changes to fix compiler warnings and incorrect colors in dark theme.
