### PR TITLE
Fix MauiPlanets animation issue

### DIFF
--- a/showcase/MauiPlanets/MauiPlanets/Views/PlanetsPage.xaml.cs
+++ b/showcase/MauiPlanets/MauiPlanets/Views/PlanetsPage.xaml.cs
@@ -15,6 +15,12 @@ public partial class PlanetsPage : ContentPage
 
         lstPopularPlanets.ItemsSource = PlanetsService.GetFeaturedPlanets();
         lstAllPlanets.ItemsSource = PlanetsService.GetAllPlanets();
+
+        // Reset the menu state
+        MainContentGrid.TranslationX = 0;
+        MainContentGrid.TranslationY = 0;
+        MainContentGrid.Scale = 1;
+        MainContentGrid.Opacity = 1;
     }
 
     async void Planets_SelectionChanged(System.Object sender, Microsoft.Maui.Controls.SelectionChangedEventArgs e)


### PR DESCRIPTION
Fix MauiPlanets animation issue.

To reproduce before the changes:

1. Launch the MauiPlanets showcase into WebAssembly.
2. Open the lateral menu tapping the profile.
3. Tap a planet.
4. Navigate back.

<img width="1250" height="1752" alt="image" src="https://github.com/user-attachments/assets/a50ea8ad-6e98-42ef-8747-6c750edf772c" />

This PR must reset the lateral menu state.