### PR TITLE
During View Arrange, only measure if the measure is not valid

### DIFF
--- a/src/Avalonia.Controls.Maui/Handlers/ViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ViewHandler.cs
@@ -188,8 +188,13 @@ public abstract partial class ViewHandler : ElementHandler, IViewHandler
     {
         if (PlatformView is null)
             return;
-            
-        PlatformView.Measure(new global::Avalonia.Size(frame.Width, frame.Height));
+
+        // Only measure if the control hasn't been measured yet or if measure is invalid.
+        if (!PlatformView.IsMeasureValid)
+        {
+            PlatformView.Measure(new global::Avalonia.Size(frame.Width, frame.Height));
+        }
+
         PlatformView.Arrange(new global::Avalonia.Rect(frame.X, frame.Y, frame.Width, frame.Height));
     }
 


### PR DESCRIPTION
Running on X11, I kept running into Layout Cycle issues where the perf would slow to a crawl. Adding the Platform.Measure during Arrange was, I think, the problem. On macOS and Windows, the call is cheap and the resulting layout queue is small, so it wasn't visible as a perf issue, but on X11, the measure call would be much worse, and since Arrange in the MAUI ViewHandler can be called a number of times in succession, it would cause bad things to happen.

Stepping through it, it's also not needed at all. If the measure is valid, it shouldn't need to be remeasured, and that should also be taken care of elsewhere. Wrapping the check and running through it on Windows, macOS, X11, and WASM, it fixed the layout cycle issue.