### PR TITLE
Add MergedDictionaries for ControlTheme to default AppBuilder

### DIFF
--- a/src/Avalonia.Controls.Maui/Controls/RadioButton/MauiRadioButton.axaml
+++ b/src/Avalonia.Controls.Maui/Controls/RadioButton/MauiRadioButton.axaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:Class="Avalonia.Controls.Maui.MauiRadioButtonResources"
                     xmlns:controls="clr-namespace:Avalonia.Controls.Maui">
 
     <!--

--- a/src/Avalonia.Controls.Maui/Controls/RadioButton/MauiRadioButton.axaml.cs
+++ b/src/Avalonia.Controls.Maui/Controls/RadioButton/MauiRadioButton.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Markup.Xaml;
+
+namespace Avalonia.Controls.Maui;
+
+public class MauiRadioButtonResources : ResourceDictionary
+{
+    public MauiRadioButtonResources()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Avalonia.Controls.Maui/Extensions/MauiAppBuilderExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/MauiAppBuilderExtensions.cs
@@ -1,14 +1,18 @@
 using System.Collections;
 using Avalonia.Controls.Maui.Animations;
+using Avalonia.Controls.Maui.LifecycleEvents;
 using Avalonia.Controls.Maui.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Maui;
 using Microsoft.Maui.Animations;
 using Microsoft.Maui.Hosting;
+using Microsoft.Maui.LifecycleEvents;
 
 public static class MauiAppBuilderExtensions
 {
+    private const string RegistrationKey = "__AvaloniaControlsMauiResourcesRegistered";
+
     /// <summary>
     /// Configures Avalonia-specific services for MAUI image handling
     /// </summary>
@@ -154,7 +158,37 @@ public static class MauiAppBuilderExtensions
                 handlers.AddHandler<Microsoft.Maui.Controls.TitleBar, Avalonia.Controls.Maui.Handlers.TitleBarHandler>();
 
             })
+            .UseAvaloniaResources()
             .ConfigureImageSources();
+    }
+
+    /// <summary>
+    /// Registers the built-in Avalonia themes and all control templates/styles
+    /// shipped with Avalonia.Controls.Maui.
+    /// </summary>
+    private static MauiAppBuilder UseAvaloniaResources(this MauiAppBuilder builder)
+    {
+        builder.ConfigureLifecycleEvents(events =>
+        {
+            events.AddWindows(avalonia =>
+            {
+                avalonia.OnLaunching((application, _) => RegisterResources(application));
+            });
+        });
+
+        return builder;
+    }
+
+    private static void RegisterResources(Avalonia.Application application)
+    {
+        if (application.Resources.ContainsKey(RegistrationKey))
+            return;
+
+        application.Resources[RegistrationKey] = true;
+
+        application.Resources.MergedDictionaries.Add(new Avalonia.Controls.Maui.MauiRadioButtonResources());
+        application.Resources.MergedDictionaries.Add(new Avalonia.Controls.Maui.ProgressRingResources());
+        application.Resources.MergedDictionaries.Add(new Avalonia.Controls.Maui.MauiComboBoxResources());
     }
 
     class ImageSourceRegistration


### PR DESCRIPTION
<img width="1017" height="962" alt="スクリーンショット 2025-12-15 16 56 13" src="https://github.com/user-attachments/assets/57c2f603-7987-4b19-a8e2-dce0f11f8e2b" />

Attempt number 2 from https://github.com/AvaloniaUI/Avalonia.Controls.Maui/pull/70,

This splits out stuff done in https://github.com/AvaloniaUI/Avalonia.Controls.Maui/pull/69, except

- It's apart of the default `UseAvalonia` path, so no need to add another builder parameter.
- No `Control.axaml` (https://github.com/AvaloniaUI/Avalonia.Controls.Maui/blob/1a7f180dce6fd6d8830c451e69f9db528f98833c/src/Avalonia.Controls.Maui/Styles/Controls.axaml) which, as far as I can tell, is redundant when directly adding the themes in code and would be trimmed out as written.