### PR TITLE
[Bug] Fix Incorrect Border content clipping

### DIFF
--- a/samples/ControlGallery/ControlGallery/Pages/BorderPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/BorderPage.xaml
@@ -457,6 +457,128 @@
                             HorizontalOptions="Center"/>
                 </VerticalStackLayout>
             </Border>
+            <!-- Feature Cards -->
+            <Border Stroke="{AppThemeBinding Light={StaticResource SectionBorderLight}, Dark={StaticResource SectionBorderDark}}"
+                    Background="{AppThemeBinding Light={StaticResource SectionBackgroundLight}, Dark={StaticResource SectionBackgroundDark}}"
+                    Padding="10">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10"/>
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Feature Cards"
+                           FontAttributes="Bold"/>
+                    
+                    <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="15" RowSpacing="15">
+                        <Border StrokeShape="RoundRectangle 12" 
+                                StrokeThickness="0"
+                                Padding="16" 
+                                BackgroundColor="{AppThemeBinding Light=#F5F5F5, Dark=#212121}">
+                            <VerticalStackLayout Spacing="8">
+                                <Label Text="Lorem Ipsum" FontAttributes="Bold" FontSize="16" TextColor="{AppThemeBinding Light=Black, Dark=White}"/>
+                                <Label Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit." FontSize="13" TextColor="{AppThemeBinding Light=#757575, Dark=#BDBDBD}"/>
+                            </VerticalStackLayout>
+                        </Border>
+
+                        <Border Grid.Column="1"
+                                StrokeShape="RoundRectangle 12" 
+                                StrokeThickness="0"
+                                Padding="16" 
+                                BackgroundColor="{AppThemeBinding Light=#F5F5F5, Dark=#212121}">
+                            <VerticalStackLayout Spacing="8">
+                                <Label Text="Dolor Sit Amet" FontAttributes="Bold" FontSize="16" TextColor="{AppThemeBinding Light=Black, Dark=White}"/>
+                                <Label Text="Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." FontSize="13" TextColor="{AppThemeBinding Light=#757575, Dark=#BDBDBD}"/>
+                            </VerticalStackLayout>
+                        </Border>
+
+                        <Border Grid.Row="1"
+                                StrokeShape="RoundRectangle 12" 
+                                StrokeThickness="0"
+                                Padding="16" 
+                                BackgroundColor="{AppThemeBinding Light=#F5F5F5, Dark=#212121}">
+                            <VerticalStackLayout Spacing="8">
+                                <Label Text="Consectetur Elit" FontAttributes="Bold" FontSize="16" TextColor="{AppThemeBinding Light=Black, Dark=White}"/>
+                                <Label Text="Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris." FontSize="13" TextColor="{AppThemeBinding Light=#757575, Dark=#BDBDBD}"/>
+                            </VerticalStackLayout>
+                        </Border>
+
+                        <Border Grid.Row="1" Grid.Column="1"
+                                StrokeShape="RoundRectangle 12" 
+                                StrokeThickness="0"
+                                Padding="16" 
+                                BackgroundColor="{AppThemeBinding Light=#F5F5F5, Dark=#212121}">
+                            <VerticalStackLayout Spacing="8">
+                                <Label Text="Sed Do Eiusmod" FontAttributes="Bold" FontSize="16" TextColor="{AppThemeBinding Light=Black, Dark=White}"/>
+                                <Label Text="Duis aute irure dolor in reprehenderit in voluptate velit esse cillum." FontSize="13" TextColor="{AppThemeBinding Light=#757575, Dark=#BDBDBD}"/>
+                            </VerticalStackLayout>
+                        </Border>
+                    </Grid>
+                </VerticalStackLayout>
+            </Border>
+            <!-- Profile Example -->
+            <Border Stroke="{AppThemeBinding Light={StaticResource SectionBorderLight}, Dark={StaticResource SectionBorderDark}}"
+                    Background="{AppThemeBinding Light={StaticResource SectionBackgroundLight}, Dark={StaticResource SectionBackgroundDark}}"
+                    Padding="10">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10"/>
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Profile Card (Ellipse Clipping)"
+                           FontAttributes="Bold"/>
+                    
+                    <Border Stroke="{AppThemeBinding Light=#E0E0E0, Dark=#424242}"
+                            StrokeThickness="1"
+                            Padding="20"
+                            HorizontalOptions="Center"
+                            Background="{AppThemeBinding Light=White, Dark=#303030}">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="20"/>
+                        </Border.StrokeShape>
+                        <Border.Shadow>
+                            <Shadow Brush="#99000000"
+                                    Offset="5,5"
+                                    Radius="20"
+                                    Opacity="0.2"/>
+                        </Border.Shadow>
+                        
+                        <VerticalStackLayout Spacing="15" 
+                                             WidthRequest="250"
+                                             HorizontalOptions="Center">
+                            
+                            <!-- Circular Avatar -->
+                            <Border Stroke="{AppThemeBinding Light={StaticResource AccentPrimary}, Dark={StaticResource AccentSecondary}}"
+                                    StrokeThickness="4"
+                                    WidthRequest="100"
+                                    HeightRequest="100"
+                                    HorizontalOptions="Center">
+                                <Border.StrokeShape>
+                                    <Ellipse/>
+                                </Border.StrokeShape>
+                                <Image Source="dotnet_logo.png"
+                                       Aspect="AspectFill"
+                                       WidthRequest="100"
+                                       HeightRequest="100"/>
+                            </Border>
+                            
+                            <VerticalStackLayout Spacing="5" HorizontalOptions="Center">
+                                <Label Text="Jane Doe"
+                                       FontSize="20"
+                                       FontAttributes="Bold"
+                                       HorizontalOptions="Center"
+                                       TextColor="{AppThemeBinding Light=Black, Dark=White}"/>
+                                <Label Text="Senior Software Engineer"
+                                       FontSize="14"
+                                       HorizontalOptions="Center"
+                                       TextColor="{AppThemeBinding Light=#757575, Dark=#BDBDBD}"/>
+                            </VerticalStackLayout>
+                            
+                            <Button Text="View Profile"
+                                    HorizontalOptions="Fill"
+                                    BackgroundColor="{AppThemeBinding Light={StaticResource AccentPrimary}, Dark={StaticResource AccentSecondary}}"
+                                    TextColor="White"/>
+                        </VerticalStackLayout>
+                    </Border>
+                </VerticalStackLayout>
+            </Border>
 
         </VerticalStackLayout>
     </ScrollView>

--- a/src/Avalonia.Controls.Maui/Controls/MauiBorder/MauiBorder.cs
+++ b/src/Avalonia.Controls.Maui/Controls/MauiBorder/MauiBorder.cs
@@ -237,11 +237,9 @@ namespace Avalonia.Controls.Maui
         protected override Size ArrangeOverride(Size finalSize)
         {
             // Update geometries used for rendering
-            // Both background and stroke use the same geometry path (stroke is centered on this path)
+            // Both background and stroke use the same geometry at StrokeThickness/2 offset
             if (_strokeGeometry == null || _lastRenderSize != finalSize)
             {
-                // Use StrokeThickness/2 offset so the path is at the center of where the stroke will be drawn
-                // Background fills this path, stroke is drawn on this path
                 _strokeGeometry = CreateGeometry(finalSize, StrokeThickness / 2);
                 _backgroundGeometry = _strokeGeometry;
                 _lastRenderSize = finalSize;
@@ -251,14 +249,15 @@ namespace Avalonia.Controls.Maui
             {
                 var strokeThickness = StrokeThickness;
                 var padding = Padding;
-                // Child is arranged with only padding - content can extend under the stroke
+                // Child is arranged inside padding only
+                // Stroke is drawn at the outer edge and doesn't reduce content area
                 var childRect = new Rect(finalSize).Deflate(padding);
                 Child.Arrange(childRect);
 
                 if (Shape != null)
                 {
-                    // Clip child to the stroke path (same geometry used for stroke/background)
-                    Child.Clip = CreateClipGeometry(childRect.Size, strokeThickness);
+                    // Clip child to the border inner edge (relative to Child coordinates)
+                    Child.Clip = CreateClipGeometry(childRect, finalSize, strokeThickness);
                 }
                 else
                 {
@@ -273,64 +272,80 @@ namespace Avalonia.Controls.Maui
             return finalSize;
         }
 
-        private Geometry? CreateClipGeometry(Size childSize, double strokeThickness)
+        private Geometry? CreateClipGeometry(Rect childRect, Size borderSize, double strokeThickness)
         {
             if (Shape == null)
                 return null;
 
-            // The clip should match the stroke path (at StrokeThickness/2 offset from outer edge)
-            // Since child is arranged at padding only, we need to offset the clip by strokeThickness/2
-            var halfStroke = strokeThickness / 2;
-        
+            // When strokeThickness is 0, padding already keeps content inside the border
+            // No clipping is needed for straight edges; rounded corners are handled by the shape
+            // UNLESS padding is 0, then we might need to clip to the shape
+            if (strokeThickness <= 0 && childRect.X > 0 && childRect.Y > 0)
+                return null;
+
+            // Calculate the inner border rectangle (the visible area inside the stroke)
+            // relative to the Border's coordinate system
+            // Stroke is centered on the path at StrokeThickness/2
+            // Calculate the inner border rectangle (the visible area inside the stroke)
+            // relative to the Border's coordinate system
+            // Stroke is centered on the path at StrokeThickness/2
+            // We align the clip with the CENTER of the stroke to ensure robust overlap
+            var innerStrokePos = strokeThickness / 2;
+            
+            var innerBorderRect = new MauiGraphics.Rect(
+                innerStrokePos, 
+                innerStrokePos, 
+                Math.Max(0, borderSize.Width - 2 * innerStrokePos), 
+                Math.Max(0, borderSize.Height - 2 * innerStrokePos));
+
+            // Instead of offsetting the rect (which creates negative coordinates that MauiGraphics might mishandle),
+            // we generate the geometry in Border coordinates and then apply a TranslateTransform.
+            // This is safer and robust against shape generation quirks.
+            Geometry? clipGeometry = null;
+
             if (Shape is MauiShapes.RoundRectangle roundRectangleShape)
             {
-                // Clip bounds offset by half stroke to align with stroke path
-                var clipBounds = new MauiGraphics.Rect(
-                    halfStroke,
-                    halfStroke,
-                    Math.Max(0, childSize.Width - strokeThickness),
-                    Math.Max(0, childSize.Height - strokeThickness));
-
+                // We need to adjust the corner radius to account for the stroke thickness
+                // The shape's CornerRadius is for the outer edge (or center, depending on definition)
+                // But effectively we want the radius at the INNER edge of the stroke.
+                // We basically want the radius at the clip position (innerStrokePos)
                 var radii = roundRectangleShape.CornerRadius;
-                // Adjust corner radii by half stroke (to match stroke path geometry)
+                
+                // Adjust radii based on the actual clip position
                 var adjustedRadii = new Microsoft.Maui.CornerRadius(
-                    Math.Max(0, radii.TopLeft - halfStroke),
-                    Math.Max(0, radii.TopRight - halfStroke),
-                    Math.Max(0, radii.BottomLeft - halfStroke),
-                    Math.Max(0, radii.BottomRight - halfStroke));
+                    Math.Max(0, radii.TopLeft - innerStrokePos),
+                    Math.Max(0, radii.TopRight - innerStrokePos),
+                    Math.Max(0, radii.BottomLeft - innerStrokePos),
+                    Math.Max(0, radii.BottomRight - innerStrokePos));
 
                 var tempRr = new MauiShapes.RoundRectangle
                 {
                     CornerRadius = adjustedRadii
                 };
 
-                var pathF = ((MauiGraphics.IShape)tempRr).PathForBounds(clipBounds);
-                return ShapeExtensions.ToAvaloniaGeometry(pathF);
+                // Generate path for the adjusted rect and radius
+                var pathF = ((MauiGraphics.IShape)tempRr).PathForBounds(innerBorderRect);
+                clipGeometry = ShapeExtensions.ToAvaloniaGeometry(pathF);
             }
-
-            if (Shape is MauiGraphics.IRoundRectangle roundRectangle)
+            else if (Shape is MauiGraphics.IRoundRectangle roundRectangle)
             {
-                var clipBounds = new MauiGraphics.Rect(
-                    halfStroke,
-                    halfStroke,
-                    Math.Max(0, childSize.Width - strokeThickness),
-                    Math.Max(0, childSize.Height - strokeThickness));
-
-                var innerPath = roundRectangle.InnerPathForBounds(clipBounds, (float)halfStroke);
-                if (innerPath is not null)
-                {
-                    return ShapeExtensions.ToAvaloniaGeometry(innerPath);
-                }
+                var pathF = roundRectangle.PathForBounds(innerBorderRect);
+                clipGeometry = ShapeExtensions.ToAvaloniaGeometry(pathF);
+            }
+            else
+            {
+                // For other shapes, generate path at the clip rect location
+                var genericPath = Shape.PathForBounds(innerBorderRect);
+                clipGeometry = ShapeExtensions.ToAvaloniaGeometry(genericPath);
             }
 
-            // For other shapes, clip using the shape path offset by half stroke
-            var genericClipBounds = new MauiGraphics.Rect(
-                halfStroke,
-                halfStroke,
-                Math.Max(0, childSize.Width - strokeThickness),
-                Math.Max(0, childSize.Height - strokeThickness));
-            var genericPath = Shape.PathForBounds(genericClipBounds);
-            return ShapeExtensions.ToAvaloniaGeometry(genericPath);
+            // Apply transformation to shift from Border coordinates to Child coordinates
+            if (clipGeometry != null)
+            {
+                clipGeometry.Transform = new TranslateTransform(-childRect.X, -childRect.Y);
+            }
+
+            return clipGeometry;
         }
 
         public override void Render(DrawingContext context)
@@ -340,22 +355,24 @@ namespace Avalonia.Controls.Maui
             if (bounds.Width <= 0 || bounds.Height <= 0)
                 return;
 
-            // Ensure geometries are valid (ArrangeOverride usually handles this, but safe to check)
+            // Ensure geometries are valid
             if (_strokeGeometry == null || _lastRenderSize != bounds.Size)
             {
-                // Use StrokeThickness/2 offset so the path is at the center of where the stroke will be drawn
+                // Both background and stroke use the same geometry at StrokeThickness/2 offset
+                // This way background fills to the stroke center line
+                // Stroke is drawn centered on this path, so it extends from 0 to StrokeThickness at the edge
                 _strokeGeometry = CreateGeometry(bounds.Size, StrokeThickness / 2);
                 _backgroundGeometry = _strokeGeometry;
                 _lastRenderSize = bounds.Size;
             }
 
-            // Draw background (fills the entire shape area)
+            // Draw background first - fills to the stroke center line
             if (Background != null && _backgroundGeometry != null)
             {
                 context.DrawGeometry(Background, null, _backgroundGeometry);
             }
 
-            // Draw stroke (centered on the edge, handled by CreateGeometry offset)
+            // Draw stroke on top - centered on the same path
             if (Stroke != null && StrokeThickness > 0 && _strokeGeometry != null)
             {
                 var pen = CreatePen();

--- a/tests/Avalonia.Controls.Maui.Tests/Controls/MauiBorderTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Controls/MauiBorderTests.cs
@@ -35,9 +35,10 @@ public class MauiBorderTests
 
         var clip = child.Clip;
         Assert.NotNull(clip);
-        // Clip is based on strokeThickness
-        var expectedClipWidth = expectedChildWidth - stroke;
-        var expectedClipHeight = expectedChildHeight - stroke;
+        // Clip is based on strokeThickness relative to the Border Size (not Child size)
+        // because the clip defines the BORDER shape.
+        var expectedClipWidth = finalSize.Width - stroke;
+        var expectedClipHeight = finalSize.Height - stroke;
 
         Assert.Equal(expectedClipWidth, clip!.Bounds.Width, 3);
         Assert.Equal(expectedClipHeight, clip.Bounds.Height, 3);
@@ -195,8 +196,8 @@ public class MauiBorderTests
         Assert.NotNull(child.Clip);
     }
 
-    [AvaloniaFact(DisplayName = "Zero stroke thickness creates no clip")]
-    public void ZeroStrokeThickness_CreatesNoClip()
+    [AvaloniaFact(DisplayName = "Zero stroke thickness with rounded corners creates clip")]
+    public void ZeroStrokeThickness_WithRoundedCorners_CreatesClip()
     {
         var border = new MauiBorder
         {
@@ -211,7 +212,8 @@ public class MauiBorderTests
         border.Measure(size);
         border.Arrange(new Rect(size));
         
-        Assert.Null(child.Clip);
+        // Even with 0 stroke, we must clip to the CornerRadius
+        Assert.NotNull(child.Clip);
     }
 
     [AvaloniaFact(DisplayName = "Large stroke thickness reduces clip size")]

--- a/tests/Avalonia.Controls.Maui.Tests/Controls/MauiBorderTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Controls/MauiBorderTests.cs
@@ -26,6 +26,7 @@ public class MauiBorderTests
 
         var padding = border.Padding;
         var stroke = border.StrokeThickness;
+        // Child is arranged inside padding only
         var expectedChildWidth = finalSize.Width - padding.Left - padding.Right;
         var expectedChildHeight = finalSize.Height - padding.Top - padding.Bottom;
 
@@ -34,6 +35,7 @@ public class MauiBorderTests
 
         var clip = child.Clip;
         Assert.NotNull(clip);
+        // Clip is based on strokeThickness
         var expectedClipWidth = expectedChildWidth - stroke;
         var expectedClipHeight = expectedChildHeight - stroke;
 
@@ -46,7 +48,8 @@ public class MauiBorderTests
     {
         var border = new MauiBorder
         {
-            Shape = new RoundRectangle { CornerRadius = new Microsoft.Maui.CornerRadius(10) }
+            Shape = new RoundRectangle { CornerRadius = new Microsoft.Maui.CornerRadius(10) },
+            StrokeThickness = 2
         };
 
         var child = new Border();
@@ -100,6 +103,7 @@ public class MauiBorderTests
         border.Measure(finalSize);
         border.Arrange(new Rect(finalSize));
 
+        // Child uses full size when no padding
         Assert.Equal(finalSize.Width, child.Bounds.Width, 3);
         Assert.Equal(finalSize.Height, child.Bounds.Height, 3);
     }
@@ -145,6 +149,8 @@ public class MauiBorderTests
         border.Arrange(new Rect(size));
 
         Assert.NotNull(child.Clip);
+        
+        // Clip is reduced by stroke
         var expectedClipWidth = size.Width - border.StrokeThickness;
         var expectedClipHeight = size.Height - border.StrokeThickness;
         Assert.Equal(expectedClipWidth, child.Clip!.Bounds.Width, 3);
@@ -189,8 +195,8 @@ public class MauiBorderTests
         Assert.NotNull(child.Clip);
     }
 
-    [AvaloniaFact(DisplayName = "Zero stroke thickness creates full-size clip")]
-    public void ZeroStrokeThickness_CreatesFullSizeClip()
+    [AvaloniaFact(DisplayName = "Zero stroke thickness creates no clip")]
+    public void ZeroStrokeThickness_CreatesNoClip()
     {
         var border = new MauiBorder
         {
@@ -204,10 +210,8 @@ public class MauiBorderTests
         var size = new Size(100, 100);
         border.Measure(size);
         border.Arrange(new Rect(size));
-
-        Assert.NotNull(child.Clip);
-        Assert.Equal(100, child.Clip!.Bounds.Width, 3);
-        Assert.Equal(100, child.Clip.Bounds.Height, 3);
+        
+        Assert.Null(child.Clip);
     }
 
     [AvaloniaFact(DisplayName = "Large stroke thickness reduces clip size")]
@@ -605,7 +609,7 @@ public class MauiBorderTests
         var size = new Size(200, 150);
         border.Measure(size);
         border.Arrange(new Rect(size));
-
+        
         Assert.Equal(size.Width - 20, child.Bounds.Width, 3);
         Assert.Equal(size.Height - 20, child.Bounds.Height, 3);
         Assert.NotNull(child.Clip);


### PR DESCRIPTION
Fix Incorrect Border content clipping because not take into account all the necessary details: stroke thickness, padding, etc.
![fix-border](https://github.com/user-attachments/assets/b00c7160-a5fc-454d-8d88-aa5ca7f9cfb1)

Added more samples, and reviewed tests.

Fixes #86 