### PR TITLE
Throw WarningsAsErrors for all the things, build the sample apps

### DIFF
--- a/.github/workflows/build-desktop-samples.yml
+++ b/.github/workflows/build-desktop-samples.yml
@@ -9,30 +9,8 @@ on:
 
 jobs:
   build:
-    strategy:
-      fail-fast: false
-      matrix:
-        app:
-          - name: ControlGallery.Desktop
-            project: samples/ControlGallery/ControlGallery.Desktop/ControlGallery.Desktop.csproj
-          - name: MauiPlanets.Desktop
-            project: showcase/MauiPlanets/MauiPlanets.Desktop/MauiPlanets.Desktop.csproj
-          - name: AlohaKit.Gallery.Desktop
-            project: showcase/AlohaKit.Gallery/AlohaKit.Gallery.Desktop/AlohaKit.Gallery.Desktop.csproj
-          - name: 2048Game.Desktop
-            project: showcase/2048Game/2048Game.Desktop/2048Game.Desktop.csproj
-        build-type:
-          - name: Release
-            publish-aot: false
-            rid: ''
-            os: ubuntu-latest
-          - name: Release-AOT
-            publish-aot: true
-            rid: linux-x64
-            os: ubuntu-latest
-
-    runs-on: ${{ matrix.build-type.os }}
-    name: ${{ matrix.app.name }} (${{ matrix.build-type.name }})
+    runs-on: ubuntu-latest
+    name: Build All Desktop Samples
 
     steps:
       - name: Checkout
@@ -47,34 +25,123 @@ jobs:
           dotnet-quality: 'preview'
 
       - name: Install AOT dependencies
-        if: matrix.build-type.publish-aot
         run: |
           sudo apt-get update
           sudo apt-get install -y clang zlib1g-dev
 
-      - name: Restore
-        run: dotnet restore ${{ matrix.app.project }}
-
-      - name: Publish (Non-AOT)
-        if: ${{ !matrix.build-type.publish-aot }}
+      - name: Install maui-tizen workload
         run: |
-          dotnet publish ${{ matrix.app.project }} \
+          dotnet workload install maui-tizen
+
+      # ControlGallery.Desktop
+      - name: Publish ControlGallery.Desktop (Release)
+        run: |
+          dotnet publish samples/ControlGallery/ControlGallery.Desktop/ControlGallery.Desktop.csproj \
             -c Release \
-            -o ./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }} \
+            -o ./artifacts/ControlGallery.Desktop-Release \
             /p:PublishAot=false
 
-      - name: Publish (AOT)
-        if: matrix.build-type.publish-aot
+      - name: Publish ControlGallery.Desktop (Release-AOT)
         run: |
-          dotnet publish ${{ matrix.app.project }} \
+          dotnet publish samples/ControlGallery/ControlGallery.Desktop/ControlGallery.Desktop.csproj \
             -c Release \
-            -r ${{ matrix.build-type.rid }} \
-            -o ./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }} \
+            -r linux-x64 \
+            -o ./artifacts/ControlGallery.Desktop-Release-AOT \
             /p:PublishAot=true
 
-      - name: Upload Artifact
+      # MauiPlanets.Desktop
+      - name: Publish MauiPlanets.Desktop (Release)
+        run: |
+          dotnet publish showcase/MauiPlanets/MauiPlanets.Desktop/MauiPlanets.Desktop.csproj \
+            -c Release \
+            -o ./artifacts/MauiPlanets.Desktop-Release \
+            /p:PublishAot=false
+
+      - name: Publish MauiPlanets.Desktop (Release-AOT)
+        run: |
+          dotnet publish showcase/MauiPlanets/MauiPlanets.Desktop/MauiPlanets.Desktop.csproj \
+            -c Release \
+            -r linux-x64 \
+            -o ./artifacts/MauiPlanets.Desktop-Release-AOT \
+            /p:PublishAot=true
+
+      # AlohaKit.Gallery.Desktop
+      - name: Publish AlohaKit.Gallery.Desktop (Release)
+        run: |
+          dotnet publish showcase/AlohaKit.Gallery/AlohaKit.Gallery.Desktop/AlohaKit.Gallery.Desktop.csproj \
+            -c Release \
+            -o ./artifacts/AlohaKit.Gallery.Desktop-Release \
+            /p:PublishAot=false
+
+      - name: Publish AlohaKit.Gallery.Desktop (Release-AOT)
+        run: |
+          dotnet publish showcase/AlohaKit.Gallery/AlohaKit.Gallery.Desktop/AlohaKit.Gallery.Desktop.csproj \
+            -c Release \
+            -r linux-x64 \
+            -o ./artifacts/AlohaKit.Gallery.Desktop-Release-AOT \
+            /p:PublishAot=true
+
+      # 2048Game.Desktop
+      - name: Publish 2048Game.Desktop (Release)
+        run: |
+          dotnet publish showcase/2048Game/2048Game.Desktop/2048Game.Desktop.csproj \
+            -c Release \
+            -o ./artifacts/2048Game.Desktop-Release \
+            /p:PublishAot=false
+
+      - name: Publish 2048Game.Desktop (Release-AOT)
+        run: |
+          dotnet publish showcase/2048Game/2048Game.Desktop/2048Game.Desktop.csproj \
+            -c Release \
+            -r linux-x64 \
+            -o ./artifacts/2048Game.Desktop-Release-AOT \
+            /p:PublishAot=true
+
+      # Upload all artifacts
+      - name: Upload ControlGallery.Desktop-Release
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.app.name }}-${{ matrix.build-type.name }}
-          path: ./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }}
-          retention-days: 14
+          name: ControlGallery.Desktop-Release
+          path: ./artifacts/ControlGallery.Desktop-Release
+
+      - name: Upload ControlGallery.Desktop-Release-AOT
+        uses: actions/upload-artifact@v4
+        with:
+          name: ControlGallery.Desktop-Release-AOT
+          path: ./artifacts/ControlGallery.Desktop-Release-AOT
+
+      - name: Upload MauiPlanets.Desktop-Release
+        uses: actions/upload-artifact@v4
+        with:
+          name: MauiPlanets.Desktop-Release
+          path: ./artifacts/MauiPlanets.Desktop-Release
+
+      - name: Upload MauiPlanets.Desktop-Release-AOT
+        uses: actions/upload-artifact@v4
+        with:
+          name: MauiPlanets.Desktop-Release-AOT
+          path: ./artifacts/MauiPlanets.Desktop-Release-AOT
+
+      - name: Upload AlohaKit.Gallery.Desktop-Release
+        uses: actions/upload-artifact@v4
+        with:
+          name: AlohaKit.Gallery.Desktop-Release
+          path: ./artifacts/AlohaKit.Gallery.Desktop-Release
+
+      - name: Upload AlohaKit.Gallery.Desktop-Release-AOT
+        uses: actions/upload-artifact@v4
+        with:
+          name: AlohaKit.Gallery.Desktop-Release-AOT
+          path: ./artifacts/AlohaKit.Gallery.Desktop-Release-AOT
+
+      - name: Upload 2048Game.Desktop-Release
+        uses: actions/upload-artifact@v4
+        with:
+          name: 2048Game.Desktop-Release
+          path: ./artifacts/2048Game.Desktop-Release
+
+      - name: Upload 2048Game.Desktop-Release-AOT
+        uses: actions/upload-artifact@v4
+        with:
+          name: 2048Game.Desktop-Release-AOT
+          path: ./artifacts/2048Game.Desktop-Release-AOT

--- a/.github/workflows/build-desktop-samples.yml
+++ b/.github/workflows/build-desktop-samples.yml
@@ -76,6 +76,69 @@ jobs:
             -o ./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }} \
             /p:PublishAOT=true
 
+      - name: Create AppImage (AOT)
+        if: matrix.build-type.publish-aot
+        run: |
+          # Download appimagetool
+          wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
+          chmod +x appimagetool
+
+          # Extract appimagetool (needed for running in containers/CI without FUSE)
+          ./appimagetool --appimage-extract
+
+          APP_NAME="${{ matrix.app.name }}"
+          APP_DIR="./AppDir"
+          PUBLISH_DIR="./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }}"
+
+          # Find the main executable (assumes it matches the app name pattern)
+          EXECUTABLE=$(find "$PUBLISH_DIR" -maxdepth 1 -type f -executable -name "*.Desktop" | head -1)
+          if [ -z "$EXECUTABLE" ]; then
+            EXECUTABLE=$(find "$PUBLISH_DIR" -maxdepth 1 -type f -executable ! -name "*.so" ! -name "*.dll" | head -1)
+          fi
+          EXECUTABLE_NAME=$(basename "$EXECUTABLE")
+
+          # Create AppDir structure
+          mkdir -p "$APP_DIR/usr/bin"
+          mkdir -p "$APP_DIR/usr/lib"
+
+          # Copy all published files to AppDir
+          cp -r "$PUBLISH_DIR"/* "$APP_DIR/usr/bin/"
+
+          # Create .desktop file
+          cat > "$APP_DIR/$APP_NAME.desktop" << EOF
+          [Desktop Entry]
+          Name=$APP_NAME
+          Exec=$EXECUTABLE_NAME
+          Icon=$APP_NAME
+          Type=Application
+          Categories=Development;
+          EOF
+
+          # Create AppRun script
+          cat > "$APP_DIR/AppRun" << EOF
+          #!/bin/bash
+          SELF=\$(readlink -f "\$0")
+          HERE=\${SELF%/*}
+          export PATH="\${HERE}/usr/bin:\${PATH}"
+          export LD_LIBRARY_PATH="\${HERE}/usr/lib:\${HERE}/usr/bin:\${LD_LIBRARY_PATH}"
+          exec "\${HERE}/usr/bin/$EXECUTABLE_NAME" "\$@"
+          EOF
+          chmod +x "$APP_DIR/AppRun"
+
+          # Copy the app icon
+          cp build/Assets/Icon.png "$APP_DIR/$APP_NAME.png"
+
+          # Build the AppImage
+          ARCH=x86_64 ./squashfs-root/AppRun "$APP_DIR" "./artifacts/$APP_NAME-x86_64.AppImage"
+
+      - name: Upload AppImage
+        if: matrix.build-type.publish-aot
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.app.name }}-AppImage
+          path: ./artifacts/${{ matrix.app.name }}-x86_64.AppImage
+          retention-days: 14
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-desktop-samples.yml
+++ b/.github/workflows/build-desktop-samples.yml
@@ -1,0 +1,80 @@
+name: Build Desktop Samples
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        app:
+          - name: ControlGallery.Desktop
+            project: samples/ControlGallery/ControlGallery.Desktop/ControlGallery.Desktop.csproj
+          - name: MauiPlanets.Desktop
+            project: showcase/MauiPlanets/MauiPlanets.Desktop/MauiPlanets.Desktop.csproj
+          - name: AlohaKit.Gallery.Desktop
+            project: showcase/AlohaKit.Gallery/AlohaKit.Gallery.Desktop/AlohaKit.Gallery.Desktop.csproj
+          - name: 2048Game.Desktop
+            project: showcase/2048Game/2048Game.Desktop/2048Game.Desktop.csproj
+        build-type:
+          - name: Release
+            publish-aot: false
+            rid: ''
+            os: ubuntu-latest
+          - name: Release-AOT
+            publish-aot: true
+            rid: linux-x64
+            os: ubuntu-latest
+
+    runs-on: ${{ matrix.build-type.os }}
+    name: ${{ matrix.app.name }} (${{ matrix.build-type.name }})
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Install AOT dependencies
+        if: matrix.build-type.publish-aot
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang zlib1g-dev
+
+      - name: Restore
+        run: dotnet restore ${{ matrix.app.project }}
+
+      - name: Publish (Non-AOT)
+        if: ${{ !matrix.build-type.publish-aot }}
+        run: |
+          dotnet publish ${{ matrix.app.project }} \
+            -c Release \
+            -o ./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }} \
+            /p:PublishAot=false
+
+      - name: Publish (AOT)
+        if: matrix.build-type.publish-aot
+        run: |
+          dotnet publish ${{ matrix.app.project }} \
+            -c Release \
+            -r ${{ matrix.build-type.rid }} \
+            -o ./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }} \
+            /p:PublishAot=true
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.app.name }}-${{ matrix.build-type.name }}
+          path: ./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }}
+          retention-days: 14

--- a/.github/workflows/build-desktop-samples.yml
+++ b/.github/workflows/build-desktop-samples.yml
@@ -9,8 +9,30 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    name: Build All Desktop Samples
+    strategy:
+      fail-fast: false
+      matrix:
+        app:
+          - name: ControlGallery.Desktop
+            project: samples/ControlGallery/ControlGallery.Desktop/ControlGallery.Desktop.csproj
+          - name: MauiPlanets.Desktop
+            project: showcase/MauiPlanets/MauiPlanets.Desktop/MauiPlanets.Desktop.csproj
+          - name: AlohaKit.Gallery.Desktop
+            project: showcase/AlohaKit.Gallery/AlohaKit.Gallery.Desktop/AlohaKit.Gallery.Desktop.csproj
+          - name: 2048Game.Desktop
+            project: showcase/2048Game/2048Game.Desktop/2048Game.Desktop.csproj
+        build-type:
+          - name: Release
+            publish-aot: false
+            rid: ''
+            os: ubuntu-latest
+          - name: Release-AOT
+            publish-aot: true
+            rid: linux-x64
+            os: ubuntu-latest
+
+    runs-on: ${{ matrix.build-type.os }}
+    name: ${{ matrix.app.name }} (${{ matrix.build-type.name }})
 
     steps:
       - name: Checkout
@@ -25,6 +47,7 @@ jobs:
           dotnet-quality: 'preview'
 
       - name: Install AOT dependencies
+        if: matrix.build-type.publish-aot
         run: |
           sudo apt-get update
           sudo apt-get install -y clang zlib1g-dev
@@ -33,115 +56,29 @@ jobs:
         run: |
           dotnet workload install maui-tizen --source https://api.nuget.org/v3/index.json
 
-      # ControlGallery.Desktop
-      - name: Publish ControlGallery.Desktop (Release)
+      - name: Restore
+        run: dotnet restore ${{ matrix.app.project }}
+
+      - name: Publish (Non-AOT)
+        if: ${{ !matrix.build-type.publish-aot }}
         run: |
-          dotnet publish samples/ControlGallery/ControlGallery.Desktop/ControlGallery.Desktop.csproj \
+          dotnet publish ${{ matrix.app.project }} \
             -c Release \
-            -o ./artifacts/ControlGallery.Desktop-Release \
+            -o ./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }} \
             /p:PublishAot=false
 
-      - name: Publish ControlGallery.Desktop (Release-AOT)
+      - name: Publish (AOT)
+        if: matrix.build-type.publish-aot
         run: |
-          dotnet publish samples/ControlGallery/ControlGallery.Desktop/ControlGallery.Desktop.csproj \
+          dotnet publish ${{ matrix.app.project }} \
             -c Release \
-            -r linux-x64 \
-            -o ./artifacts/ControlGallery.Desktop-Release-AOT \
+            -r ${{ matrix.build-type.rid }} \
+            -o ./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }} \
             /p:PublishAot=true
 
-      # MauiPlanets.Desktop
-      - name: Publish MauiPlanets.Desktop (Release)
-        run: |
-          dotnet publish showcase/MauiPlanets/MauiPlanets.Desktop/MauiPlanets.Desktop.csproj \
-            -c Release \
-            -o ./artifacts/MauiPlanets.Desktop-Release \
-            /p:PublishAot=false
-
-      - name: Publish MauiPlanets.Desktop (Release-AOT)
-        run: |
-          dotnet publish showcase/MauiPlanets/MauiPlanets.Desktop/MauiPlanets.Desktop.csproj \
-            -c Release \
-            -r linux-x64 \
-            -o ./artifacts/MauiPlanets.Desktop-Release-AOT \
-            /p:PublishAot=true
-
-      # AlohaKit.Gallery.Desktop
-      - name: Publish AlohaKit.Gallery.Desktop (Release)
-        run: |
-          dotnet publish showcase/AlohaKit.Gallery/AlohaKit.Gallery.Desktop/AlohaKit.Gallery.Desktop.csproj \
-            -c Release \
-            -o ./artifacts/AlohaKit.Gallery.Desktop-Release \
-            /p:PublishAot=false
-
-      - name: Publish AlohaKit.Gallery.Desktop (Release-AOT)
-        run: |
-          dotnet publish showcase/AlohaKit.Gallery/AlohaKit.Gallery.Desktop/AlohaKit.Gallery.Desktop.csproj \
-            -c Release \
-            -r linux-x64 \
-            -o ./artifacts/AlohaKit.Gallery.Desktop-Release-AOT \
-            /p:PublishAot=true
-
-      # 2048Game.Desktop
-      - name: Publish 2048Game.Desktop (Release)
-        run: |
-          dotnet publish showcase/2048Game/2048Game.Desktop/2048Game.Desktop.csproj \
-            -c Release \
-            -o ./artifacts/2048Game.Desktop-Release \
-            /p:PublishAot=false
-
-      - name: Publish 2048Game.Desktop (Release-AOT)
-        run: |
-          dotnet publish showcase/2048Game/2048Game.Desktop/2048Game.Desktop.csproj \
-            -c Release \
-            -r linux-x64 \
-            -o ./artifacts/2048Game.Desktop-Release-AOT \
-            /p:PublishAot=true
-
-      # Upload all artifacts
-      - name: Upload ControlGallery.Desktop-Release
+      - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ControlGallery.Desktop-Release
-          path: ./artifacts/ControlGallery.Desktop-Release
-
-      - name: Upload ControlGallery.Desktop-Release-AOT
-        uses: actions/upload-artifact@v4
-        with:
-          name: ControlGallery.Desktop-Release-AOT
-          path: ./artifacts/ControlGallery.Desktop-Release-AOT
-
-      - name: Upload MauiPlanets.Desktop-Release
-        uses: actions/upload-artifact@v4
-        with:
-          name: MauiPlanets.Desktop-Release
-          path: ./artifacts/MauiPlanets.Desktop-Release
-
-      - name: Upload MauiPlanets.Desktop-Release-AOT
-        uses: actions/upload-artifact@v4
-        with:
-          name: MauiPlanets.Desktop-Release-AOT
-          path: ./artifacts/MauiPlanets.Desktop-Release-AOT
-
-      - name: Upload AlohaKit.Gallery.Desktop-Release
-        uses: actions/upload-artifact@v4
-        with:
-          name: AlohaKit.Gallery.Desktop-Release
-          path: ./artifacts/AlohaKit.Gallery.Desktop-Release
-
-      - name: Upload AlohaKit.Gallery.Desktop-Release-AOT
-        uses: actions/upload-artifact@v4
-        with:
-          name: AlohaKit.Gallery.Desktop-Release-AOT
-          path: ./artifacts/AlohaKit.Gallery.Desktop-Release-AOT
-
-      - name: Upload 2048Game.Desktop-Release
-        uses: actions/upload-artifact@v4
-        with:
-          name: 2048Game.Desktop-Release
-          path: ./artifacts/2048Game.Desktop-Release
-
-      - name: Upload 2048Game.Desktop-Release-AOT
-        uses: actions/upload-artifact@v4
-        with:
-          name: 2048Game.Desktop-Release-AOT
-          path: ./artifacts/2048Game.Desktop-Release-AOT
+          name: ${{ matrix.app.name }}-${{ matrix.build-type.name }}
+          path: ./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }}
+          retention-days: 14

--- a/.github/workflows/build-desktop-samples.yml
+++ b/.github/workflows/build-desktop-samples.yml
@@ -21,18 +21,9 @@ jobs:
             project: showcase/AlohaKit.Gallery/AlohaKit.Gallery.Desktop/AlohaKit.Gallery.Desktop.csproj
           - name: 2048Game.Desktop
             project: showcase/2048Game/2048Game.Desktop/2048Game.Desktop.csproj
-        build-type:
-          - name: Release
-            publish-aot: false
-            rid: ''
-            os: ubuntu-latest
-          - name: Release-AOT
-            publish-aot: true
-            rid: linux-x64
-            os: ubuntu-latest
 
-    runs-on: ${{ matrix.build-type.os }}
-    name: ${{ matrix.app.name }} (${{ matrix.build-type.name }})
+    runs-on: ubuntu-latest
+    name: ${{ matrix.app.name }} (NativeAOT)
 
     steps:
       - name: Checkout
@@ -47,7 +38,6 @@ jobs:
           dotnet-quality: 'preview'
 
       - name: Install AOT dependencies
-        if: matrix.build-type.publish-aot
         run: |
           sudo apt-get update
           sudo apt-get install -y clang zlib1g-dev
@@ -59,25 +49,15 @@ jobs:
       - name: Restore
         run: dotnet restore ${{ matrix.app.project }}
 
-      - name: Publish (Non-AOT)
-        if: ${{ !matrix.build-type.publish-aot }}
+      - name: Publish (NativeAOT)
         run: |
           dotnet publish ${{ matrix.app.project }} \
             -c Release \
-            -o ./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }} \
-            /p:PublishAOT=false
-
-      - name: Publish (AOT)
-        if: matrix.build-type.publish-aot
-        run: |
-          dotnet publish ${{ matrix.app.project }} \
-            -c Release \
-            -r ${{ matrix.build-type.rid }} \
-            -o ./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }} \
+            -r linux-x64 \
+            -o ./artifacts/${{ matrix.app.name }} \
             /p:PublishAOT=true
 
-      - name: Create AppImage (AOT)
-        if: matrix.build-type.publish-aot
+      - name: Create AppImage
         run: |
           # Download appimagetool
           wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
@@ -88,7 +68,7 @@ jobs:
 
           APP_NAME="${{ matrix.app.name }}"
           APP_DIR="./AppDir"
-          PUBLISH_DIR="./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }}"
+          PUBLISH_DIR="./artifacts/${{ matrix.app.name }}"
 
           # Find the main executable (assumes it matches the app name pattern)
           EXECUTABLE=$(find "$PUBLISH_DIR" -maxdepth 1 -type f -executable -name "*.Desktop" | head -1)
@@ -135,16 +115,8 @@ jobs:
           chmod +x "./artifacts/$APP_NAME-x86_64.AppImage"
 
       - name: Upload AppImage
-        if: matrix.build-type.publish-aot
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.app.name }}-AppImage
           path: ./artifacts/${{ matrix.app.name }}-x86_64.AppImage
-          retention-days: 14
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.app.name }}-${{ matrix.build-type.name }}
-          path: ./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }}
           retention-days: 14

--- a/.github/workflows/build-desktop-samples.yml
+++ b/.github/workflows/build-desktop-samples.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install maui-tizen workload
         run: |
-          dotnet workload install maui-tizen
+          dotnet workload install maui-tizen --source https://api.nuget.org/v3/index.json
 
       # ControlGallery.Desktop
       - name: Publish ControlGallery.Desktop (Release)

--- a/.github/workflows/build-desktop-samples.yml
+++ b/.github/workflows/build-desktop-samples.yml
@@ -131,6 +131,9 @@ jobs:
           # Build the AppImage
           ARCH=x86_64 ./squashfs-root/AppRun "$APP_DIR" "./artifacts/$APP_NAME-x86_64.AppImage"
 
+          # Make the AppImage executable
+          chmod +x "./artifacts/$APP_NAME-x86_64.AppImage"
+
       - name: Upload AppImage
         if: matrix.build-type.publish-aot
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-desktop-samples.yml
+++ b/.github/workflows/build-desktop-samples.yml
@@ -65,7 +65,7 @@ jobs:
           dotnet publish ${{ matrix.app.project }} \
             -c Release \
             -o ./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }} \
-            /p:PublishAot=false
+            /p:PublishAOT=false
 
       - name: Publish (AOT)
         if: matrix.build-type.publish-aot
@@ -74,7 +74,7 @@ jobs:
             -c Release \
             -r ${{ matrix.build-type.rid }} \
             -o ./artifacts/${{ matrix.app.name }}-${{ matrix.build-type.name }} \
-            /p:PublishAot=true
+            /p:PublishAOT=true
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,8 @@
         <Nullable>enable</Nullable>
         <ValidateXcodeVersion>false</ValidateXcodeVersion>
         <AddMauiInternals>false</AddMauiInternals>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <NoWarn>$(NoWarn);CS0618;CS8002</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(DotNetTfm)' == 'net10.0'">

--- a/samples/ControlGallery/ControlGallery/MainPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/MainPage.xaml.cs
@@ -8,6 +8,77 @@ public partial class MainPage : FlyoutPage
 {
     private List<SampleGroup> _allSamples = new List<SampleGroup>();
 
+    // Static page factory for AOT compatibility - no reflection
+    private static readonly Dictionary<Type, Func<Page>> PageFactory = new()
+    {
+        // Apps
+        [typeof(RpnCalculator.MainPage)] = () => new RpnCalculator.MainPage(),
+        [typeof(SolitaireEncryption.SolitairePage)] = () => new SolitaireEncryption.SolitairePage(),
+        [typeof(TipCalc.TipCalcPage)] = () => new TipCalc.TipCalcPage(),
+        [typeof(Weather.MainPage)] = () => new Weather.MainPage(),
+        [typeof(WordPuzzle.MainPage)] = () => new WordPuzzle.MainPage(),
+        // Services
+        [typeof(FontsPage)] = () => new FontsPage(),
+        // Pages
+        [typeof(NavigationDemoPage)] = () => new NavigationPage(new NavigationDemoPage()),
+        [typeof(ControlGallery.Pages.TabbedPage)] = () => new ControlGallery.Pages.TabbedPage(),
+        [typeof(TitleBarPage)] = () => new TitleBarPage(),
+        [typeof(PopupsPage)] = () => new PopupsPage(),
+        // Layout
+        [typeof(StackLayoutPage)] = () => new StackLayoutPage(),
+        [typeof(GridPage)] = () => new GridPage(),
+        [typeof(FlexLayoutPage)] = () => new FlexLayoutPage(),
+        [typeof(AbsoluteLayoutPage)] = () => new AbsoluteLayoutPage(),
+        // Views
+        [typeof(ActivityIndicatorPage)] = () => new ActivityIndicatorPage(),
+        [typeof(BorderPage)] = () => new BorderPage(),
+        [typeof(BoxViewPage)] = () => new BoxViewPage(),
+        [typeof(ButtonPage)] = () => new ButtonPage(),
+        [typeof(CheckBoxPage)] = () => new CheckBoxPage(),
+        [typeof(CollectionViewPage)] = () => new CollectionViewPage(),
+        [typeof(ContentViewPage)] = () => new ContentViewPage(),
+        [typeof(DatePickerPage)] = () => new DatePickerPage(),
+        [typeof(EditorPage)] = () => new EditorPage(),
+        [typeof(FramePage)] = () => new FramePage(),
+        [typeof(GraphicsViewPage)] = () => new GraphicsViewPage(),
+        [typeof(ImagePage)] = () => new ImagePage(),
+        [typeof(ImageButtonPage)] = () => new ImageButtonPage(),
+        [typeof(PickerPage)] = () => new PickerPage(),
+        [typeof(ProgressBarPage)] = () => new ProgressBarPage(),
+        [typeof(RadioButtonPage)] = () => new RadioButtonPage(),
+        [typeof(ScrollViewPage)] = () => new ScrollViewPage(),
+        [typeof(SearchBarPage)] = () => new SearchBarPage(),
+        [typeof(SliderPage)] = () => new SliderPage(),
+        [typeof(StepperPage)] = () => new StepperPage(),
+        [typeof(SwipeViewPage)] = () => new SwipeViewPage(),
+        [typeof(SwitchPage)] = () => new SwitchPage(),
+        [typeof(TableViewPage)] = () => new TableViewPage(),
+        [typeof(TimePickerPage)] = () => new TimePickerPage(),
+        // Effects
+        [typeof(ClipPage)] = () => new ClipPage(),
+        [typeof(ShadowPage)] = () => new ShadowPage(),
+        [typeof(TransformationsPage)] = () => new TransformationsPage(),
+        // Shapes
+        [typeof(RectanglePage)] = () => new RectanglePage(),
+        [typeof(EllipsePage)] = () => new EllipsePage(),
+        [typeof(LinePage)] = () => new LinePage(),
+        [typeof(PolygonPage)] = () => new PolygonPage(),
+        [typeof(PolylinePage)] = () => new PolylinePage(),
+        [typeof(PathPage)] = () => new PathPage(),
+        [typeof(RoundRectanglePage)] = () => new RoundRectanglePage(),
+        // Core
+        [typeof(AnimationPage)] = () => new AnimationPage(),
+        [typeof(BehaviorsPage)] = () => new BehaviorsPage(),
+        [typeof(BrushesPage)] = () => new BrushesPage(),
+        [typeof(GesturesPage)] = () => new GesturesPage(),
+        [typeof(StylesPage)] = () => new StylesPage(),
+        [typeof(TooltipsPage)] = () => new TooltipsPage(),
+        [typeof(TriggersPage)] = () => new TriggersPage(),
+        [typeof(VisualStateManagerPage)] = () => new VisualStateManagerPage(),
+        // Settings
+        [typeof(ThemePage)] = () => new ThemePage(),
+    };
+
     public ObservableCollection<SampleGroup> FilteredSamples { get; private set; } = new ObservableCollection<SampleGroup>();
     public ICommand NavigateCommand { get; private set; }
 
@@ -19,7 +90,7 @@ public partial class MainPage : FlyoutPage
 
         InitializeSamples();
         UpdateMenu(string.Empty);
-        
+
         // Navigate to Welcome Page by default
         Detail = new WelcomePage();
     }
@@ -171,19 +242,10 @@ public partial class MainPage : FlyoutPage
 
     private void NavigateToPage(Type pageType)
     {
-        Page? page = null;
-
-        // Custom instantiation logic for specific pages if needed
-        if (pageType == typeof(NavigationDemoPage))
+        if (PageFactory.TryGetValue(pageType, out var factory))
         {
-            page = new NavigationPage(new NavigationDemoPage());
+            Detail = factory();
         }
-        else
-        {
-            page = (Page)Activator.CreateInstance(pageType)!;
-        }
-
-        Detail = page;
     }
 }
 

--- a/samples/ControlGallery/ControlGallery/Pages/TabbedPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/TabbedPage.xaml.cs
@@ -406,8 +406,8 @@ public partial class TabbedPage : ContentPage
         tabbedPage.ItemTemplate = new DataTemplate(() =>
         {
             var page = new ContentPage();
-            page.SetBinding(ContentPage.TitleProperty, "Title");
-            
+            page.SetBinding(ContentPage.TitleProperty, static (TabInfo t) => t.Title);
+
             var content = new VerticalStackLayout
             {
                 Spacing = 15,
@@ -427,11 +427,11 @@ public partial class TabbedPage : ContentPage
             };
 
             var titleLabel = new Label { FontSize = 28, FontAttributes = FontAttributes.Bold, HorizontalOptions = LayoutOptions.Center };
-            titleLabel.SetBinding(Label.TextProperty, "Title");
+            titleLabel.SetBinding(Label.TextProperty, static (TabInfo t) => t.Title);
             content.Children.Add(titleLabel);
 
             var descLabel = new Label { FontSize = 16, HorizontalOptions = LayoutOptions.Center };
-            descLabel.SetBinding(Label.TextProperty, "Description");
+            descLabel.SetBinding(Label.TextProperty, static (TabInfo t) => t.Description);
             content.Children.Add(descLabel);
 
             page.Content = content;
@@ -470,8 +470,8 @@ public partial class TabbedPage : ContentPage
         tabbedPage.ItemTemplate = new DataTemplate(() =>
         {
             var page = new ContentPage();
-            page.SetBinding(ContentPage.TitleProperty, "Title");
-            
+            page.SetBinding(ContentPage.TitleProperty, static (TabInfo t) => t.Title);
+
             var content = new VerticalStackLayout
             {
                 Spacing = 15,
@@ -491,11 +491,11 @@ public partial class TabbedPage : ContentPage
             };
 
             var titleLabel = new Label { FontSize = 28, FontAttributes = FontAttributes.Bold, HorizontalOptions = LayoutOptions.Center };
-            titleLabel.SetBinding(Label.TextProperty, "Title");
+            titleLabel.SetBinding(Label.TextProperty, static (TabInfo t) => t.Title);
             content.Children.Add(titleLabel);
 
             var descLabel = new Label { FontSize = 16, HorizontalOptions = LayoutOptions.Center };
-            descLabel.SetBinding(Label.TextProperty, "Description");
+            descLabel.SetBinding(Label.TextProperty, static (TabInfo t) => t.Description);
             content.Children.Add(descLabel);
 
             page.Content = content;

--- a/samples/SandboxApp/SandboxApp.csproj
+++ b/samples/SandboxApp/SandboxApp.csproj
@@ -7,6 +7,7 @@
 		<AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
 		<UseMaui>true</UseMaui>
 		<_MauiTargetPlatformIsAvalonia>True</_MauiTargetPlatformIsAvalonia>
+		<TreatWarningsAsErrors>false</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/SandboxAppWasm/MainPage.xaml.cs
+++ b/samples/SandboxAppWasm/MainPage.xaml.cs
@@ -5,8 +5,6 @@ namespace SandboxApp;
 
 public partial class MainPage : ContentPage
 {
-    int count = 0;
-
     public MainPage()
     {
         InitializeComponent();

--- a/samples/SandboxAppWasm/SandboxAppWasm.csproj
+++ b/samples/SandboxAppWasm/SandboxAppWasm.csproj
@@ -8,6 +8,7 @@
 		<UseMaui>true</UseMaui>
 		<_MauiTargetPlatformIsAvalonia>True</_MauiTargetPlatformIsAvalonia>
 		<RootNamespace>SandboxApp</RootNamespace>
+		<TreatWarningsAsErrors>false</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/showcase/2048Game/2048Game/Converters/EnumToBoolConverter.cs
+++ b/showcase/2048Game/2048Game/Converters/EnumToBoolConverter.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace _2048Game.Converters
@@ -14,6 +15,8 @@ namespace _2048Game.Converters
             return value.Equals(TrueValue);
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+            Justification = "Binding.DoNothing is a static sentinel value, safe for AOT")]
         public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             if (value is bool boolValue && boolValue)

--- a/showcase/2048Game/2048Game/MainPage.xaml
+++ b/showcase/2048Game/2048Game/MainPage.xaml
@@ -33,7 +33,7 @@
         </Style>
     </ContentPage.Resources>
     <Grid x:Name="MainGrid"
-          Margin="{OnPlatform Android='0,30,0,0', iOS=0}" RowDefinitions="Auto,*,Auto">
+          Margin="0" RowDefinitions="Auto,*,Auto">
             <Grid
                 Padding="20"
                 Grid.Row="0"

--- a/showcase/2048Game/2048Game/Resources/Styles/Styles.xaml
+++ b/showcase/2048Game/2048Game/Resources/Styles/Styles.xaml
@@ -355,7 +355,7 @@
 
     <Style ApplyToDerivedTypes="True" TargetType="Shell">
         <Setter Property="Shell.BackgroundColor" Value="{AppThemeBinding Light={StaticResource ButtonColorLight}, Dark={StaticResource GameBackgroundDark}}" />
-        <Setter Property="Shell.ForegroundColor" Value="{OnPlatform WinUI={StaticResource ButtonColorLight}, Default={StaticResource White}}" />
+        <Setter Property="Shell.ForegroundColor" Value="{StaticResource White}" />
         <Setter Property="Shell.TitleColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource White}}" />
         <Setter Property="Shell.DisabledColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray950}}" />
         <Setter Property="Shell.UnselectedColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray200}}" />

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/AlohaKit.Gallery.csproj
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/AlohaKit.Gallery.csproj
@@ -5,6 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<UseMaui>true</UseMaui>
+		<MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation> 
 	</PropertyGroup>
 
 	<PropertyGroup Label="AOT Validation">

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/ViewModels/Base/BaseGalleryViewModel.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/ViewModels/Base/BaseGalleryViewModel.cs
@@ -8,8 +8,7 @@ namespace AlohaKit.Gallery.ViewModels.Base
         {
             var items = CreateItems();
 
-            if (items != null)
-                Items = items.ToList();
+            Items = items?.ToList() ?? [];
         }
 
         public IReadOnlyList<SectionModel> Items { get; }

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/ViewModels/Base/BaseViewModel.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/ViewModels/Base/BaseViewModel.cs
@@ -7,7 +7,7 @@ namespace AlohaKit.Gallery.ViewModels
 	{
 		protected bool SetProperty<T>(ref T backingStore, T value,
 		[CallerMemberName] string propertyName = "",
-		Action onChanged = null)
+		Action? onChanged = null)
 		{
 			if (EqualityComparer<T>.Default.Equals(backingStore, value))
 				return false;
@@ -20,7 +20,7 @@ namespace AlohaKit.Gallery.ViewModels
 
 		#region INotifyPropertyChanged
 
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged;
 		protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
 		{
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/AvatarView.xaml.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/AvatarView.xaml.cs
@@ -42,7 +42,7 @@ public partial class AvatarView : ContentPage
         }
     }
 
-    Color GetColorFromString(string value)
+    Color? GetColorFromString(string value)
     {
         if (string.IsNullOrEmpty(value))
             return null;

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/BarChartView.xaml
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/BarChartView.xaml
@@ -3,7 +3,9 @@
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:cv="clr-namespace:AlohaKit.Controls;assembly=AlohaKit"
+	xmlns:views="clr-namespace:AlohaKit.Gallery.Views"
 	x:Name="thisView"
+	x:DataType="views:BarChartView"
 	BackgroundColor="{DynamicResource WhiteColor}"
 	x:Class="AlohaKit.Gallery.Views.BarChartView">
 	<ScrollView

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/Base/BasePage.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/Base/BasePage.cs
@@ -1,11 +1,38 @@
 ﻿using AlohaKit.Gallery.Models;
 using System.Windows.Input;
 
+// View types for AOT page factory
+using AlohaKit.Gallery;
+
 namespace AlohaKit.Gallery.Views.Base
 {
 	public class BasePage : ContentPage
 	{
 		SectionModel? _selectedItem;
+
+		// Static page factory for AOT compatibility - no reflection
+		private static readonly Dictionary<Type, Func<Page>> PageFactory = new()
+		{
+			[typeof(AvatarView)] = () => new AvatarView(),
+			[typeof(LoadingView)] = () => new LoadingView(),
+			[typeof(ButtonView)] = () => new ButtonView(),
+			[typeof(CaptchaView)] = () => new CaptchaView(),
+			[typeof(CheckBoxView)] = () => new CheckBoxView(),
+			[typeof(LinearGaugeView)] = () => new LinearGaugeView(),
+			[typeof(NumericUpDownView)] = () => new NumericUpDownView(),
+			[typeof(PieChartView)] = () => new PieChartView(),
+			[typeof(PulseIconView)] = () => new PulseIconView(),
+			[typeof(ProgressBarView)] = () => new ProgressBarView(),
+			[typeof(ProgressRadialView)] = () => new ProgressRadialView(),
+			[typeof(SegmentedControlView)] = () => new SegmentedControlView(),
+			[typeof(RatingView)] = () => new RatingView(),
+			[typeof(SliderView)] = () => new SliderView(),
+			[typeof(ToggleSwitchView)] = () => new ToggleSwitchView(),
+			[typeof(BarChartView)] = () => new BarChartView(),
+			[typeof(LineChartView)] = () => new LineChartView(),
+			[typeof(MultiBarChartView)] = () => new MultiBarChartView(),
+			[typeof(MultiLineChartView)] = () => new MultiLineChartView(),
+		};
 
 		public BasePage()
 		{
@@ -34,7 +61,8 @@ namespace AlohaKit.Gallery.Views.Base
 
 		Page PreparePage(SectionModel model)
 		{
-			var page = (Handler?.MauiContext?.Services?.GetService(model.Type) as Page) ?? (Page)Activator.CreateInstance(model.Type)!;
+			var page = (Handler?.MauiContext?.Services?.GetService(model.Type) as Page)
+				?? (PageFactory.TryGetValue(model.Type, out var factory) ? factory() : throw new InvalidOperationException($"No factory registered for {model.Type}"));
 			page.Title = model.Title;
 
 			return page;

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/Base/BasePage.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/Base/BasePage.cs
@@ -5,14 +5,14 @@ namespace AlohaKit.Gallery.Views.Base
 {
 	public class BasePage : ContentPage
 	{
-		SectionModel _selectedItem;
+		SectionModel? _selectedItem;
 
 		public BasePage()
 		{
 			NavigateCommand = new Command(async () =>
 			{
 				if (SelectedItem != null)
-				{	
+				{
 					await Navigation.PushAsync(PreparePage(SelectedItem));
 
 					SelectedItem = null;
@@ -22,7 +22,7 @@ namespace AlohaKit.Gallery.Views.Base
 
 		public ICommand NavigateCommand { get; }
 
-		public SectionModel SelectedItem
+		public SectionModel? SelectedItem
 		{
 			get { return _selectedItem; }
 			set
@@ -34,7 +34,7 @@ namespace AlohaKit.Gallery.Views.Base
 
 		Page PreparePage(SectionModel model)
 		{
-			var page = (Handler?.MauiContext?.Services?.GetService(model.Type) as Page) ?? (Page)Activator.CreateInstance(model.Type);
+			var page = (Handler?.MauiContext?.Services?.GetService(model.Type) as Page) ?? (Page)Activator.CreateInstance(model.Type)!;
 			page.Title = model.Title;
 
 			return page;

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/ButtonView.xaml
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/ButtonView.xaml
@@ -120,6 +120,7 @@
 						<Label
                             Grid.Column="1"
                             VerticalOptions="Center"
+                            x:DataType="Slider"
                             Text="{Binding Source={x:Reference StrokeThicknessSlider}, Path=Value, StringFormat='{0:F2}'}"/>
 					</Grid>
 				</Grid>
@@ -216,9 +217,10 @@
 					Style="{StaticResource SettingsEntryStyle}"/>
 			</StackLayout>
 		</StackLayout>
-		<controls:Button 
+		<controls:Button
             Grid.Row="3"
             x:Name="Button"
+            x:DataType="Slider"
             Text="Button"
             TextColor="White"
             StrokeThickness="{Binding Source={x:Reference StrokeThicknessSlider}, Path=Value}"

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/ButtonView.xaml.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/ButtonView.xaml.cs
@@ -160,7 +160,7 @@ public partial class ButtonView : ContentPage
 	}
 
 
-	Color GetColorFromString(string value)
+	Color? GetColorFromString(string value)
 	{
 		if (string.IsNullOrEmpty(value))
 			return null;

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/CaptchaView.xaml.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/CaptchaView.xaml.cs
@@ -25,7 +25,7 @@ public partial class CaptchaView : ContentPage
 		}
 	}
 
-	Color GetColorFromString(string value)
+	Color? GetColorFromString(string value)
 	{
 		if (string.IsNullOrEmpty(value))
 			return null;

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/CheckBoxView.xaml.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/CheckBoxView.xaml.cs
@@ -54,7 +54,7 @@ public partial class CheckBoxView : ContentPage
         }
     }
 
-    Color GetColorFromString(string value)
+    Color? GetColorFromString(string value)
     {
         if (string.IsNullOrEmpty(value))
             return null;

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/LineChartView.xaml
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/LineChartView.xaml
@@ -3,7 +3,9 @@
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:cv="clr-namespace:AlohaKit.Controls;assembly=AlohaKit"
+	xmlns:views="clr-namespace:AlohaKit.Gallery.Views"
 	x:Name="thisView"
+	x:DataType="views:LineChartView"
 	BackgroundColor="{DynamicResource WhiteColor}"
 	x:Class="AlohaKit.Gallery.Views.LineChartView">
 	<ScrollView

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/LinearGaugeView.xaml
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/LinearGaugeView.xaml
@@ -104,6 +104,7 @@
                         <Label
                             Grid.Column="1"
                             VerticalOptions="Center"
+                            x:DataType="Slider"
                             Text="{Binding Source={x:Reference ValueSlider}, Path=Value, StringFormat='{0:F2}'}"/>
                     </Grid>
                 </Grid>
@@ -111,7 +112,8 @@
         </StackLayout>
         <controls:LinearGauge
             x:Name="LinearGauge"
-            Grid.Row="3" 
+            x:DataType="Slider"
+            Grid.Row="3"
             RangeStart="0"
             RangeEnd="100"
             Value="{Binding Source={x:Reference ValueSlider}, Path=Value}"

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/LinearGaugeView.xaml.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/LinearGaugeView.xaml.cs
@@ -42,7 +42,7 @@ public partial class LinearGaugeView : ContentPage
         }
     }
 
-    Color GetColorFromString(string value)
+    Color? GetColorFromString(string value)
     {
         if (string.IsNullOrEmpty(value))
             return null;

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/LoadingView.xaml.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/LoadingView.xaml.cs
@@ -48,7 +48,7 @@ public partial class LoadingView : ContentPage
         }
     }
 
-    Color GetColorFromString(string value)
+    Color? GetColorFromString(string value)
     {
         if (string.IsNullOrEmpty(value))
             return null;

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/MainView.xaml
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/MainView.xaml
@@ -87,8 +87,8 @@
                     BackgroundColor="Transparent"
                     ItemsSource="{Binding Items}"
                     SelectionMode="Single"
-                    SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}, Mode=TwoWay}"
-                    SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}}"
+                    SelectedItem="{Binding SelectedItem, Source={x:Reference MainPage}, Mode=TwoWay, x:DataType=views:BasePage}"
+                    SelectionChangedCommand="{Binding NavigateCommand, Source={x:Reference MainPage}, x:DataType=views:BasePage}"
                     Margin="6, 12, 6, 0">
                     <CollectionView.ItemsLayout>
                         <GridItemsLayout

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/MainView.xaml
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/MainView.xaml
@@ -6,6 +6,8 @@
     x:Class="AlohaKit.Gallery.MainView"
     xmlns:views="clr-namespace:AlohaKit.Gallery.Views.Base"
     xmlns:viewmodels="clr-namespace:AlohaKit.Gallery.ViewModels"
+    xmlns:models="clr-namespace:AlohaKit.Gallery.Models"
+    x:DataType="viewmodels:MainViewModel"
     Title="AlohaKit Gallery">
     <views:BasePage.Resources>
         <ResourceDictionary>
@@ -79,13 +81,14 @@
             <Grid
                 Grid.Row="1"
                 Margin="12">
-                <CollectionView 
+                <CollectionView
                     x:Name="HomeSections"
+                    x:DataType="viewmodels:MainViewModel"
                     BackgroundColor="Transparent"
                     ItemsSource="{Binding Items}"
-                    SelectionMode="Single"    
-                    SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type ContentPage}}, Mode=TwoWay}"
-                    SelectionChangedCommand="{Binding NavigateCommand, Source={x:Reference MainPage}}"
+                    SelectionMode="Single"
+                    SelectedItem="{Binding SelectedItem, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}, Mode=TwoWay}"
+                    SelectionChangedCommand="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type views:BasePage}}}"
                     Margin="6, 12, 6, 0">
                     <CollectionView.ItemsLayout>
                         <GridItemsLayout
@@ -95,7 +98,7 @@
                             VerticalItemSpacing="6"/>
                     </CollectionView.ItemsLayout>
                     <CollectionView.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="models:SectionModel">
                             <Border
                                Style="{StaticResource SectionItemContainerStyle}">
                                 <Border.StrokeShape>

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/MultiBarChartView.xaml
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/MultiBarChartView.xaml
@@ -3,7 +3,9 @@
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:cv="clr-namespace:AlohaKit.Controls;assembly=AlohaKit"
+	xmlns:views="clr-namespace:AlohaKit.Gallery.Views"
 	x:Name="thisView"
+	x:DataType="views:MultiBarChartView"
 	BackgroundColor="{DynamicResource WhiteColor}"
 	x:Class="AlohaKit.Gallery.Views.MultiBarChartView">
 	<ScrollView

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/MultiLineChartView.xaml
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/MultiLineChartView.xaml
@@ -3,7 +3,9 @@
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:cv="clr-namespace:AlohaKit.Controls;assembly=AlohaKit"
+	xmlns:views="clr-namespace:AlohaKit.Gallery.Views"
 	x:Name="thisView"
+	x:DataType="views:MultiLineChartView"
 	BackgroundColor="{DynamicResource WhiteColor}"
 	x:Class="AlohaKit.Gallery.Views.MultiLineChartView">
 	<ScrollView

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/NumericUpDownView.xaml.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/NumericUpDownView.xaml.cs
@@ -96,7 +96,7 @@ public partial class NumericUpDownView : ContentPage
         }
     }
 
-    Color GetColorFromString(string value)
+    Color? GetColorFromString(string value)
     {
         if (string.IsNullOrEmpty(value))
             return null;

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/PieChartView.xaml
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/PieChartView.xaml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentPage 
+<ContentPage
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="AlohaKit.Gallery.PieChartView"
     xmlns:controls="clr-namespace:AlohaKit.Controls;assembly=AlohaKit"
+    xmlns:viewmodels="clr-namespace:AlohaKit.Gallery.ViewModels"
+    x:DataType="viewmodels:ChartViewModel"
     Title="PieChart">
 	<ContentPage.Resources>
 		<ResourceDictionary>
@@ -75,9 +77,8 @@
             VerticalOptions="Center">
 			<controls:PieChart
 				x:Name="PieChart"
-				x:DataType="CheckBox"
 				ItemsSource="{Binding Items}"
-				ShowLabels="{Binding Source={x:Reference HasShowLabels}, Path=IsChecked}"/>
+				ShowLabels="{Binding Source={x:Reference HasShowLabels}, Path=IsChecked, x:DataType=CheckBox}"/>
 		</Grid>
 	</Grid>
 </ContentPage>

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/PieChartView.xaml
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/PieChartView.xaml
@@ -73,8 +73,9 @@
             Grid.Row="3"
             HorizontalOptions="Center"
             VerticalOptions="Center">
-			<controls:PieChart 
+			<controls:PieChart
 				x:Name="PieChart"
+				x:DataType="CheckBox"
 				ItemsSource="{Binding Items}"
 				ShowLabels="{Binding Source={x:Reference HasShowLabels}, Path=IsChecked}"/>
 		</Grid>

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/ProgressBarView.xaml
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/ProgressBarView.xaml
@@ -75,6 +75,7 @@
                                 Value="0.5" />
                             <Label
                                 Grid.Column="1"
+                                x:DataType="Slider"
                                 Text="{Binding Source={x:Reference ValueSlider}, Path=Value, StringFormat='{0:F2}'}"
                                 VerticalOptions="Center" />
                         </Grid>
@@ -164,6 +165,7 @@
                     WidthRequest="120"
                     HeightRequest="18"
                     x:Name="HorizontalProgressBar"
+                    x:DataType="Slider"
                     Margin="12"
                     HorizontalOptions="Center"
                     Progress="{Binding Source={x:Reference ValueSlider}, Path=Value}"
@@ -173,6 +175,7 @@
                     HeightRequest="120"
                     IsVertical="True"
                     x:Name="VerticalProgressBar"
+                    x:DataType="Slider"
                     Grid.Column="1"
                     Margin="12"
                     HorizontalOptions="Center"

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/ProgressBarView.xaml.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/ProgressBarView.xaml.cs
@@ -73,7 +73,7 @@ public partial class ProgressBarView : ContentPage
 		}
 	}
 
-	Color GetColorFromString(string value)
+	Color? GetColorFromString(string value)
     {
         if (string.IsNullOrEmpty(value))
             return null;
@@ -90,14 +90,14 @@ public partial class ProgressBarView : ContentPage
 
     private void stylePicker_SelectedIndexChanged(object sender, EventArgs e)
     {
-        var selectedItem = (sender as Picker).SelectedItem as string;
-		HorizontalProgressBar.RoundCorners = selectedItem == "Rounded" ? true : false;
-		VerticalProgressBar.RoundCorners = selectedItem == "Rounded" ? true : false;
+        var selectedItem = (sender as Picker)?.SelectedItem as string;
+		HorizontalProgressBar.RoundCorners = selectedItem == "Rounded";
+		VerticalProgressBar.RoundCorners = selectedItem == "Rounded";
 	}
 
     private void CheckAnimate_CheckedChanged(object sender, CheckedChangedEventArgs e)
     {
-        var isChecked = (sender as CheckBox).IsChecked;
+        var isChecked = (sender as CheckBox)?.IsChecked ?? false;
 		HorizontalProgressBar.EnableAnimations = isChecked;
 		VerticalProgressBar.EnableAnimations = isChecked;
 	}

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/ProgressRadialView.xaml
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/ProgressRadialView.xaml
@@ -81,6 +81,7 @@
                         <Label
                             Grid.Column="1"
                             VerticalOptions="Center"
+                            x:DataType="Slider"
                             Text="{Binding Source={x:Reference ValueSlider}, Path=Value, StringFormat='{0:F2}'}"/>
                     </Grid>
                 </Grid>
@@ -136,9 +137,10 @@
                     StrokeThickness="3"/>
             </StackLayout>
         </StackLayout>
-        <controls:ProgressRadial 
+        <controls:ProgressRadial
             Grid.Row="3"
             x:Name="ProgressRadial"
+            x:DataType="Slider"
             Maximum="10"
             Direction="RightToLeft"
             Value="{Binding Source={x:Reference ValueSlider}, Path=Value}"

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/ProgressRadialView.xaml.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/ProgressRadialView.xaml.cs
@@ -12,7 +12,7 @@ public partial class ProgressRadialView : ContentPage
         checkBox.IsChecked = ProgressRadial.Direction == ProgressRadialDirection.LeftToRight ? true : false;
     }
 
-    private void CheckBox_CheckedChanged(object sender, CheckedChangedEventArgs e)
+    private void CheckBox_CheckedChanged(object? sender, CheckedChangedEventArgs e)
     {
         ProgressRadial.Direction = e.Value ? ProgressRadialDirection.LeftToRight : ProgressRadialDirection.RightToLeft;
     }
@@ -56,7 +56,7 @@ public partial class ProgressRadialView : ContentPage
         }
     }
 
-    Color GetColorFromString(string value)
+    Color? GetColorFromString(string value)
     {
         if (string.IsNullOrEmpty(value))
             return null;

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/PulseIconView.xaml.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/PulseIconView.xaml.cs
@@ -37,7 +37,7 @@ public partial class PulseIconView : ContentPage
         }
     }
 
-    Color GetColorFromString(string value)
+    Color? GetColorFromString(string value)
     {
         if (string.IsNullOrEmpty(value))
             return null;

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/RatingView.xaml
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/RatingView.xaml
@@ -83,6 +83,7 @@
                         <Label
                             Grid.Column="1"
                             VerticalOptions="Center"
+                            x:DataType="Slider"
                             Text="{Binding Source={x:Reference ValueSlider}, Path=Value, StringFormat='{0:F2}'}"/>
                     </Grid>
                 </Grid>
@@ -139,6 +140,7 @@
         <controls:Rating
             Grid.Row="3"
             x:Name="Rating"
+            x:DataType="Slider"
             Value="{Binding Source={x:Reference ValueSlider}, Path=Value}"/>
     </Grid>
 </ContentPage>

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/RatingView.xaml.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/RatingView.xaml.cs
@@ -60,7 +60,7 @@ public partial class RatingView : ContentPage
         }
     }
 
-    Color GetColorFromString(string value)
+    Color? GetColorFromString(string value)
     {
         if (string.IsNullOrEmpty(value))
             return null;

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/SliderView.xaml
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/SliderView.xaml
@@ -125,7 +125,7 @@
             </StackLayout>
         </StackLayout>
         <VerticalStackLayout Grid.Row="3">
-            <Label HorizontalOptions="Center" Text="{Binding Source={x:Reference Slider}, Path=Value}" />
+            <Label HorizontalOptions="Center" x:DataType="controls:Slider" Text="{Binding Source={x:Reference Slider}, Path=Value}" />
             <controls:Slider x:Name="Slider" />
         </VerticalStackLayout>
     </Grid>

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/SliderView.xaml.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/SliderView.xaml.cs
@@ -102,7 +102,7 @@ public partial class SliderView : ContentPage
         }
     }
 
-    Color GetColorFromString(string value)
+    Color? GetColorFromString(string value)
     {
         if (string.IsNullOrEmpty(value))
             return null;

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/ToggleSwitchView.xaml
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/ToggleSwitchView.xaml
@@ -126,6 +126,7 @@
         <controls:ToggleSwitch
             Grid.Row="3"
             x:Name="ToggleSwitch"
+            x:DataType="CheckBox"
             HorizontalOptions="Center"
             HasShadow="{Binding Source={x:Reference HasShadowCheckBox}, Path=IsChecked}"/>
     </Grid>

--- a/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/ToggleSwitchView.xaml.cs
+++ b/showcase/AlohaKit.Gallery/AlohaKit.Gallery/Views/ToggleSwitchView.xaml.cs
@@ -72,7 +72,7 @@ public partial class ToggleSwitchView : ContentPage
         }
     }
 
-    Color GetColorFromString(string value)
+    Color? GetColorFromString(string value)
     {
         if (string.IsNullOrEmpty(value))
             return null;

--- a/src/Avalonia.Controls.Maui/Controls/MauiTableView/MauiTableView.cs
+++ b/src/Avalonia.Controls.Maui/Controls/MauiTableView/MauiTableView.cs
@@ -2,10 +2,9 @@ using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Templates;
 using Avalonia.Layout;
 using Avalonia.Controls.Maui.Platform;
-using Microsoft.Maui;
-using Avalonia.Data.Converters;
 using Avalonia.Controls.Maui.Extensions;
 using Avalonia.Media;
+using Microsoft.Maui;
 
 namespace Avalonia.Controls.Maui;
 
@@ -239,72 +238,50 @@ public class MauiTableView : MauiView
 
                         // Height logic following MAUI TableView behavior:
                         // - Cell.Height defaults to -1 (auto-size)
-                        // - RowHeight defaults to -1 (auto-size) 
+                        // - RowHeight defaults to -1 (auto-size)
                         // - HasUnevenRows defaults to false
                         // - DefaultCellHeight = 40 (per MAUI source)
                         // When HasUnevenRows=true: use Cell.Height if > 0, otherwise auto-size
                         // When HasUnevenRows=false: use RowHeight if > 0, otherwise auto-size (cells have MinHeight)
                         var capturedCell = cell; // Capture for closure
-                        
-#pragma warning disable IL2026, IL3050
-                        var heightBinding = new Data.MultiBinding
+                        var tableView = this; // Capture for closure
+
+                        void UpdateGridHeight()
                         {
-                            Converter = new FuncMultiValueConverter<object, double>(values =>
+                            int rowHeight = tableView.RowHeight;
+                            bool hasUnevenRows = tableView.HasUnevenRows;
+                            double cellHeight = capturedCell.Height;
+
+                            if (hasUnevenRows)
                             {
-                                var valueList = values?.ToList();
-                                if (valueList == null || valueList.Count < 2)
-                                    return double.NaN;
-
-                                // Parse RowHeight (defaults to -1 in MAUI)
-                                int rowHeight = -1;
-                                if (valueList[0] is int rh)
-                                    rowHeight = rh;
-                                else if (valueList[0] is double rhd)
-                                    rowHeight = (int)rhd;
-
-                                // Parse HasUnevenRows (defaults to false in MAUI)
-                                bool hasUnevenRows = false;
-                                if (valueList[1] is bool hur)
-                                    hasUnevenRows = hur;
-
-                                // Get Cell.Height from captured cell (defaults to -1)
-                                double cellHeight = capturedCell.Height;
-
-                                if (hasUnevenRows)
-                                {
-                                    // When uneven rows allowed, prefer explicit Cell.Height if set
-                                    if (cellHeight > 0)
-                                        return cellHeight;
-                                    // Otherwise auto-size based on content
-                                    return double.NaN;
-                                }
-                                else
-                                {
-                                    // When uniform rows required
-                                    // Use RowHeight if explicitly set
-                                    if (rowHeight > 0)
-                                        return rowHeight;
-                                    // Otherwise auto-size (cells have their own MinHeight)
-                                    return double.NaN;
-                                }
-                            }),
-                            Bindings =
-                            {
-                                new Data.Binding
-                                {
-                                    Path = nameof(RowHeight),
-                                    Source = this
-                                },
-                                new Data.Binding
-                                {
-                                    Path = nameof(HasUnevenRows),
-                                    Source = this
-                                }
+                                // When uneven rows allowed, prefer explicit Cell.Height if set
+                                grid.Height = cellHeight > 0 ? cellHeight : double.NaN;
                             }
+                            else
+                            {
+                                // When uniform rows required, use RowHeight if explicitly set
+                                grid.Height = rowHeight > 0 ? rowHeight : double.NaN;
+                            }
+                        }
+
+                        // Set initial height
+                        UpdateGridHeight();
+
+                        void OnPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+                        {
+                            if (e.Property == RowHeightProperty || e.Property == HasUnevenRowsProperty)
+                            {
+                                UpdateGridHeight();
+                            }
+                        }
+
+                        tableView.PropertyChanged += OnPropertyChanged;
+
+                        // Clean up subscription when grid is detached
+                        grid.DetachedFromVisualTree += (_, _) =>
+                        {
+                            tableView.PropertyChanged -= OnPropertyChanged;
                         };
-                        
-                        grid.Bind(HeightProperty, heightBinding);
-#pragma warning restore IL2026, IL3050
                         
                         return grid;
                     }

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/CollectionViewHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/CollectionViewHandlerTests.cs
@@ -1027,8 +1027,8 @@ public partial class CollectionViewHandlerTests : HandlerTestBase
 
 public class TestTemplateSelector : DataTemplateSelector
 {
-    public DataTemplate TemplateA { get; set; }
-    public DataTemplate TemplateB { get; set; }
+    public DataTemplate TemplateA { get; set; } = null!;
+    public DataTemplate TemplateB { get; set; } = null!;
 
     protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
     {

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/DatePickerHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/DatePickerHandlerTests.cs
@@ -441,7 +441,7 @@ public partial class DatePickerHandlerTests : HandlerTestBase<AvaloniaDatePicker
         var handler = await CreateHandlerAsync(datePicker);
 
         // Now set to null
-        datePicker.TextColor = null;
+        datePicker.TextColor = null!;
         await InvokeOnMainThreadAsync(() =>
         {
             handler.UpdateValue(nameof(IDatePicker.TextColor));

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/EditorHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/EditorHandlerTests.cs
@@ -38,7 +38,7 @@ namespace Avalonia.Controls.Maui.Tests.Handlers
         [AvaloniaFact(DisplayName = "Null Text Mapped As Empty")]
         public async Task NullTextMappedAsEmpty()
         {
-            var editor = new EditorStub { Text = null };
+            var editor = new EditorStub { Text = null! };
             var handler = await CreateHandlerAsync(editor);
             var platformView = (MauiEditor)handler.PlatformView!;
             

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/TimePickerHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/TimePickerHandlerTests.cs
@@ -260,7 +260,7 @@ public partial class TimePickerHandlerTests : HandlerTestBase<AvaloniaTimePicker
         var handler = await CreateHandlerAsync(picker);
 
         // Now set to null
-        picker.TextColor = null;
+        picker.TextColor = null!;
         await InvokeOnMainThreadAsync(() =>
         {
             handler.UpdateValue(nameof(ITimePicker.TextColor));

--- a/tests/Avalonia.Controls.Maui.Tests/Platform/AlertManagerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Platform/AlertManagerTests.cs
@@ -94,11 +94,11 @@ namespace Avalonia.Controls.Maui.Tests.Platform
             var avaloniaWindow = windowHandler.PlatformView as Window;
             var wrapper = avaloniaWindow.Content as AvaloniaGrid;
             
-            var overlayGrid = wrapper.Children.OfType<AvaloniaGrid>().LastOrDefault();
-            var dialogGrid = overlayGrid.Children.OfType<AvaloniaGrid>().LastOrDefault();
-            
-            var dialogContainer = dialogGrid.Children.Last() as AvaloniaGrid;
-            var dialogControl = dialogContainer.Children.FirstOrDefault();
+            var overlayGrid = wrapper!.Children.OfType<AvaloniaGrid>().LastOrDefault();
+            var dialogGrid = overlayGrid!.Children.OfType<AvaloniaGrid>().LastOrDefault();
+
+            var dialogContainer = dialogGrid!.Children.Last() as AvaloniaGrid;
+            var dialogControl = dialogContainer!.Children.FirstOrDefault();
             Assert.IsType<MauiActionSheetDialog>(dialogControl);
             
             (dialogControl as TemplatedControl)?.ApplyTemplate();
@@ -149,11 +149,11 @@ namespace Avalonia.Controls.Maui.Tests.Platform
             var avaloniaWindow = windowHandler.PlatformView as Window;
             var wrapper = avaloniaWindow.Content as AvaloniaGrid;
             
-            var overlayGrid = wrapper.Children.OfType<AvaloniaGrid>().LastOrDefault();
-            var dialogGrid = overlayGrid.Children.OfType<AvaloniaGrid>().LastOrDefault();
-            
-            var dialogContainer = dialogGrid.Children.Last() as AvaloniaGrid;
-            var dialogControl = dialogContainer.Children.FirstOrDefault();
+            var overlayGrid = wrapper!.Children.OfType<AvaloniaGrid>().LastOrDefault();
+            var dialogGrid = overlayGrid!.Children.OfType<AvaloniaGrid>().LastOrDefault();
+
+            var dialogContainer = dialogGrid!.Children.Last() as AvaloniaGrid;
+            var dialogControl = dialogContainer!.Children.FirstOrDefault();
             Assert.IsType<MauiPromptDialog>(dialogControl);
             
             (dialogControl as TemplatedControl)?.ApplyTemplate();

--- a/tests/Avalonia.Controls.Maui.Tests/Stubs/EditorStub.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Stubs/EditorStub.cs
@@ -7,15 +7,15 @@ namespace Avalonia.Controls.Maui.Tests.Stubs
     public class EditorStub : StubBase, IEditor
     {
         public string Text { get; set; } = string.Empty;
-        public Color TextColor { get; set; }
+        public Color TextColor { get; set; } = null!;
         public double CharacterSpacing { get; set; }
         public bool IsReadOnly { get; set; }
         public bool IsTextPredictionEnabled { get; set; }
         public bool IsSpellCheckEnabled { get; set; }
         public int MaxLength { get; set; } = int.MaxValue;
-        public Keyboard Keyboard { get; set; }
-        public string Placeholder { get; set; }
-        public Color PlaceholderColor { get; set; }
+        public Keyboard Keyboard { get; set; } = Keyboard.Default;
+        public string Placeholder { get; set; } = string.Empty;
+        public Color PlaceholderColor { get; set; } = null!;
         public TextAlignment HorizontalTextAlignment { get; set; }
         public TextAlignment VerticalTextAlignment { get; set; }
         public int CursorPosition { get; set; }

--- a/tests/Avalonia.Controls.Maui.Tests/Stubs/LayoutStub.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Stubs/LayoutStub.cs
@@ -16,7 +16,7 @@ public class LayoutStub : StubBase, ILayout, ICrossPlatformLayout
 
     public bool IgnoreSafeArea { get; set; }
     
-    public new Microsoft.Maui.Thickness Padding { get; set; }
+    public Microsoft.Maui.Thickness Padding { get; set; }
 
     public IReadOnlyList<IView> this[Range range] => _children.ToArray()[range];
 


### PR DESCRIPTION
Fixes #67 

<img width="2213" height="1370" alt="Screenshot From 2026-01-14 17-46-29" src="https://github.com/user-attachments/assets/a07c257a-7827-48e2-8569-66ec9c8372d7" />

This PR adds `TreatWarningsAsErrors` for all projects except for the Sandbox apps, and builds and bundles the sample and showcase projects as artifacts, with Linux x64 AppImages for the AOT versions. This is to ensure that will can always build with NativeAOT and so we can test the builds after the fact.

The biggest AOT change was for [MauiTableView](https://github.com/AvaloniaUI/Avalonia.Controls.Maui/pull/104/changes#diff-8954f9ba5207d3258141b284bb4414049e4e7ceeccb71f9d404171d6016c45f9). The rest of it should be mostly Null warnings and some light trimming stuff that had to be adjusted

