### PR TITLE
Improve Gallery: Selected sample indicator, etc

### DIFF
--- a/samples/ControlGallery/ControlGallery/MainPage.xaml
+++ b/samples/ControlGallery/ControlGallery/MainPage.xaml
@@ -9,7 +9,7 @@
 		<ContentPage
 			BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}"
 			x:Name="FlyoutPageMenu"
-			Title="Control Gallery">
+			Title="Gallery">
 			<Grid RowDefinitions="Auto,*">
 				<SearchBar Placeholder="Search..."
 						   TextChanged="OnSearchBarTextChanged"

--- a/samples/ControlGallery/ControlGallery/MainPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/MainPage.xaml.cs
@@ -7,8 +7,9 @@ namespace ControlGallery;
 public partial class MainPage : FlyoutPage
 {
     private List<SampleGroup> _allSamples = new List<SampleGroup>();
+    private Type? _selectedPageType;
+    private string _lastSearchText = string.Empty;
 
-    // Static page factory for AOT compatibility - no reflection
     private static readonly Dictionary<Type, Func<Page>> PageFactory = new()
     {
         // Apps
@@ -113,16 +114,40 @@ public partial class MainPage : FlyoutPage
                     item.Title.Contains(searchText, StringComparison.OrdinalIgnoreCase) || 
                     item.Detail.Contains(searchText, StringComparison.OrdinalIgnoreCase))
                 {
-                    var cell = new TextCell
+                    bool isSelected = item.PageType == _selectedPageType;
+                    
+                    var cell = new ViewCell();
+                    var grid = new Grid
                     {
-                        Text = item.Title,
-                        Detail = item.Detail,
-                        Command = NavigateCommand,
-                        CommandParameter = item.PageType
+                        Padding = new Thickness(16, 8),
+                        BackgroundColor = isSelected ? Color.FromRgba(128, 128, 128, 40) : Colors.Transparent
                     };
 
-                    cell.SetAppThemeColor(TextCell.TextColorProperty, Colors.Black, Colors.White);
-                    cell.SetAppThemeColor(TextCell.DetailColorProperty, Colors.Gray, Colors.LightGray);
+                    var stack = new StackLayout { Spacing = 2 };
+                    var titleLabel = new Label 
+                    { 
+                        Text = item.Title, 
+                        FontSize = 16,
+                        FontAttributes = isSelected ? FontAttributes.Bold : FontAttributes.None
+                    };
+                    titleLabel.SetAppThemeColor(Label.TextColorProperty, Colors.Black, Colors.White);
+                    
+                    var detailLabel = new Label 
+                    { 
+                        Text = item.Detail, 
+                        FontSize = 13, 
+                        Opacity = 0.7 
+                    };
+                    detailLabel.SetAppThemeColor(Label.TextColorProperty, Colors.Gray, Colors.LightGray);
+                    
+                    stack.Children.Add(titleLabel);
+                    stack.Children.Add(detailLabel);
+                    grid.Children.Add(stack);
+                    cell.View = grid;
+
+                    var tap = new TapGestureRecognizer();
+                    tap.Tapped += (s, e) => NavigateToPage(item.PageType);
+                    grid.GestureRecognizers.Add(tap);
 
                     section.Add(cell);
                     hasItems = true;
@@ -175,32 +200,32 @@ public partial class MainPage : FlyoutPage
 
             new SampleGroup("Views", new List<SampleItem>
             {
-                new("ActivityIndicator", "ActivityIndicator control", typeof(ActivityIndicatorPage)),
-                new("Border", "Border with shapes and strokes", typeof(BorderPage)),
-                new("BoxView", "Simple colored rectangles", typeof(BoxViewPage)),
-                new("Button", "Button control", typeof(ButtonPage)),
-                new("CheckBox", "CheckBox control for selections", typeof(CheckBoxPage)),
-                new("CollectionView", "Collection display with templates", typeof(CollectionViewPage)),
-                new("ContentView", "Custom content", typeof(ContentViewPage)),
-                new("DatePicker", "Date picker control", typeof(DatePickerPage)),
-                new("Editor", "Editor control", typeof(EditorPage)),
-                new("Frame", "Frame control", typeof(FramePage)),
-                new("GraphicsView", "Custom drawing and graphics", typeof(GraphicsViewPage)),
-                new("Image", "Image display with various sources", typeof(ImagePage)),
-                new("ImageButton", "ImageButton control", typeof(ImageButtonPage)),
-                new("ListView", "ListView with Header/Footer and Grouping", typeof(ListViewPage)),
-                new("Picker", "Picker control", typeof(PickerPage)),
-                new("ProgressBar", "Progress indicator control", typeof(ProgressBarPage)),
-                new("RadioButton", "RadioButton control", typeof(RadioButtonPage)),
-                new("RefreshView", "Pull to refresh control", typeof(RefreshViewPage)),
-                new("ScrollView", "Scroll scenarios and behaviors", typeof(ScrollViewPage)),
-                new("SearchBar", "Search input control", typeof(SearchBarPage)),
-                new("Slider", "Slider control", typeof(SliderPage)),
-                new("Stepper", "Numeric increment/decrement control", typeof(StepperPage)),
-                new("SwipeView", "SwipeView control", typeof(SwipeViewPage)),
-                new("Switch", "Toggle control with colors", typeof(SwitchPage)),
-                new("TableView", "TableView with cell types", typeof(TableViewPage)),
-                new("TimePicker", "TimePicker control", typeof(TimePickerPage))
+                new("ActivityIndicator", "Animated busy indicator", typeof(ActivityIndicatorPage)),
+                new("Border", "Custom strikes and shapes", typeof(BorderPage)),
+                new("BoxView", "Decorative colored rectangles", typeof(BoxViewPage)),
+                new("Button", "Standard clickable button", typeof(ButtonPage)),
+                new("CheckBox", "Toggle selection control", typeof(CheckBoxPage)),
+                new("CollectionView", "Modern templated list", typeof(CollectionViewPage)),
+                new("ContentView", "Reusable custom content", typeof(ContentViewPage)),
+                new("DatePicker", "Date selection picker", typeof(DatePickerPage)),
+                new("Editor", "Multi-line text editor", typeof(EditorPage)),
+                new("Frame", "Bordered layout container", typeof(FramePage)),
+                new("GraphicsView", "Custom 2D drawing canvas", typeof(GraphicsViewPage)),
+                new("Image", "Visual content display", typeof(ImagePage)),
+                new("ImageButton", "Interactive image button", typeof(ImageButtonPage)),
+                new("ListView", "Scrolling data items", typeof(ListViewPage)),
+                new("Picker", "Item selection dropdown", typeof(PickerPage)),
+                new("ProgressBar", "Visual progress status", typeof(ProgressBarPage)),
+                new("RadioButton", "Single-select option list", typeof(RadioButtonPage)),
+                new("RefreshView", "Pull-to-refresh container", typeof(RefreshViewPage)),
+                new("ScrollView", "Scrollable layout container", typeof(ScrollViewPage)),
+                new("SearchBar", "Search text input", typeof(SearchBarPage)),
+                new("Slider", "Range value selection", typeof(SliderPage)),
+                new("Stepper", "Discrete incremental changes", typeof(StepperPage)),
+                new("SwipeView", "Swipe action container", typeof(SwipeViewPage)),
+                new("Switch", "Binary toggle switch", typeof(SwitchPage)),
+                new("TableView", "Form-based data table", typeof(TableViewPage)),
+                new("TimePicker", "Time selection picker", typeof(TimePickerPage))
             }),
 
             new SampleGroup("Effects", new List<SampleItem>
@@ -228,7 +253,7 @@ public partial class MainPage : FlyoutPage
                 new("Brushes", "Solid and Gradient brushes", typeof(BrushesPage)),
                 new("Gestures", "Tap, Swipe, Pan and more", typeof(GesturesPage)),
                 new("Styles", "Styles and Style Classes", typeof(StylesPage)),
-                new("Tooltips", "Tooltips on various controls", typeof(TooltipsPage)),
+                new("Tooltips", "Tooltips on various elements", typeof(TooltipsPage)),
                 new("Triggers", "Visual states and actions", typeof(TriggersPage)),
                 new("Visual States", "VisualStateManager examples", typeof(VisualStateManagerPage)),
             }),
@@ -242,12 +267,15 @@ public partial class MainPage : FlyoutPage
 
     private void OnSearchBarTextChanged(object sender, TextChangedEventArgs e)
     {
-        var searchBar = (SearchBar)sender;
-        UpdateMenu(searchBar.Text ?? string.Empty);
+        _lastSearchText = e.NewTextValue ?? string.Empty;
+        UpdateMenu(_lastSearchText);
     }
 
     private void NavigateToPage(Type pageType)
     {
+        _selectedPageType = pageType;
+        UpdateMenu(_lastSearchText);
+
         if (PageFactory.TryGetValue(pageType, out var factory))
         {
             Detail = factory();

--- a/samples/ControlGallery/ControlGallery/Pages/ActivityIndicatorPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/ActivityIndicatorPage.xaml
@@ -10,12 +10,12 @@
         <VerticalStackLayout Padding="20"
                              Spacing="20">
 
-            <Label Text="ActivityIndicator Control"
+            <Label Text="ActivityIndicator"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center"/>
 
-            <!-- Basic control and running toggle -->
+            <!-- Basic elements and running toggle -->
             <Border Stroke="Gray"
                     Padding="10">
                 <Border.StrokeShape>

--- a/samples/ControlGallery/ControlGallery/Pages/BorderPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/BorderPage.xaml
@@ -16,7 +16,7 @@
         <VerticalStackLayout Padding="20"
                              Spacing="20">
 
-            <Label Text="Border Control"
+            <Label Text="Border"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center"/>

--- a/samples/ControlGallery/ControlGallery/Pages/BoxViewPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/BoxViewPage.xaml
@@ -10,7 +10,7 @@
         <VerticalStackLayout Padding="20"
                              Spacing="20">
 
-            <Label Text="BoxView Control"
+            <Label Text="BoxView"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center"/>

--- a/samples/ControlGallery/ControlGallery/Pages/ButtonPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/ButtonPage.xaml
@@ -9,7 +9,7 @@
         <VerticalStackLayout Padding="20"
                              Spacing="20">
 
-            <Label Text="Button Control"
+            <Label Text="Button"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center"/>

--- a/samples/ControlGallery/ControlGallery/Pages/CheckBoxPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/CheckBoxPage.xaml
@@ -7,7 +7,7 @@
         <VerticalStackLayout Padding="20"
                              Spacing="20">
 
-            <Label Text="CheckBox Control"
+            <Label Text="CheckBox"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center"/>

--- a/samples/ControlGallery/ControlGallery/Pages/ClipPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/ClipPage.xaml
@@ -84,7 +84,7 @@
                             <Label Text="Rounded corners via clip"
                                    FontAttributes="Bold"
                                    TextColor="White" />
-                            <Label Text="The clip follows the control's bounds"
+                            <Label Text="The clip follows the element's bounds"
                                    FontAttributes="Italic"
                                    TextColor="#FFF7ED" />
                         </VerticalStackLayout>

--- a/samples/ControlGallery/ControlGallery/Pages/CollectionViewPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/CollectionViewPage.xaml.cs
@@ -43,10 +43,10 @@ public partial class CollectionViewPage : ContentPage
         }
     }
 
-    // Empty view items - observable for dynamic add/remove
+    // Empty view items using observable collection for dynamic updates
     public ObservableCollection<string> EmptyViewItems { get; } = new();
 
-    // Empty view template items - observable for dynamic add/remove
+    // Empty view template items using observable collection for dynamic updates
     public ObservableCollection<string> EmptyViewTemplateItems { get; } = new();
 
     // Grouped animals
@@ -94,7 +94,7 @@ public partial class CollectionViewPage : ContentPage
         "Red", "Orange", "Yellow", "Green", "Blue", "Indigo", "Violet"
     };
 
-    // Infinite scroll items - observable for dynamic loading
+    // Infinite scroll items using observable collection for dynamic loading
     public ObservableCollection<string> InfiniteScrollItems { get; } = new();
     private bool _isLoadingMore = false;
     private int _infiniteScrollBatch = 0;
@@ -334,7 +334,7 @@ public partial class CollectionViewPage : ContentPage
 
     private async void OnLoadMoreItems(object? sender, EventArgs e)
     {
-        if (_isLoadingMore || _infiniteScrollBatch >= 5) // Limit to 5 batches (100 items total)
+        if (_isLoadingMore || _infiniteScrollBatch >= 5) // Limit to 5 batches or 100 items total
             return;
 
         _isLoadingMore = true;
@@ -357,7 +357,7 @@ public partial class CollectionViewPage : ContentPage
 
     private void OnScrollToIndex(object? sender, EventArgs e)
     {
-        // Treat input as 1-based for user intuitiveness (Item 1 = index 0)
+        // Use 1-based input for user intuitiveness where Item 1 corresponds to index 0
         if (int.TryParse(ScrollIndexEntry.Text, out int itemNumber) && itemNumber >= 1 && itemNumber <= LargeList.Count)
         {
             var index = itemNumber - 1;

--- a/samples/ControlGallery/ControlGallery/Pages/ContentViewPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/ContentViewPage.xaml
@@ -8,7 +8,7 @@
              Title="ContentView">
     <ScrollView>
         <VerticalStackLayout Padding="20" Spacing="20">
-            <Label Text="ContentView Control"
+            <Label Text="ContentView"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center" />

--- a/samples/ControlGallery/ControlGallery/Pages/DatePickerPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/DatePickerPage.xaml
@@ -7,12 +7,12 @@
         <VerticalStackLayout Padding="20"
                              Spacing="24">
 
-            <Label Text="DatePicker Control"
+            <Label Text="DatePicker"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center" />
 
-            <Label Text="The DatePicker invokes the platform's date-picker control and allows the user to select a date."
+            <Label Text="The DatePicker invokes the platform's selection interface and allows the user to select a date."
                    FontSize="14"
                    TextColor="Gray"
                    HorizontalOptions="Center"
@@ -190,14 +190,14 @@
                 </VerticalStackLayout>
             </Border>
 
-            <!-- Programmatic Control -->
+            <!-- Programmatic Selection -->
             <Border Stroke="Gray"
                     Padding="12">
                 <Border.StrokeShape>
                     <RoundRectangle CornerRadius="10" />
                 </Border.StrokeShape>
                 <VerticalStackLayout Spacing="8">
-                    <Label Text="Programmatic Control"
+                    <Label Text="Programmatic Selection"
                            FontAttributes="Bold" />
                     <Label Text="Set the date programmatically using buttons."
                            FontSize="12"

--- a/samples/ControlGallery/ControlGallery/Pages/EditorPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/EditorPage.xaml
@@ -6,7 +6,7 @@
 
     <ScrollView>
         <VerticalStackLayout Padding="20" Spacing="20">
-            <Label Text="Editor Control" FontSize="24" FontAttributes="Bold" HorizontalOptions="Center" />
+            <Label Text="Editor" FontSize="24" FontAttributes="Bold" HorizontalOptions="Center" />
 
             <!-- Basic Editor -->
             <Border Stroke="Gray" Padding="10">

--- a/samples/ControlGallery/ControlGallery/Pages/FlexLayoutPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/FlexLayoutPage.xaml
@@ -213,7 +213,7 @@
                 <VerticalStackLayout Spacing="10">
                     <Label Text="FlexLayout.Grow Attached Property"
                            FontAttributes="Bold"/>
-                    <Label Text="Controls how items grow to fill available space"
+                    <Label Text="Determines how items grow to fill available space"
                            FontSize="12"
                            FontAttributes="Italic"/>
                     
@@ -344,7 +344,7 @@
                 <VerticalStackLayout Spacing="10">
                     <Label Text="FlexLayout.Order Attached Property"
                            FontAttributes="Bold"/>
-                    <Label Text="Controls the visual order of items (default is 0)"
+                    <Label Text="Specifies the visual order of items (default is 0)"
                            FontSize="12"
                            FontAttributes="Italic"/>
                     

--- a/samples/ControlGallery/ControlGallery/Pages/FramePage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/FramePage.xaml
@@ -18,7 +18,7 @@
         <VerticalStackLayout Padding="20"
                              Spacing="20">
 
-            <Label Text="Frame Control"
+            <Label Text="Frame"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center"/>
@@ -29,7 +29,7 @@
                     <RoundRectangle CornerRadius="8"/>
                 </Border.StrokeShape>
                 <VerticalStackLayout Spacing="4">
-                    <Label Text="Deprecated Control" 
+                    <Label Text="Deprecated" 
                            FontAttributes="Bold" 
                            TextColor="#856404"/>
                     <Label Text="Frame is deprecated in .NET MAUI 9+. Use Border instead for new development."

--- a/samples/ControlGallery/ControlGallery/Pages/GraphicsViewPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/GraphicsViewPage.xaml
@@ -16,7 +16,7 @@
         <VerticalStackLayout Padding="20"
                              Spacing="20">
 
-            <Label Text="GraphicsView Control"
+            <Label Text="GraphicsView"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center"/>

--- a/samples/ControlGallery/ControlGallery/Pages/ImageButtonPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/ImageButtonPage.xaml
@@ -9,7 +9,7 @@
         <VerticalStackLayout Padding="20"
                              Spacing="20">
 
-            <Label Text="ImageButton Control"
+            <Label Text="ImageButton"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center"/>

--- a/samples/ControlGallery/ControlGallery/Pages/ImagePage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/ImagePage.xaml
@@ -52,7 +52,7 @@
         <VerticalStackLayout Padding="20"
                              Spacing="24">
 
-            <Label Text="Image Control"
+            <Label Text="Image"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center" />
@@ -189,7 +189,7 @@
                     <RoundRectangle CornerRadius="10" />
                 </Border.StrokeShape>
                 <VerticalStackLayout Spacing="8">
-                    <Label Text="Opacity Control"
+                    <Label Text="Opacity"
                            FontAttributes="Bold" />
                     <Label x:Name="OpacityLabel"
                            Text="Opacity: 1.0"

--- a/samples/ControlGallery/ControlGallery/Pages/ListViewPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/ListViewPage.xaml
@@ -94,7 +94,7 @@
                     <RoundRectangle CornerRadius="8"/>
                 </Border.StrokeShape>
                 <VerticalStackLayout Spacing="4">
-                    <Label Text="Deprecated Control" 
+                    <Label Text="Deprecated" 
                            FontAttributes="Bold" 
                            TextColor="#856404"/>
                     <Label Text="ListView is deprecated in .NET MAUI 9+. Use CollectionView instead for new development."

--- a/samples/ControlGallery/ControlGallery/Pages/ListViewPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/ListViewPage.xaml.cs
@@ -377,9 +377,9 @@ public class CellTypeItem
 {
     public string? Name { get; set; }
     public string? Detail { get; set; }
-    public bool IsToggled { get; set; } // For SwitchCell
-    public string? Placeholder { get; set; } // For EntryCell
-    public string? Type { get; set; } // "Text", "Image", "Switch", "Entry", "View"
+    public bool IsToggled { get; set; } // SwitchCell state
+    public string? Placeholder { get; set; } // EntryCell placeholder
+    public string? Type { get; set; } // Cell type: Text, Image, Switch, Entry, View
 }
 
 public class ListViewGroup : ObservableCollection<ItemModel>

--- a/samples/ControlGallery/ControlGallery/Pages/PickerPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/PickerPage.xaml
@@ -7,12 +7,12 @@
         <VerticalStackLayout Padding="20"
                              Spacing="24">
 
-            <Label Text="Picker Control"
+            <Label Text="Picker"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center" />
 
-            <Label Text="The Title property displays a header above the Picker control, and TitleColor allows customizing its color."
+            <Label Text="The Title property displays a header above the Picker, and TitleColor allows customizing its color."
                    FontSize="14"
                    TextColor="Gray"
                    HorizontalOptions="Center"

--- a/samples/ControlGallery/ControlGallery/Pages/ProgressBarPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/ProgressBarPage.xaml
@@ -9,7 +9,7 @@
         <VerticalStackLayout Padding="20"
                              Spacing="20">
 
-            <Label Text="ProgressBar Control"
+            <Label Text="ProgressBar"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center"/>
@@ -77,7 +77,7 @@
                     <RoundRectangle CornerRadius="10"/>
                 </Border.StrokeShape>
                 <VerticalStackLayout Spacing="10">
-                    <Label Text="Progress Control"
+                    <Label Text="Progress"
                            FontAttributes="Bold"/>
                     <Slider x:Name="ProgressSlider"
                             Minimum="0"

--- a/samples/ControlGallery/ControlGallery/Pages/RadioButtonPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/RadioButtonPage.xaml
@@ -113,7 +113,7 @@
     <ScrollView>
         <VerticalStackLayout Padding="20"
                              Spacing="20">
-            <Label Text="RadioButton Control"
+            <Label Text="RadioButton"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center"/>

--- a/samples/ControlGallery/ControlGallery/Pages/RefreshViewPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/RefreshViewPage.xaml
@@ -10,7 +10,7 @@
         <VerticalStackLayout Padding="20"
                              Spacing="20">
 
-            <Label Text="RefreshView Control"
+            <Label Text="RefreshView"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center"/>
@@ -22,7 +22,7 @@
                     <RoundRectangle CornerRadius="10"/>
                 </Border.StrokeShape>
                 <VerticalStackLayout Spacing="10">
-                    <Label Text="RefreshView State Control"
+                    <Label Text="RefreshView State"
                            FontAttributes="Bold"/>
                     <Label Text="Pull down to refresh or use the controls below (desktop friendly)."
                            FontSize="12"/>

--- a/samples/ControlGallery/ControlGallery/Pages/ScrollViewPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/ScrollViewPage.xaml
@@ -8,7 +8,7 @@
     <ScrollView>
         <VerticalStackLayout Padding="20"
                              Spacing="16">
-            <Label Text="ScrollView Control"
+            <Label Text="ScrollView"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center" />

--- a/samples/ControlGallery/ControlGallery/Pages/SearchBarPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/SearchBarPage.xaml
@@ -10,7 +10,7 @@
         <VerticalStackLayout Padding="20"
                              Spacing="20">
 
-            <Label Text="SearchBar Control"
+            <Label Text="SearchBar"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center"/>

--- a/samples/ControlGallery/ControlGallery/Pages/SliderPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/SliderPage.xaml
@@ -10,7 +10,7 @@
         <VerticalStackLayout Padding="20"
                              Spacing="20">
 
-            <Label Text="Slider Control"
+            <Label Text="Slider"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center"/>

--- a/samples/ControlGallery/ControlGallery/Pages/StepperPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/StepperPage.xaml
@@ -9,7 +9,7 @@
         <VerticalStackLayout Padding="20"
                              Spacing="20">
 
-            <Label Text="Stepper Control"
+            <Label Text="Stepper"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center"/>
@@ -101,7 +101,7 @@
                     <RoundRectangle CornerRadius="10"/>
                 </Border.StrokeShape>
                 <VerticalStackLayout Spacing="10">
-                    <Label Text="Temperature Control"
+                    <Label Text="Temperature"
                            FontAttributes="Bold"/>
                     <Label Text="Thermostat-style control (15-30°C)"
                            FontSize="12"
@@ -130,7 +130,7 @@
                     <RoundRectangle CornerRadius="10"/>
                 </Border.StrokeShape>
                 <VerticalStackLayout Spacing="10">
-                    <Label Text="Volume Control"
+                    <Label Text="Volume"
                            FontAttributes="Bold"/>
                     <Label Text="Volume level (0-100)"
                            FontSize="12"

--- a/samples/ControlGallery/ControlGallery/Pages/SwipeViewPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/SwipeViewPage.xaml
@@ -10,7 +10,7 @@
         <VerticalStackLayout Padding="20"
                              Spacing="20">
 
-            <Label Text="SwipeView Control"
+            <Label Text="SwipeView"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center"/>
@@ -218,14 +218,14 @@
                 </VerticalStackLayout>
             </Border>
 
-            <!-- Programmatic Control -->
+            <!-- Programmatic State -->
             <Border Stroke="{AppThemeBinding Light=#E0E0E0, Dark=#404040}"
                     Padding="0">
                 <Border.StrokeShape>
                     <RoundRectangle CornerRadius="10"/>
                 </Border.StrokeShape>
                 <VerticalStackLayout Spacing="10" Padding="10">
-                    <Label Text="Programmatic Control"
+                    <Label Text="Programmatic State"
                            FontAttributes="Bold"/>
 
                     <SwipeView x:Name="ProgrammaticSwipeView"
@@ -252,7 +252,7 @@
                             </SwipeItems>
                         </SwipeView.BottomItems>
                         <Grid Padding="20" BackgroundColor="{AppThemeBinding Light=#F5F5F5, Dark=#2C2C2C}">
-                            <Label Text="Control Me with Buttons Below"
+                            <Label Text="Interact with Buttons Below"
                                    HorizontalOptions="Center"/>
                         </Grid>
                     </SwipeView>

--- a/samples/ControlGallery/ControlGallery/Pages/SwitchPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/SwitchPage.xaml
@@ -9,7 +9,7 @@
         <VerticalStackLayout Padding="20"
                              Spacing="20">
 
-            <Label Text="Switch Control"
+            <Label Text="Switch"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center" />

--- a/samples/ControlGallery/ControlGallery/Pages/TableViewPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/TableViewPage.xaml
@@ -41,7 +41,7 @@
                                           Detail="Learn about .NET MAUI and what it provides."/>
                                 <TextCell Text="2. Anatomy of an app"
                                           Detail="Learn about the visual elements in .NET MAUI"/>
-                                <StatusTextCell Text="3. Text display"
+                                <TextCell Text="3. Text display"
                                           Detail="Learn about the .NET MAUI elements that display text."/>
                             </TableSection>
                         </TableRoot>

--- a/samples/ControlGallery/ControlGallery/Pages/TableViewPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/TableViewPage.xaml
@@ -7,7 +7,7 @@
              Title="TableView">
     <ScrollView>
         <VerticalStackLayout Padding="20" Spacing="20">
-            <Label Text="TableView Control"
+            <Label Text="TableView"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center"/>
@@ -18,7 +18,7 @@
                     <RoundRectangle CornerRadius="8"/>
                 </Border.StrokeShape>
                 <VerticalStackLayout Spacing="4">
-                    <Label Text="Deprecated Control" 
+                    <Label Text="Deprecated" 
                            FontAttributes="Bold" 
                            TextColor="#856404"/>
                     <Label Text="TableView and its cells (TextCell, SwitchCell, EntryCell, ImageCell, ViewCell) are deprecated in .NET MAUI 9+. Use CollectionView instead for new development."
@@ -41,8 +41,8 @@
                                           Detail="Learn about .NET MAUI and what it provides."/>
                                 <TextCell Text="2. Anatomy of an app"
                                           Detail="Learn about the visual elements in .NET MAUI"/>
-                                <TextCell Text="3. Text controls"
-                                          Detail="Learn about the .NET MAUI controls that display text."/>
+                                <StatusTextCell Text="3. Text display"
+                                          Detail="Learn about the .NET MAUI elements that display text."/>
                             </TableSection>
                         </TableRoot>
                     </TableView>

--- a/samples/ControlGallery/ControlGallery/Pages/TimePickerPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/TimePickerPage.xaml
@@ -7,7 +7,7 @@
         <VerticalStackLayout Padding="20"
                              Spacing="24">
 
-            <Label Text="TimePicker Control"
+            <Label Text="TimePicker"
                    FontSize="24"
                    FontAttributes="Bold"
                    HorizontalOptions="Center" />
@@ -189,7 +189,7 @@
                     <RoundRectangle CornerRadius="10" />
                 </Border.StrokeShape>
                 <VerticalStackLayout Spacing="8">
-                    <Label Text="Programmatic Control"
+                    <Label Text="Programmatic Selection"
                            FontAttributes="Bold" />
                     <Label Text="Set the time programmatically using buttons."
                            FontSize="12"

--- a/samples/ControlGallery/ControlGallery/Pages/TitleBarPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/TitleBarPage.xaml
@@ -6,7 +6,7 @@
     <ScrollView>
         <VerticalStackLayout Padding="20" Spacing="15">
 
-            <Label Text="TitleBar Control"
+            <Label Text="TitleBar"
                    FontSize="24"
                    FontAttributes="Bold" />
 

--- a/samples/ControlGallery/ControlGallery/Pages/TooltipsPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/TooltipsPage.xaml
@@ -14,7 +14,7 @@
             <Border Stroke="Gray" Padding="20">
                 <VerticalStackLayout Spacing="20">
                     <Label Text="Basic Tooltips" FontAttributes="Bold" FontSize="18"/>
-                    <Label Text="Tooltips provide helpful hints when hovering over controls." TextColor="Gray"/>
+                    <Label Text="Tooltips provide helpful hints when hovering over elements." TextColor="Gray"/>
                     
                     <HorizontalStackLayout Spacing="15" HorizontalOptions="Center">
                         <Button Text="Save" 
@@ -35,10 +35,10 @@
                 </VerticalStackLayout>
             </Border>
 
-            <!-- Tooltips on Various Controls -->
+            <!-- Tooltips on Various elements -->
             <Border Stroke="Gray" Padding="20">
                 <VerticalStackLayout Spacing="15">
-                    <Label Text="Tooltips on Various Controls" FontAttributes="Bold" FontSize="18"/>
+                    <Label Text="Tooltips on Various elements" FontAttributes="Bold" FontSize="18"/>
                     
                     <Label Text="Hover over me!"
                            FontSize="16"

--- a/samples/ControlGallery/ControlGallery/Pages/TransformationsPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/TransformationsPage.xaml
@@ -27,7 +27,7 @@
                Margin="0,0,0,20" />
 
         <Label Grid.Row="1" 
-               Text="Experiment with scale, rotation, translation, and anchor transformations using the controls below" 
+               Text="Experiment with scale, rotation, translation, and anchor transformations using the options below" 
                HorizontalOptions="Center"
                HorizontalTextAlignment="Center"
                Margin="0,0,0,30" />
@@ -69,11 +69,11 @@
             </VerticalStackLayout>
         </Border>
 
-        <!-- Transformation Controls -->
+        <!-- Transformation Options -->
         <ScrollView Grid.Row="3">
             <VerticalStackLayout Padding="10" Spacing="14">
 
-                <!-- Scale Controls -->
+                <!-- Scale Options -->
                 <Label Text="Scale Transformations"
                        FontSize="16"
                        FontAttributes="Bold" />
@@ -117,7 +117,7 @@
                        HorizontalOptions="Center"
                        FontSize="12" />
 
-                <!-- Rotation Controls -->
+                <!-- Rotation Options -->
                 <Label Text="Rotation Transformations"
                        FontSize="16"
                        FontAttributes="Bold"
@@ -162,7 +162,7 @@
                        HorizontalOptions="Center"
                        FontSize="12" />
 
-                <!-- Translation Controls -->
+                <!-- Translation Options -->
                 <Label Text="Translation Transformations"
                        FontSize="16"
                        FontAttributes="Bold"
@@ -194,7 +194,7 @@
                        HorizontalOptions="Center"
                        FontSize="12" />
 
-                <!-- Anchor Point Controls -->
+                <!-- Anchor Point Options -->
                 <Label Text="Anchor Point Transformations"
                        FontSize="16"
                        FontAttributes="Bold"

--- a/src/Avalonia.Controls.Maui/Controls/MauiTableView/MauiTableView.cs
+++ b/src/Avalonia.Controls.Maui/Controls/MauiTableView/MauiTableView.cs
@@ -237,12 +237,12 @@ public class MauiTableView : MauiView
                         grid.Children.Add(separator);
 
                         // Height logic following MAUI TableView behavior:
-                        // - Cell.Height defaults to -1 (auto-size)
-                        // - RowHeight defaults to -1 (auto-size)
-                        // - HasUnevenRows defaults to false
-                        // - DefaultCellHeight = 40 (per MAUI source)
-                        // When HasUnevenRows=true: use Cell.Height if > 0, otherwise auto-size
-                        // When HasUnevenRows=false: use RowHeight if > 0, otherwise auto-size (cells have MinHeight)
+                        // Cell.Height defaults to -1 (auto-size)
+                        // RowHeight defaults to -1 (auto-size)
+                        // HasUnevenRows defaults to false
+                        // DefaultCellHeight = 40 (per MAUI source)
+                        // If HasUnevenRows is true, Cell.Height is used when greater than zero; otherwise, auto-sizing applies.
+                        // If HasUnevenRows is false, RowHeight is used when greater than zero; otherwise, auto-sizing applies (cells have MinHeight).
                         var capturedCell = cell; // Capture for closure
                         var tableView = this; // Capture for closure
 

--- a/src/Avalonia.Controls.Maui/Controls/SwipeView/Swipe.cs
+++ b/src/Avalonia.Controls.Maui/Controls/SwipeView/Swipe.cs
@@ -11,7 +11,7 @@ using ContentPresenter = Avalonia.Controls.Presenters.ContentPresenter;
 namespace Avalonia.Controls.Maui;
 
 // NOTE: This control is a temporary copy of the Swipe control from Avalonia.Labs.
-// It should be replaced with a package reference once PR https://github.com/AvaloniaUI/Avalonia.Labs/pull/130 is merged and released.
+// Replaced with a package reference upon release of PR https://github.com/AvaloniaUI/Avalonia.Labs/pull/130.
 
 /// <summary>
 /// A control that provides swipe gestures to reveal items behind the main content.

--- a/src/Avalonia.Controls.Maui/Controls/SwipeView/SwipeEventArgs.cs
+++ b/src/Avalonia.Controls.Maui/Controls/SwipeView/SwipeEventArgs.cs
@@ -13,7 +13,7 @@ public class OpenRequestedEventArgs : RoutedEventArgs
     public OpenSwipeItem OpenSwipeItem { get; }
 
     /// <summary>
-    /// Gets or sets whether the open request should be cancelled
+    /// Gets or sets whether the open request is cancelled.
     /// </summary>
     public bool Cancel { get; set; }
 
@@ -34,7 +34,7 @@ public class OpenRequestedEventArgs : RoutedEventArgs
 public class CloseRequestedEventArgs : RoutedEventArgs
 {
     /// <summary>
-    /// Gets or sets whether the close request should be cancelled
+    /// Gets or sets whether the close request is cancelled.
     /// </summary>
     public bool Cancel { get; set; }
 

--- a/src/Avalonia.Controls.Maui/Dispatching/AvaloniaDispatcherTimer.cs
+++ b/src/Avalonia.Controls.Maui/Dispatching/AvaloniaDispatcherTimer.cs
@@ -32,7 +32,7 @@ public class AvaloniaDispatcherTimer : IDispatcherTimer
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the timer should repeat after each tick.
+    /// Gets or sets a value indicating whether the timer repeats after each tick.
     /// </summary>
     public bool IsRepeating { get; set; } = true;
 

--- a/src/Avalonia.Controls.Maui/Extensions/GeometryExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/GeometryExtensions.cs
@@ -15,9 +15,9 @@ namespace Avalonia.Controls.Maui.Extensions;
 /// </para>
 /// <para><b>Conversion Strategy:</b></para>
 /// <list type="bullet">
-///   <item>Preserves geometry properties (coordinates, radii, corner radii, etc.)</item>
-///   <item>Converts complex path definitions to SVG-compatible path data strings</item>
-///   <item>Handles nested geometry groups recursively</item>
+///   <item>Coordinates, radii, and corner radii are preserved</item>
+///   <item>Complex path definitions convert to SVG-compatible path data strings</item>
+///   <item>Nested geometry groups are handled recursively</item>
 ///   <item>Returns null for unsupported geometry types or invalid configurations</item>
 /// </list>
 /// </remarks>
@@ -91,8 +91,8 @@ public static class GeometryExtensions
     ///     Uses the maximum of (TopLeft, TopRight, BottomLeft, BottomRight) to ensure
     ///     all corners are at least as rounded as specified.
     ///     <br/>
-    ///     <b>Returns null if no Rect specified</b> - This signals to the caller (e.g., UpdateClip)
-    ///     that bounds-based sizing should be used instead.
+    ///     <b>Returns null if no Rect is specified</b>. This signals to the caller
+    ///     that bounds-based sizing is used instead.
     ///     </description>
     ///   </item>
     ///   <item>
@@ -138,14 +138,14 @@ public static class GeometryExtensions
     ///     CornerRadius = new CornerRadius(20)
     /// };
     /// var result = mauiRoundRect2.ToPlatform();
-    /// // Returns: null (caller should use container bounds)
+    /// // Returns: null (caller uses container bounds)
     /// </code>
     ///
     /// <para><b>Performance Considerations:</b></para>
     /// <list type="bullet">
-    ///   <item>Simple geometries (Line, Rectangle, Ellipse) - Fast, direct object creation</item>
-    ///   <item>PathGeometry - Moderate, requires string building and parsing</item>
-    ///   <item>GeometryGroup - Performance depends on number and complexity of children</item>
+    ///   <item>Simple geometries (Line, Rectangle, Ellipse) provide fast, direct object creation</item>
+    ///   <item>PathGeometry requires string building and parsing</item>
+    ///   <item>GeometryGroup performance depends on number and complexity of children</item>
     /// </list>
     /// </remarks>
     /// <seealso cref="Microsoft.Maui.Controls.Shapes.Geometry"/>
@@ -210,7 +210,7 @@ public static class GeometryExtensions
 
             // Check if an explicit Rect was provided
             // If yes: Create geometry with that rect
-            // If no: Return null to signal caller should use container bounds
+            // If no: Return null to signal that container bounds are used
             if (roundRectGeometry.Rect is { Width: > 0, Height: > 0 } rect)
             {
                 return new global::Avalonia.Media.RectangleGeometry(
@@ -219,8 +219,8 @@ public static class GeometryExtensions
                     radius); // radiusY (vertical)
             }
 
-            // No explicit Rect property means this should adapt to container bounds
-            // Return null to signal that UpdateClip or similar method needs to provide bounds
+            // No explicit Rect property means this adapts to container bounds
+            // Return null to signal that UpdateClip or similar method provides bounds
             // Example XAML: <RoundRectangleGeometry CornerRadius="20" /> without Rect property
             return null;
         }

--- a/src/Avalonia.Controls.Maui/Extensions/KeyboardExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/KeyboardExtensions.cs
@@ -34,7 +34,7 @@ public static class KeyboardExtensions
                              keyboard != Keyboard.Url;
         TextInputOptions.SetAutoCapitalization(textBox, autoCapitalize);
 
-        // Configure suggestions. Chat keyboard should show suggestions, Plain should not
+        // Configure suggestions. Chat keyboard shows suggestions; Plain keyboard does not.
         bool? showSuggestions = null;
         if (keyboard == Keyboard.Chat)
             showSuggestions = true;

--- a/src/Avalonia.Controls.Maui/Extensions/RefreshViewExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/RefreshViewExtensions.cs
@@ -26,8 +26,7 @@ public static class RefreshViewExtensions
     /// <param name="refreshView">The cross-platform refresh view.</param>
     /// <param name="mauiContext">The MAUI context for converting views.</param>
     /// <remarks>
-    /// The content should typically be a scrollable control such as ScrollView, CollectionView, or ListView
-    /// to enable pull-to-refresh gesture recognition.
+    /// Content is typically a scrollable control such as ScrollView, CollectionView, or ListView.
     /// </remarks>
     public static void UpdateContent(this PlatformView platformView, IRefreshView refreshView, IMauiContext? mauiContext)
     {
@@ -67,9 +66,13 @@ public static class RefreshViewExtensions
         IBrush? brush = refreshView.RefreshColor?.ToPlatform();
         
         if (brush != null)
+        {
             visualizer.Foreground = brush;
+        }
         else
+        {
             visualizer.ClearValue(Primitives.TemplatedControl.ForegroundProperty);
+        }
 
         if (visualizer is Visual visual)
         {

--- a/src/Avalonia.Controls.Maui/Extensions/TimePickerExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/TimePickerExtensions.cs
@@ -28,9 +28,9 @@ public static class TimePickerExtensions
     /// <param name="timePicker">The .NET MAUI view providing the format string.</param>
     /// <remarks>
     /// Avalonia TimePicker uses ClockIdentifier property for 12/24 hour format.
-    /// MAUI uses a format string. Common patterns are detected:
-    /// - "t" or formats with "h" = 12 hour clock
-    /// - "T" or formats with "H" = 24 hour clock
+    /// MAUI uses a format string. Patterns detected:
+    /// "t" or formats with "h" specify a 12 hour clock.
+    /// "T" or formats with "H" specify a 24 hour clock.
     /// </remarks>
     public static void UpdateFormat(this PlatformView platformView, ITimePicker timePicker)
     {

--- a/src/Avalonia.Controls.Maui/Extensions/ViewExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/ViewExtensions.cs
@@ -233,7 +233,7 @@ public static class ViewExtensions
     /// </summary>
     /// <param name="control">The platform view to unfocus.</param>
     /// <param name="view">The .NET MAUI view associated with the control.</param>
-    /// <remarks>Implementation pending - unfocus logic needs to be added.</remarks>
+    /// <remarks>Implementation pending. Unfocus logic requires addition.</remarks>
     public static void Unfocus(this PlatformView control, IView view)
     {
         var topLevel = TopLevel.GetTopLevel(control);
@@ -342,10 +342,10 @@ public static class ViewExtensions
     /// <remarks>
     /// <para><b>Supported Clip Geometries:</b></para>
     /// <list type="bullet">
-    ///   <item>RectangleGeometry - Sharp rectangular clip</item>
-    ///   <item>RoundRectangleGeometry - Rounded corners (uses largest corner radius)</item>
-    ///   <item>EllipseGeometry - Elliptical/circular clip</item>
-    ///   <item>PathGeometry - Custom path-based clipping via ToPlatform()</item>
+    ///   <item>RectangleGeometry with sharp rectangular clip</item>
+    ///   <item>RoundRectangleGeometry with rounded corners</item>
+    ///   <item>EllipseGeometry with elliptical or circular clip</item>
+    ///   <item>PathGeometry with custom path-based clipping via ToPlatform()</item>
     /// </list>
     /// <para><b>Timing Issue (Known Bug):</b></para>
     /// When the window is initially large, controls may not have their bounds calculated yet,
@@ -357,9 +357,7 @@ public static class ViewExtensions
     ///   <item>Resizing the window triggers a new layout pass, which fires the event</item>
     /// </list>
     /// <para><b>Workaround:</b></para>
-    /// The method uses a PropertyChangedSubscription to automatically retry when bounds
-    /// become available. If clips don't appear initially, they should render after the
-    /// first layout pass or window resize.
+    /// become available. Visual clips render after the first layout pass or window resize if not initially present.
     /// </remarks>
     public static void UpdateClip(this PlatformView control, IView view)
     {
@@ -374,7 +372,7 @@ public static class ViewExtensions
         }
 
         // Attempt to get control dimensions from various sources
-        // This tries: control.Bounds → view.Width/Height → view.Frame → control.DesiredSize
+        // Resolve control size from Bounds, Width/Height properties, Frame, or DesiredSize
         var (width, height) = GetClipSize(control, view);
 
         if (width <= 0 || height <= 0)
@@ -404,7 +402,7 @@ public static class ViewExtensions
             SetClipSubscription(control, subscription);
 
             // POTENTIAL FIX: Force a layout pass to ensure bounds get calculated
-            // This should trigger the BoundsProperty change we're subscribed to above
+            // Triggers the BoundsProperty change subscription.
             // Note: InvalidateMeasure may not immediately solve the issue if the parent
             // container hasn't been measured yet, but it helps in many cases
             control.InvalidateMeasure();
@@ -429,7 +427,7 @@ public static class ViewExtensions
         {
             // RoundRectangleGeometry without explicit Rect - use container bounds
             // This happens when XAML has <RoundRectangleGeometry CornerRadius="32" />
-            // without a Rect property, meaning it should clip to the container's bounds
+            // without a Rect property, meaning it clips to the container bounds
             var radius = Math.Max(
                 roundRect.CornerRadius.TopLeft,
                 Math.Max(
@@ -458,17 +456,17 @@ public static class ViewExtensions
     /// <remarks>
     /// <para><b>Size Source Priority (fallback chain):</b></para>
     /// <list type="number">
-    ///   <item><b>control.Bounds</b> - Most reliable, from Avalonia's layout system</item>
-    ///   <item><b>view.Width/Height</b> - Explicit MAUI size properties</item>
-    ///   <item><b>view.Frame</b> - MAUI's calculated frame rectangle</item>
-    ///   <item><b>control.DesiredSize</b> - Avalonia's measure pass result</item>
+    ///   <item>control.Bounds from Avalonia's layout system</item>
+    ///   <item>view.Width/Height explicit MAUI size properties</item>
+    ///   <item>view.Frame MAUI calculated frame rectangle</item>
+    ///   <item>control.DesiredSize Avalonia measure pass result</item>
     /// </list>
-    /// <para><b>Why Multiple Sources?</b></para>
+    /// <para><b>Sizing Sources</b></para>
     /// Different layout phases provide size information at different times:
     /// <list type="bullet">
     ///   <item>Early: DesiredSize available after measure pass</item>
-    ///   <item>Middle: Width/Height if explicitly set in XAML/code</item>
-    ///   <item>Late: Bounds available after arrange pass (most reliable)</item>
+    ///   <item>Middle: Width/Height explicitly set in XAML or code</item>
+    ///   <item>Late: Bounds available after arrange pass</item>
     /// </list>
     /// <para><b>Common Failure Scenario:</b></para>
     /// On initial load with wide windows, none of these sources may have valid values yet,
@@ -555,31 +553,31 @@ public static class ViewExtensions
     /// <param name="control">The platform view to apply the shadow to.</param>
     /// <param name="view">The .NET MAUI view containing shadow configuration.</param>
     /// <remarks>
-    /// <para><b>How it works:</b></para>
+    /// <para><b>Functionality</b></para>
     /// <list type="number">
-    ///   <item>Converts MAUI's IShadow to Avalonia's DropShadowEffect via ToAvalonia() extension</item>
+    ///   <item>Converts IShadow to DropShadowEffect using ToAvalonia()</item>
     ///   <item>Maps shadow properties:
     ///     <list type="bullet">
-    ///       <item>Shadow.Paint.Color → DropShadowEffect.Color (with opacity applied)</item>
-    ///       <item>Shadow.Offset.X/Y → DropShadowEffect.OffsetX/OffsetY</item>
-    ///       <item>Shadow.Radius → DropShadowEffect.BlurRadius</item>
+    ///       <item>Shadow.Paint.Color to DropShadowEffect.Color</item>
+    ///       <item>Shadow.Offset to DropShadowEffect Offset</item>
+    ///       <item>Shadow.Radius to DropShadowEffect.BlurRadius</item>
     ///     </list>
     ///   </item>
-    ///   <item>If shadow is null, clears the effect to remove any existing shadow</item>
-    ///   <item>Applies the effect to control.Effect property (GPU-accelerated rendering)</item>
+    ///   <item>Clears the effect if shadow is null</item>
+    ///   <item>Applies the effect to control.Effect property</item>
     /// </list>
-    /// <para><b>Implementation details:</b></para>
+    /// <para><b>Implementation Details</b></para>
     /// <list type="bullet">
-    ///   <item>Uses Avalonia's IEffect system for efficient shadow rendering</item>
-    ///   <item>DropShadowEffect is GPU-accelerated when possible</item>
-    ///   <item>Shadow opacity is combined with paint color alpha channel</item>
-    ///   <item>Only SolidPaint is supported; gradient shadows default to black</item>
+    ///   <item>Uses the IEffect system for efficient rendering</item>
+    ///   <item>Provides GPU acceleration for DropShadowEffect</item>
+    ///   <item>Combines shadow opacity with paint color alpha channel</item>
+    ///   <item>Supports SolidPaint; gradient shadows default to black</item>
     /// </list>
-    /// <para><b>Performance notes:</b></para>
+    /// <para><b>Performance</b></para>
     /// <list type="bullet">
-    ///   <item>Shadows can impact rendering performance, especially with large blur radius</item>
-    ///   <item>Effect is applied to the container view when NeedsContainer is true</item>
-    ///   <item>Changes are immediate; no animation or transitions</item>
+    ///   <item>Large blur radius can impact rendering performance</item>
+    ///   <item>Applies to the container view when NeedsContainer is true</item>
+    ///   <item>Updates are immediate</item>
     /// </list>
     /// </remarks>
     /// <example>
@@ -652,7 +650,7 @@ public static class ViewExtensions
     /// <param name="imageSource">The image source to set as background.</param>
     /// <param name="provider">The image source service provider.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    /// <remarks>Implementation pending - image background logic needs to be added.</remarks>
+    /// <remarks>Implementation pending. Image background logic requires addition.</remarks>
     [Avalonia.Controls.Maui.Platform.NotImplemented("Pending to implement image background logic.")]
     public static Task UpdateBackgroundImageSourceAsync(this PlatformView control, IImageSource? imageSource, IImageSourceServiceProvider provider)
     {
@@ -665,7 +663,7 @@ public static class ViewExtensions
     /// </summary>
     /// <param name="control">The platform view to update.</param>
     /// <param name="view">The .NET MAUI view containing border properties.</param>
-    /// <remarks>Implementation pending - border logic needs to be added.</remarks>
+    /// <remarks>Implementation pending. Border logic requires addition.</remarks>
     [Avalonia.Controls.Maui.Platform.NotImplemented("Type or member is obsolete.")]
     public static void UpdateBorder(this PlatformView control, IView view)
     {

--- a/src/Avalonia.Controls.Maui/Handlers/FlyoutViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/FlyoutViewHandler.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Controls.Maui.Handlers;
 /// </summary>
 public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, PlatformView>
 {
-    // Like IViewHandler.ContainerView, those properties should be set with priority because other mappers depend on them.
+    // Properties are set with priority because other mappers depend on them.
     private static readonly IPropertyMapper<IFlyoutView, FlyoutViewHandler> FlyoutLayoutMapper = new PropertyMapper<IFlyoutView, FlyoutViewHandler>()
     {
         [nameof(IFlyoutView.Flyout)] = MapFlyout,
@@ -150,7 +150,7 @@ public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, PlatformView>
         }
         else if (flyoutView.FlyoutWidth == -1)
         {
-            // -1 means auto/match parent, use a reasonable default
+            // A value of -1 denotes auto or match parent; a default of 320 is applied.
             platformView.FlyoutWidth = 320;
         }
     }

--- a/src/Avalonia.Controls.Maui/Handlers/Shell/ShellHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shell/ShellHandler.cs
@@ -44,7 +44,7 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
             [nameof(MauiShell.Items)] = MapItems,
             [nameof(MauiShell.ItemTemplate)] = MapItemTemplate,
             [nameof(MauiShell.MenuItemTemplate)] = MapMenuItemTemplate,
-            // These are attached properties - use string literals for property names
+            // Attached properties use string literals for property names
             ["BackgroundColor"] = MapBackgroundColor,
             ["ForegroundColor"] = MapForegroundColor,
             ["TitleColor"] = MapTitleColor,
@@ -121,21 +121,21 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
 
         flyoutPaneContainer.Background = null; // Inherit from theme
 
-        // Flyout header - docked to top
+        // Flyout header docked to top
         _flyoutHeaderControl = new ContentControl
         {
             [DockPanel.DockProperty] = Dock.Top
         };
         flyoutPaneContainer.Children.Add(_flyoutHeaderControl);
 
-        // Flyout footer - docked to bottom
+        // Flyout footer docked to bottom
         _flyoutFooterControl = new ContentControl
         {
             [DockPanel.DockProperty] = Dock.Bottom
         };
         flyoutPaneContainer.Children.Add(_flyoutFooterControl);
 
-        // Flyout items panel - fills remaining space
+        // Flyout items panel fills remaining space
         _flyoutPanel = new StackPanel
         {
             Spacing = 4

--- a/src/Avalonia.Controls.Maui/Handlers/Shell/ShellItemHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shell/ShellItemHandler.cs
@@ -43,7 +43,7 @@ public partial class ShellItemHandler : ElementHandler<ShellItem, AvaloniaContro
 
     protected override AvaloniaControl CreatePlatformElement()
     {
-        // Determine if we should show tabs
+        // Determine tab visibility
         _showTabs = ShouldShowTabs();
 
         if (_showTabs)
@@ -60,7 +60,7 @@ public partial class ShellItemHandler : ElementHandler<ShellItem, AvaloniaContro
         }
         else
         {
-            // Single section - just show content directly without wrapper grid
+            // Single section displays content directly without a wrapper grid
             _contentControl = new ContentControl
             {
                 HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Stretch,
@@ -154,7 +154,7 @@ public partial class ShellItemHandler : ElementHandler<ShellItem, AvaloniaContro
 
         if (!_showTabs)
         {
-            // Single section or no tabs - show content directly
+            // Single section or no tabs display content directly
             UpdateCurrentItem();
             return;
         }

--- a/src/Avalonia.Controls.Maui/Platform/AlertManager.cs
+++ b/src/Avalonia.Controls.Maui/Platform/AlertManager.cs
@@ -69,7 +69,6 @@ internal class AlertManager
         /// <summary>
         /// Gets the platform host control that can contain overlays.
         /// For desktop apps, this is a Window.
-        /// For single-view apps (WASM/mobile), this is the MauiAvaloniaContent.
         /// </summary>
         static Control? GetPlatformHost(Page? page)
         {
@@ -246,7 +245,7 @@ internal class AlertManager
                      {
                          Background = new Avalonia.Media.SolidColorBrush(Media.Color.FromArgb(128, 0, 0, 0)) // Dim background
                      };
-                     dialogContainer.Children.Add(dialog); // Dialog UserControl should be Centered by itself
+                     dialogContainer.Children.Add(dialog); // Dialog UserControl center-aligns itself
                      
                      _dialogGrid?.Children.Add(dialogContainer);
                  });

--- a/src/Avalonia.Controls.Maui/Platform/FlyoutContainer.cs
+++ b/src/Avalonia.Controls.Maui/Platform/FlyoutContainer.cs
@@ -166,7 +166,7 @@ public class FlyoutContainer : Panel
     }
 
     /// <summary>
-    /// Determines if the current behavior and orientation should use split mode
+    /// Determines if the current behavior and orientation use split mode
     /// </summary>
     private bool IsSplitMode()
     {

--- a/src/Avalonia.Controls.Maui/Platform/TitleBarView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/TitleBarView.cs
@@ -279,7 +279,7 @@ public class TitleBarView : MauiView
     }
 
     /// <summary>
-    /// Checks if a control is a passthrough element (should not trigger window drag).
+    /// Checks if a control is a passthrough element that avoids triggering window drag.
     /// </summary>
     private bool IsPassthroughElement(Control control)
     {


### PR DESCRIPTION
Changes:
- Selection Highlighting: Replaced `TextCell` with `ViewCell` in the main menu to provide visual feedback for the currently selected sample.
- Clean up Polish: Removed "Control" word from samples titles because in MAUI the terminology use Views, not Controls.

<img width="1435" height="677" alt="selection-light" src="https://github.com/user-attachments/assets/3291de1e-266e-4418-b67f-b19ddaaa8d37" />
<img width="1431" height="677" alt="selection-dark" src="https://github.com/user-attachments/assets/a53d748c-89ed-4232-9ca4-5a51e70be9c2" />


