### PR TITLE
Remove IsLoading hack

### DIFF
--- a/src/Avalonia.Controls.Maui/Handlers/ImageHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ImageHandler.cs
@@ -13,6 +13,7 @@ using Avalonia.Animation;
 using AImage = Avalonia.Controls.Image;
 using AGrid = Avalonia.Controls.Grid;
 using IImage = Microsoft.Maui.IImage;
+using Microsoft.Maui.Controls;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
@@ -154,41 +155,10 @@ public partial class ImageHandler : ViewHandler<IImage, AGrid>
 
     private void UpdateIsLoading(bool isLoading)
     {
-        // IsLoading is a read-only property on the public Image API, intended to be set only by internal logic.
-        // To report accurate loading states from our custom handler back to the cross-platform control,
-        // we must use reflection to invoke the internal/private 'SetIsLoading' method.
-
-        try
+        if (VirtualView is IImageController mauiImage)
         {
-            if (VirtualView is Microsoft.Maui.Controls.Image mauiImage)
-            {
-                var method = typeof(Microsoft.Maui.Controls.Image).GetMethod(
-                    "SetIsLoading",
-                    BindingFlags.Instance | BindingFlags.NonPublic);
-
-                method?.Invoke(mauiImage, [isLoading]);
-                return;
-            }
-
-            if (VirtualView != null)
-            {
-                UpdateIsLoadingViaReflection(VirtualView, isLoading);
-            }
+            mauiImage.SetIsLoading(isLoading);
         }
-        catch
-        {
-            // Ignore reflection errors
-        }
-    }
-
-    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Custom IImage implementations may expose UpdateIsLoading via reflection.")]
-    private static void UpdateIsLoadingViaReflection(object virtualView, bool isLoading)
-    {
-        var updateIsLoading = virtualView
-            .GetType()
-            .GetMethod("UpdateIsLoading", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-
-        updateIsLoading?.Invoke(virtualView, new object[] { isLoading });
     }
 
     private async Task LoadGifAsync(IImageSource source, bool shouldPlay, CancellationToken token)

--- a/tests/Avalonia.Controls.Maui.Tests/Stubs/ImageStub.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Stubs/ImageStub.cs
@@ -1,10 +1,10 @@
-using System.Collections.Generic;
 using Microsoft.Maui;
-using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Internals;
 
 namespace Avalonia.Controls.Maui.Tests.Stubs;
 
-public class ImageStub : StubBase, Microsoft.Maui.IImage
+public class ImageStub : StubBase, Microsoft.Maui.IImage, Microsoft.Maui.Controls.IImageController
 {
     public Aspect Aspect { get; set; } = Aspect.AspectFit;
 
@@ -17,6 +17,69 @@ public class ImageStub : StubBase, Microsoft.Maui.IImage
     public List<bool> LoadingStates { get; } = new();
 
     public bool? LastIsLoading => LoadingStates.Count > 0 ? LoadingStates[^1] : null;
+
+    public bool Batched => throw new NotImplementedException();
+
+    public bool DisableLayout { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+    public EffectiveFlowDirection EffectiveFlowDirection => throw new NotImplementedException();
+
+    public bool IsInPlatformLayout { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+    public bool IsPlatformStateConsistent { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+    public bool IsPlatformEnabled { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+    public NavigationProxy NavigationProxy => throw new NotImplementedException();
+
+    public IEffectControlProvider EffectControlProvider { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+    public Element RealParent => throw new NotImplementedException();
+
+    IReadOnlyList<Element> IElementController.LogicalChildren => throw new NotImplementedException();
+
+#pragma warning disable CS0067 // Unused event
+    public event EventHandler<EventArg<VisualElement>>? BatchCommitted;
+    public event EventHandler<VisualElement.FocusRequestArgs>? FocusChangeRequested;
+#pragma warning restore CS0067
+
+    public IEnumerable<Element> Descendants()
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool EffectIsAttached(string name)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool GetLoadAsAnimation()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void InvalidateMeasure(InvalidationTrigger trigger)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void PlatformSizeChanged()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void SetIsLoading(bool isLoading)
+    {
+        LoadingStates.Add(isLoading);
+    }
+
+    public void SetValueFromRenderer(BindableProperty property, object value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void SetValueFromRenderer(BindablePropertyKey propertyKey, object value)
+    {
+        throw new NotImplementedException();
+    }
 
     public void UpdateIsLoading(bool isLoading)
     {


### PR DESCRIPTION
I had an IsLoading reflection hack for MAUI Image, which is BS. Image implements `IImageController` which has public properties, so the reflection hack isn't needed.