### PR TITLE
Bump Avalonia v12 Version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <!-- <AvaloniaVersion>9999.0.0-localbuild</AvaloniaVersion> -->
         <IsPackable>false</IsPackable>
-        <AvaloniaVersion Condition="'$(AvaloniaVersion)' == ''">12.0.0-preview1</AvaloniaVersion>
+        <AvaloniaVersion Condition="'$(AvaloniaVersion)' == ''">12.0.999-cibuild0062426-alpha</AvaloniaVersion>
         <DotNetTfm Condition="'$(DotNetTfm)' == ''">net11.0</DotNetTfm>
         <MauiSrcDirectory>$(MSBuildThisFileDirectory)/src/</MauiSrcDirectory>
         <BuildDirectory>$(MSBuildThisFileDirectory)/build/</BuildDirectory>

--- a/src/Avalonia.Controls.Maui/Controls/CollectionView/MauiCollectionView.cs
+++ b/src/Avalonia.Controls.Maui/Controls/CollectionView/MauiCollectionView.cs
@@ -504,7 +504,7 @@ public class MauiCollectionView : TemplatedControl
             if (Child is Control content)
             {
                 // Verify if we need to update the binding context registration
-                if (this.GetVisualRoot() != null)
+                if (this.Parent != null)
                 {
                     _owner.UnregisterItemContainer(this);
                     _owner.RegisterItemContainer(this, content, DataContext);
@@ -559,7 +559,7 @@ public class MauiCollectionView : TemplatedControl
                 info.Content.TryGetTarget(out var content) &&
                 info.DataContext.TryGetTarget(out var dataContext))
             {
-                if (border.IsVisible && border.GetVisualRoot() != null)
+                if (border.IsVisible && border.Parent != null)
                 {
                     bool isSelected = IsItemSelected(dataContext);
                     UpdateVisualState(content, isSelected);

--- a/src/Avalonia.Controls.Maui/Handlers/SingleViewWindowHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/SingleViewWindowHandler.cs
@@ -30,8 +30,8 @@ public partial class SingleViewWindowHandler : ElementHandler<IWindow, Avalonia.
     {
         if (arg3 is DisplayDensityRequest request)
         {
-            var toplevel = handler.PlatformView.GetVisualRoot() as Avalonia.Controls.TopLevel;
-            request.SetResult((float)(toplevel?.RenderScaling ?? 1.0));
+            var renderingScale = handler.PlatformView.Presenter?.GetPresentationSource()?.RenderScaling;
+            request.SetResult((float)(renderingScale ?? 1.0));
         }
     }
 

--- a/src/Avalonia.Controls.Maui/Handlers/ViewHandlerOfT.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ViewHandlerOfT.cs
@@ -128,7 +128,7 @@ public abstract partial class ViewHandler<TVirtualView, TPlatformView> : ViewHan
         platformView.LostFocus += OnPlatformViewLostFocus;
         platformView.PropertyChanged += OnPlatformViewPropertyChanged;
 
-        if (platformView.GetVisualRoot() != null)
+        if (platformView.Parent != null)
         {
             _isLoaded = true;
             TrySendLoaded();

--- a/src/Avalonia.Controls.Maui/Handlers/WindowHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/WindowHandler.cs
@@ -38,8 +38,8 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
     {
         if (arg3 is DisplayDensityRequest request)
         {
-            var toplevel = handler.PlatformView.GetVisualRoot() as Avalonia.Controls.TopLevel;
-            request.SetResult((float)(toplevel?.RenderScaling ?? 1.0));
+            var renderingScale = handler.PlatformView.Presenter?.GetPresentationSource()?.RenderScaling;
+            request.SetResult((float)(renderingScale ?? 1.0));
         }
     }
 


### PR DESCRIPTION
Bumps the Avalonia V12 version to a new CI build, so we can get the opacity fix. There is also a breaking change for GetVisualRoot, which as far as I can tell we don't need and can replace with other elements or new extension methods.

In terms of shipping the library, we will need a new preview build, but I think the opacity fix is great to have for it and we really should get a new build out for it.