### PR TITLE
Create Avalonia.Controls.Maui.Desktop nuget (And a few UI fixes)

### DIFF
--- a/Avalonia.Controls.Maui.nupkg.slnf
+++ b/Avalonia.Controls.Maui.nupkg.slnf
@@ -6,6 +6,7 @@
             "src\\Avalonia.Controls.Maui.Essentials\\Avalonia.Controls.Maui.Essentials.csproj",
             "src\\Avalonia.Controls.Maui.Graphics\\Avalonia.Controls.Maui.Graphics.csproj",
             "src\\Avalonia.Controls.Maui\\Avalonia.Controls.Maui.csproj",
+            "src\\Avalonia.Controls.Maui.Desktop\\Avalonia.Controls.Maui.Desktop.csproj",
             "src\\Avalonia.Controls.Maui.SourceGenerators\\Avalonia.Controls.Maui.SourceGenerators.csproj",
             "tests\\Avalonia.Controls.Maui.Tests\\Avalonia.Controls.Maui.Tests.csproj",
             "tests\\Avalonia.Controls.Maui.RenderTests\\Avalonia.Controls.Maui.RenderTests.csproj"

--- a/Avalonia.Controls.Maui.slnx
+++ b/Avalonia.Controls.Maui.slnx
@@ -17,6 +17,7 @@
     <Project Path="src/Avalonia.Controls.Maui.Graphics/Avalonia.Controls.Maui.Graphics.csproj" />
     <Project Path="src/Avalonia.Controls.Maui.Maps.Mapsui/Avalonia.Controls.Maui.Maps.Mapsui.csproj" />
     <Project Path="src/Avalonia.Controls.Maui/Avalonia.Controls.Maui.csproj" />
+    <Project Path="src/Avalonia.Controls.Maui.Desktop/Avalonia.Controls.Maui.Desktop.csproj" />
     <Project Path="src/Avalonia.Controls.Maui.SourceGenerators/Avalonia.Controls.Maui.SourceGenerators.csproj" />
   </Folder>
   <Folder Name="/Tests/">

--- a/Avalonia.Controls.Maui.tests.slnf
+++ b/Avalonia.Controls.Maui.tests.slnf
@@ -6,6 +6,7 @@
             "src\\Avalonia.Controls.Maui.Compatibility\\Avalonia.Controls.Maui.Compatibility.csproj",
             "src\\Avalonia.Controls.Maui.Essentials\\Avalonia.Controls.Maui.Essentials.csproj",
             "src\\Avalonia.Controls.Maui\\Avalonia.Controls.Maui.csproj",
+            "src\\Avalonia.Controls.Maui.Desktop\\Avalonia.Controls.Maui.Desktop.csproj",
             "src\\Avalonia.Controls.Maui.SourceGenerators\\Avalonia.Controls.Maui.SourceGenerators.csproj",
             "tests\\Avalonia.Controls.Maui.Tests\\Avalonia.Controls.Maui.Tests.csproj",
             "tests\\Avalonia.Controls.Maui.SourceGenerators.Tests\\Avalonia.Controls.Maui.SourceGenerators.Tests.csproj",

--- a/samples/AvaloniaSandboxApp/MainWindow.axaml
+++ b/samples/AvaloniaSandboxApp/MainWindow.axaml
@@ -6,4 +6,19 @@
         xmlns:local="using:AvaloniaSandboxApp"
         mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="700"
         x:Class="AvaloniaSandboxApp.MainWindow">
+        <TabControl>
+                <TabItem Background="Green" Header="Home">
+                        <StackPanel Margin="20">
+                        <TextBlock Text="Welcome to Avalonia.Controls.Maui!" FontSize="24" FontWeight="Bold" Margin="0,0,0,10"/>
+                        <TextBlock Text="This is a sample application demonstrating the use of Avalonia.Controls.Maui in a .NET MAUI project." FontSize="16" Margin="0,0,0,20"/>
+                        <Button Content="Click Me" Width="120" Height="40"/>
+                        </StackPanel>
+                </TabItem>
+                <TabItem Header="Settings">
+                        <StackPanel Margin="20">
+                        <TextBlock Text="Settings Page" FontSize="24" FontWeight="Bold" Margin="0,0,0,10"/>
+                        <TextBlock Text="Here you can configure your application settings." FontSize="16"/>
+                        </StackPanel>
+                </TabItem>                
+</TabControl>
 </Window>

--- a/samples/ControlGallery/ControlGallery/Pages/GesturesPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/GesturesPage.xaml
@@ -184,6 +184,104 @@
                 </VerticalStackLayout>
             </Border>
 
+            <!-- Grid Tap Gesture -->
+            <Border Stroke="{AppThemeBinding Light={StaticResource SectionBorderLight}, Dark={StaticResource SectionBorderDark}}"
+                    Background="{AppThemeBinding Light={StaticResource SectionBackgroundLight}, Dark={StaticResource SectionBackgroundDark}}"
+                    Padding="10">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10"/>
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Grid Tap Gesture" FontAttributes="Bold"/>
+                    <Label Text="TapGestureRecognizer on a Grid layout" FontSize="12" FontAttributes="Italic"/>
+
+                    <Grid x:Name="TapGrid"
+                          HeightRequest="150"
+                          BackgroundColor="LightSteelBlue"
+                          ColumnDefinitions="*,*"
+                          Padding="10">
+                        <Grid.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnGridTapTapped" NumberOfTapsRequired="1" />
+                        </Grid.GestureRecognizers>
+                        <Label Text="Left"
+                               VerticalOptions="Center"
+                               HorizontalOptions="Center"
+                               FontAttributes="Bold"/>
+                        <Label Text="Right"
+                               Grid.Column="1"
+                               VerticalOptions="Center"
+                               HorizontalOptions="Center"
+                               FontAttributes="Bold"/>
+                    </Grid>
+                    <Label x:Name="GridTapCountLabel" Text="Grid Taps: 0" HorizontalOptions="Center" />
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Grid Pointer Gesture -->
+            <Border Stroke="{AppThemeBinding Light={StaticResource SectionBorderLight}, Dark={StaticResource SectionBorderDark}}"
+                    Background="{AppThemeBinding Light={StaticResource SectionBackgroundLight}, Dark={StaticResource SectionBackgroundDark}}"
+                    Padding="10">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10"/>
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Grid Pointer Gesture" FontAttributes="Bold"/>
+                    <Label Text="PointerGestureRecognizer on a Grid with multiple cells" FontSize="12" FontAttributes="Italic"/>
+
+                    <Grid x:Name="PointerGrid"
+                          HeightRequest="150"
+                          BackgroundColor="Lavender"
+                          RowDefinitions="*,*"
+                          ColumnDefinitions="*,*"
+                          RowSpacing="2"
+                          ColumnSpacing="2">
+                        <Grid.GestureRecognizers>
+                            <PointerGestureRecognizer PointerEntered="OnGridPointerEntered"
+                                                      PointerExited="OnGridPointerExited"
+                                                      PointerMoved="OnGridPointerMoved" />
+                        </Grid.GestureRecognizers>
+                        <BoxView Color="CornflowerBlue" Grid.Row="0" Grid.Column="0" />
+                        <BoxView Color="MediumSeaGreen" Grid.Row="0" Grid.Column="1" />
+                        <BoxView Color="Coral" Grid.Row="1" Grid.Column="0" />
+                        <BoxView Color="MediumPurple" Grid.Row="1" Grid.Column="1" />
+                    </Grid>
+                    <Label x:Name="GridPointerStatusLabel" Text="Grid Pointer: Idle" HorizontalOptions="Center" />
+                    <Label x:Name="GridPointerPositionLabel" Text="Position: -" HorizontalOptions="Center" FontSize="12" />
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Grid Multiple Gestures -->
+            <Border Stroke="{AppThemeBinding Light={StaticResource SectionBorderLight}, Dark={StaticResource SectionBorderDark}}"
+                    Background="{AppThemeBinding Light={StaticResource SectionBackgroundLight}, Dark={StaticResource SectionBackgroundDark}}"
+                    Padding="10">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10"/>
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Grid Multiple Gestures" FontAttributes="Bold"/>
+                    <Label Text="Tap + Pointer + Swipe on the same Grid" FontSize="12" FontAttributes="Italic"/>
+
+                    <Grid x:Name="MultiGestureGrid"
+                          HeightRequest="150"
+                          BackgroundColor="MistyRose"
+                          Padding="10">
+                        <Grid.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnMultiGridTapped" NumberOfTapsRequired="1" />
+                            <PointerGestureRecognizer PointerEntered="OnMultiGridPointerEntered"
+                                                      PointerExited="OnMultiGridPointerExited" />
+                            <SwipeGestureRecognizer Direction="Left" Swiped="OnMultiGridSwiped" />
+                            <SwipeGestureRecognizer Direction="Right" Swiped="OnMultiGridSwiped" />
+                        </Grid.GestureRecognizers>
+                        <Label x:Name="MultiGestureGridLabel"
+                               Text="Tap, hover, or swipe!"
+                               VerticalOptions="Center"
+                               HorizontalOptions="Center"
+                               FontAttributes="Bold"/>
+                    </Grid>
+                    <Label x:Name="MultiGestureStatusLabel" Text="Last Event: None" HorizontalOptions="Center" />
+                </VerticalStackLayout>
+            </Border>
+
         </VerticalStackLayout>
     </ScrollView>
 </ContentPage>

--- a/samples/ControlGallery/ControlGallery/Pages/GesturesPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/GesturesPage.xaml.cs
@@ -4,9 +4,10 @@ namespace ControlGallery.Pages;
 
 public partial class GesturesPage : ContentPage
 {
-    private int _singleTapCount = 0;
-    private int _doubleTapCount = 0;
-    
+    private int _singleTapCount;
+    private int _doubleTapCount;
+    private int _gridTapCount;
+
     // Pan gesture state
     private double _panX;
     private double _panY;
@@ -133,5 +134,68 @@ public partial class GesturesPage : ContentPage
             SwipeDirection.Down => Colors.LightYellow,
             _ => Colors.LightCyan
         };
+    }
+
+    // Grid Tap Gesture
+    private void OnGridTapTapped(object? sender, TappedEventArgs e)
+    {
+        _gridTapCount++;
+        GridTapCountLabel.Text = $"Grid Taps: {_gridTapCount}";
+
+        // Flash the grid background
+        TapGrid.BackgroundColor = Colors.SteelBlue;
+        Dispatcher.DispatchDelayed(TimeSpan.FromMilliseconds(150), () =>
+        {
+            TapGrid.BackgroundColor = Colors.LightSteelBlue;
+        });
+    }
+
+    // Grid Pointer Gesture
+    private void OnGridPointerEntered(object? sender, PointerEventArgs e)
+    {
+        GridPointerStatusLabel.Text = "Grid Pointer: Entered";
+    }
+
+    private void OnGridPointerExited(object? sender, PointerEventArgs e)
+    {
+        GridPointerStatusLabel.Text = "Grid Pointer: Exited";
+        GridPointerPositionLabel.Text = "Position: -";
+    }
+
+    private void OnGridPointerMoved(object? sender, PointerEventArgs e)
+    {
+        GridPointerStatusLabel.Text = "Grid Pointer: Moving";
+        var pos = e.GetPosition(PointerGrid);
+        GridPointerPositionLabel.Text = pos.HasValue
+            ? $"Position: ({pos.Value.X:F0}, {pos.Value.Y:F0})"
+            : "Position: -";
+    }
+
+    // Grid Multiple Gestures
+    private void OnMultiGridTapped(object? sender, TappedEventArgs e)
+    {
+        MultiGestureStatusLabel.Text = "Last Event: Tapped";
+        MultiGestureGrid.BackgroundColor = Colors.PeachPuff;
+        Dispatcher.DispatchDelayed(TimeSpan.FromMilliseconds(200), () =>
+        {
+            MultiGestureGrid.BackgroundColor = Colors.MistyRose;
+        });
+    }
+
+    private void OnMultiGridPointerEntered(object? sender, PointerEventArgs e)
+    {
+        MultiGestureStatusLabel.Text = "Last Event: Pointer Entered";
+        MultiGestureGrid.BackgroundColor = Colors.LavenderBlush;
+    }
+
+    private void OnMultiGridPointerExited(object? sender, PointerEventArgs e)
+    {
+        MultiGestureStatusLabel.Text = "Last Event: Pointer Exited";
+        MultiGestureGrid.BackgroundColor = Colors.MistyRose;
+    }
+
+    private void OnMultiGridSwiped(object? sender, SwipedEventArgs e)
+    {
+        MultiGestureStatusLabel.Text = $"Last Event: Swiped {e.Direction}";
     }
 }

--- a/samples/ControlGallery/ControlGallery/Pages/TabbedPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/TabbedPage.xaml.cs
@@ -173,7 +173,7 @@ public partial class TabbedPage : ContentPage
             BarBackgroundColor = Color.FromArgb("#312E81"), // Indigo 900
             BarTextColor = Colors.White,
             SelectedTabColor = Color.FromArgb("#4338CA"), // Indigo 700
-            UnselectedTabColor = Color.FromArgb("#312E81") // Indigo 900 (Same as bar)
+            UnselectedTabColor = Color.FromArgb("#3b38a5")
         };
 
         var controlPage = new ContentPage
@@ -203,7 +203,7 @@ public partial class TabbedPage : ContentPage
             BarBackgroundColor = Colors.RoyalBlue,
             BarTextColor = Colors.White,
             SelectedTabColor = Colors.White,
-            UnselectedTabColor = Colors.RoyalBlue
+            UnselectedTabColor = Colors.White
         };
 
         tabbedPage.Children.Add(new ContentPage

--- a/src/Avalonia.Controls.Maui.Desktop/Avalonia.Controls.Maui.Desktop.csproj
+++ b/src/Avalonia.Controls.Maui.Desktop/Avalonia.Controls.Maui.Desktop.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(DotNetTfm)</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoWarn>$(NoWarn);CS0618;CS8002;NU5128</NoWarn>
+    <IsAotCompatible>true</IsAotCompatible>
+    <AssemblyOriginatorKeyFile>$(BuildDirectory)/avalonia.snk</AssemblyOriginatorKeyFile>
+    <PackageDescription>.NET MAUI Desktop platform support for Avalonia.Controls.Maui.</PackageDescription>
+    <SignAssembly>true</SignAssembly>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Avalonia.Controls.Maui/Avalonia.Controls.Maui.csproj" />
+    <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
+  </ItemGroup>
+
+  <!-- Source generator -->
+  <ItemGroup>
+    <ProjectReference Include="../Avalonia.Controls.Maui.SourceGenerators/Avalonia.Controls.Maui.SourceGenerators.csproj"
+        PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false"
+        GlobalPropertiesToRemove="PublishAot" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <None Include="../Avalonia.Controls.Maui.SourceGenerators/bin/$(Configuration)/netstandard2.0/Avalonia.Controls.Maui.SourceGenerators.dll"
+        Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
+  <!-- Pack Desktop props -->
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)Avalonia.Controls.Maui.Desktop.props"
+        Pack="true" PackagePath="build/Avalonia.Controls.Maui.Desktop.props" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)Avalonia.Controls.Maui.Desktop.props"
+        Pack="true" PackagePath="buildTransitive/Avalonia.Controls.Maui.Desktop.props" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="" Visible="false" />
+  </ItemGroup>
+</Project>

--- a/src/Avalonia.Controls.Maui.Desktop/Avalonia.Controls.Maui.Desktop.props
+++ b/src/Avalonia.Controls.Maui.Desktop/Avalonia.Controls.Maui.Desktop.props
@@ -1,0 +1,27 @@
+<Project>
+
+  <!-- Defaults -->
+  <PropertyGroup>
+    <!-- Disable bootstrap generation on platform TFMs (Android, iOS, macCatalyst, Windows, etc.).
+         The desktop bootstrap (Main + StartWithClassicDesktopLifetime) only applies to the base TFM.
+         Platform TFMs have their own entry points and Avalonia lifecycle bootstrapping. -->
+    <AvaloniaControlsMauiGenerateBootstrap
+        Condition="'$(AvaloniaControlsMauiGenerateBootstrap)' == '' And '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != ''">false</AvaloniaControlsMauiGenerateBootstrap>
+    <AvaloniaControlsMauiGenerateBootstrap Condition="'$(AvaloniaControlsMauiGenerateBootstrap)' == ''">true</AvaloniaControlsMauiGenerateBootstrap>
+    <AvaloniaControlsMauiTheme Condition="'$(AvaloniaControlsMauiTheme)' == ''">Fluent</AvaloniaControlsMauiTheme>
+    <AvaloniaControlsMauiThemeVariant Condition="'$(AvaloniaControlsMauiThemeVariant)' == ''">Default</AvaloniaControlsMauiThemeVariant>
+    <AvaloniaControlsMauiIncludeInterFont Condition="'$(AvaloniaControlsMauiIncludeInterFont)' == ''">true</AvaloniaControlsMauiIncludeInterFont>
+  </PropertyGroup>
+
+  <!-- Pass properties to source generator -->
+  <ItemGroup>
+    <CompilerVisibleProperty Include="AvaloniaControlsMauiGenerateBootstrap" />
+    <CompilerVisibleProperty Include="AvaloniaControlsMauiTheme" />
+    <CompilerVisibleProperty Include="AvaloniaControlsMauiThemeVariant" />
+    <CompilerVisibleProperty Include="AvaloniaControlsMauiIncludeInterFont" />
+    <CompilerVisibleProperty Include="AvaloniaControlsMauiProgramClass" />
+    <CompilerVisibleProperty Include="AvaloniaControlsMauiAppClassName" />
+    <CompilerVisibleProperty Include="RootNamespace" />
+  </ItemGroup>
+
+</Project>

--- a/src/Avalonia.Controls.Maui.Desktop/README.md
+++ b/src/Avalonia.Controls.Maui.Desktop/README.md
@@ -1,0 +1,36 @@
+# Avalonia.Controls.Maui.Desktop
+
+This package provides Avalonia.Controls.Maui support for .NET MAUI Single Project apps, adding Avalonia.Desktop support to apps that implement the single project build system.
+
+If you wish to build for Avalonia.Browser (WASM), or the other Avalonia target types, refer to the Avalonia.Controls.Maui documentation.
+
+## Usage
+
+Reference this package in your .NET MAUI project:
+
+```xml
+<PackageReference Include="Avalonia.Controls.Maui.Desktop" Version="..." />
+```
+
+And update the target frameworks to include the standard .NET version.
+
+```xml
+<PropertyGroup>
+		<!-- Add net11.0... -->
+		<TargetFrameworks>net11.0;net11.0-android</TargetFrameworks>
+		<TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">
+...
+```
+
+The source generator will automatically create a `Program.Main` entry point for your desktop app. You can control its behavior with MSBuild properties:
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `AvaloniaControlsMauiGenerateBootstrap` | `true` | Generate the desktop bootstrap entry point |
+| `AvaloniaControlsMauiTheme` | `Fluent` | Theme to use |
+| `AvaloniaControlsMauiThemeVariant` | `Default` | Theme variant (Default, Light, Dark) |
+| `AvaloniaControlsMauiIncludeInterFont` | `true` | Include Inter font family |
+
+## License
+
+This project is licensed under the [MIT License](https://github.com/AvaloniaUI/Avalonia.Controls.Maui/blob/main/LICENSE).

--- a/src/Avalonia.Controls.Maui.props
+++ b/src/Avalonia.Controls.Maui.props
@@ -6,29 +6,4 @@
     <AvaloniaVersion Condition="'$(AvaloniaVersion)' == ''">__AvaloniaVersionPlaceholder__</AvaloniaVersion>
   </PropertyGroup>
 
-  <!-- Defaults -->
-  <PropertyGroup>
-    <!-- Disable bootstrap generation on platform TFMs (Android, iOS, macCatalyst, Windows, etc.).
-         The desktop bootstrap (Main + StartWithClassicDesktopLifetime) only applies to the base TFM.
-         Platform TFMs have their own entry points and Avalonia lifecycle bootstrapping. -->
-    <AvaloniaControlsMauiGenerateBootstrap
-        Condition="'$(AvaloniaControlsMauiGenerateBootstrap)' == '' And '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != ''">false</AvaloniaControlsMauiGenerateBootstrap>
-    <AvaloniaControlsMauiGenerateBootstrap Condition="'$(AvaloniaControlsMauiGenerateBootstrap)' == ''">true</AvaloniaControlsMauiGenerateBootstrap>
-    <AvaloniaControlsMauiTheme Condition="'$(AvaloniaControlsMauiTheme)' == ''">Fluent</AvaloniaControlsMauiTheme>
-    <AvaloniaControlsMauiThemeVariant Condition="'$(AvaloniaControlsMauiThemeVariant)' == ''">Default</AvaloniaControlsMauiThemeVariant>
-    <AvaloniaControlsMauiIncludeInterFont Condition="'$(AvaloniaControlsMauiIncludeInterFont)' == ''">true</AvaloniaControlsMauiIncludeInterFont>
-  </PropertyGroup>
-
-  <!-- Pass properties to source generator -->
-  <ItemGroup>
-    <CompilerVisibleProperty Include="AvaloniaControlsMauiGenerateBootstrap" />
-    <CompilerVisibleProperty Include="AvaloniaControlsMauiTheme" />
-    <CompilerVisibleProperty Include="AvaloniaControlsMauiThemeVariant" />
-    <CompilerVisibleProperty Include="AvaloniaControlsMauiIncludeInterFont" />
-    <CompilerVisibleProperty Include="AvaloniaControlsMauiProgramClass" />
-    <CompilerVisibleProperty Include="AvaloniaControlsMauiAppClassName" />
-    <CompilerVisibleProperty Include="RootNamespace" />
-  </ItemGroup>
-
-
 </Project>

--- a/src/Avalonia.Controls.Maui/Avalonia.Controls.Maui.csproj
+++ b/src/Avalonia.Controls.Maui/Avalonia.Controls.Maui.csproj
@@ -33,18 +33,16 @@
   </ItemGroup>
 
   <!-- Platform-specific Avalonia packages (become nuspec dependency groups per TFM) -->
-  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">
-    <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
-  </ItemGroup>
-
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
     <PackageReference Include="Avalonia.iOS" Version="$(AvaloniaVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
     <PackageReference Include="Avalonia.Android" Version="$(AvaloniaVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browser'">
+    <PackageReference Include="Avalonia.Browser" Version="$(AvaloniaVersion)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -74,21 +72,6 @@
         Pack="true" PackagePath="build/Avalonia.Controls.Maui.props" Visible="false" />
     <None Include="$(IntermediateOutputPath)Avalonia.Controls.Maui.props"
         Pack="true" PackagePath="buildTransitive/Avalonia.Controls.Maui.props" Visible="false" />
-  </ItemGroup>
-
-  <!-- Reference source generator project -->
-  <ItemGroup>
-    <ProjectReference Include="../Avalonia.Controls.Maui.SourceGenerators/Avalonia.Controls.Maui.SourceGenerators.csproj"
-        PrivateAssets="all"
-        OutputItemType="Analyzer"
-        ReferenceOutputAssembly="false"
-        GlobalPropertiesToRemove="PublishAot" />
-  </ItemGroup>
-
-  <!-- Pack generator DLL into analyzers path -->
-  <ItemGroup Condition="'$(IsPackable)' == 'true'">
-    <None Include="../Avalonia.Controls.Maui.SourceGenerators/bin/$(Configuration)/netstandard2.0/Avalonia.Controls.Maui.SourceGenerators.dll"
-        Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <!-- Platform-specific file includes -->

--- a/src/Avalonia.Controls.Maui/Controls/TabbedPage/TabbedPage.axaml
+++ b/src/Avalonia.Controls.Maui/Controls/TabbedPage/TabbedPage.axaml
@@ -61,12 +61,4 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
 
-    <Style Selector="TabControl.TabbedPage > TabItem:selected">
-        <Setter Property="Background" Value="Transparent" />
-    </Style>
-    
-    <Style Selector="TabControl.TabbedPage > TabItem:pointerover">
-        <Setter Property="Background" Value="Transparent" />
-    </Style>
-
 </Styles>

--- a/src/Avalonia.Controls.Maui/Extensions/ShellItemExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/ShellItemExtensions.cs
@@ -302,6 +302,22 @@ public static class ShellItemExtensions
         handler.UpdateTabAppearance(item);
     }
 
+    // All Fluent theme resource keys we may override for tab appearance
+    private static readonly string[] ThemeResourceKeys =
+    [
+        "TabItemHeaderSelectedPipeFill",
+        "TabItemHeaderForegroundSelected",
+        "TabItemHeaderForegroundSelectedPointerOver",
+        "TabItemHeaderForegroundSelectedPressed",
+        "TabItemHeaderForegroundUnselected",
+        "TabItemHeaderForegroundUnselectedPointerOver",
+        "TabItemHeaderForegroundUnselectedPressed",
+        "ThemeAccentBrush",
+        "ThemeAccentBrush2",
+        "ThemeAccentBrush3",
+        "ThemeAccentBrush4"
+    ];
+
     internal static void UpdateTabAppearanceInternal(this ShellItemHandler handler, ShellItem item)
     {
         if (handler._tabControl == null || item == null)
@@ -312,53 +328,79 @@ public static class ShellItemExtensions
         var unselectedColor = handler.GetResolvedProperty<Color?>(Microsoft.Maui.Controls.Shell.TabBarUnselectedColorProperty, item);
         var disabledColor = handler.GetResolvedProperty<Color?>(Microsoft.Maui.Controls.Shell.TabBarDisabledColorProperty, item);
 
-        var selectedIconBrush = (foregroundColor ?? titleColor)?.ToPlatform();
+        bool hasExplicitColors = foregroundColor != null || titleColor != null || unselectedColor != null;
+
+        // In MAUI, TabBarForegroundColor maps to the selection indicator and selected icon/text tint,
+        // NOT to a full background color. TabBarTitleColor overrides the selected text color specifically.
+        var accentBrush = foregroundColor?.ToPlatform();
         var selectedTextBrush = (titleColor ?? foregroundColor)?.ToPlatform();
-        var highlightBrush = (IBrush?)foregroundColor?.ToPlatform() ?? Brushes.Transparent;
+        var selectedIconBrush = (foregroundColor ?? titleColor)?.ToPlatform();
         var unselectedBrush = unselectedColor?.ToPlatform();
         var disabledBrush = disabledColor?.ToPlatform();
 
-        // Populate dynamic resources used by our custom Styles and the built-in themes
-        handler._tabControl.Resources["ShellTabSelectedBackground"] = highlightBrush;
-        handler._tabControl.Resources["ShellTabSelectedForeground"] = selectedTextBrush;
-        handler._tabControl.Resources["ShellTabHoverBackground"] = Brushes.Transparent;
-        handler._tabControl.Resources["ShellTabUnselectedForeground"] = unselectedBrush;
-
-        // Correct Avalonia theme resource keys for selection/accent
-        var resourceKeys = new[]
+        if (hasExplicitColors)
         {
-            "TabItemHeaderSelectedBackground",
-            "TabItemHeaderSelectedPointerOverBackground",
-            "TabItemHeaderPointerOverBackground",
-            "TabItemHeaderSelectedForeground",
-            "TabItemHeaderSelectedPipeFill",          // Fluent selection line
-            "ThemeAccentBrush",                       // Simple accent
-            "ThemeAccentBrush2",
-            "ThemeAccentBrush3",
-            "ThemeAccentBrush4"                        // Simple selected background fallback
-        };
+            // Override Fluent theme resources with MAUI-specified colors.
+            // Map TabBarForegroundColor to the selection indicator (pipe) and accent colors.
+            if (accentBrush != null)
+            {
+                handler._tabControl.Resources["TabItemHeaderSelectedPipeFill"] = accentBrush;
+                handler._tabControl.Resources["ThemeAccentBrush"] = accentBrush;
+                handler._tabControl.Resources["ThemeAccentBrush2"] = accentBrush;
+                handler._tabControl.Resources["ThemeAccentBrush3"] = accentBrush;
+                handler._tabControl.Resources["ThemeAccentBrush4"] = accentBrush;
+            }
 
+            // Map selected text color to all selected-state foreground resources
+            if (selectedTextBrush != null)
+            {
+                handler._tabControl.Resources["TabItemHeaderForegroundSelected"] = selectedTextBrush;
+                handler._tabControl.Resources["TabItemHeaderForegroundSelectedPointerOver"] = selectedTextBrush;
+                handler._tabControl.Resources["TabItemHeaderForegroundSelectedPressed"] = selectedTextBrush;
+            }
+
+            // Map unselected color to all unselected-state foreground resources
+            if (unselectedBrush != null)
+            {
+                handler._tabControl.Resources["TabItemHeaderForegroundUnselected"] = unselectedBrush;
+                handler._tabControl.Resources["TabItemHeaderForegroundUnselectedPointerOver"] = unselectedBrush;
+                handler._tabControl.Resources["TabItemHeaderForegroundUnselectedPressed"] = unselectedBrush;
+            }
+        }
+        else
+        {
+            // No explicit MAUI colors — clear any previous overrides so Fluent theme defaults apply
+            foreach (var key in ThemeResourceKeys)
+            {
+                handler._tabControl.Resources.Remove(key);
+            }
+        }
+
+        // Apply icon tint colors and clear direct text foreground overrides.
+        // Text foreground is handled by the Fluent theme through TextElement.Foreground
+        // inheritance from PART_LayoutRoot, using the resource keys we set above.
         foreach (var tabItemObj in handler._tabControl.Items)
         {
             if (tabItemObj is TabItem tabItem)
             {
-                foreach (var key in resourceKeys)
-                {
-                    if (key.Contains("Foreground")) tabItem.Resources[key] = selectedTextBrush;
-                    else tabItem.Resources[key] = highlightBrush;
-                }
-
+                IBrush? iconBrush;
                 if (!tabItem.IsEnabled)
-                    tabItem.ApplyColorsToTabItem(disabledBrush, disabledBrush);
+                    iconBrush = disabledBrush;
                 else if (tabItem.Tag == item.CurrentItem || tabItem.IsSelected)
-                    tabItem.ApplyColorsToTabItem(selectedTextBrush, selectedIconBrush);
+                    iconBrush = selectedIconBrush;
                 else
-                    tabItem.ApplyColorsToTabItem(unselectedBrush, unselectedBrush);
+                    iconBrush = unselectedBrush;
+
+                tabItem.ApplyIconColorsToTabItem(iconBrush);
             }
         }
     }
 
-    internal static void ApplyColorsToTabItem(this TabItem tabItem, IBrush? textBrush, IBrush? iconBrush)
+    /// <summary>
+    /// Applies icon tint color and clears any direct text foreground overrides on the tab header.
+    /// Text color is handled by the Fluent theme through TextElement.Foreground inheritance.
+    /// </summary>
+    internal static void ApplyIconColorsToTabItem(this TabItem tabItem, IBrush? iconBrush)
     {
         if (tabItem.Header is Panel panel)
         {
@@ -366,8 +408,8 @@ public static class ShellItemExtensions
             {
                 if (child is TextBlock textBlock)
                 {
-                    if (textBrush != null) textBlock.Foreground = textBrush;
-                    else textBlock.ClearValue(TextBlock.ForegroundProperty);
+                    // Clear direct foreground so Fluent theme TextElement.Foreground inheritance works
+                    textBlock.ClearValue(TextBlock.ForegroundProperty);
                 }
                 else if (child is Border border && border.Classes.Contains("shell-tab-header-icon"))
                 {
@@ -378,8 +420,7 @@ public static class ShellItemExtensions
         }
         else if (tabItem.Header is TextBlock tb)
         {
-            if (textBrush != null) tb.Foreground = textBrush;
-            else tb.ClearValue(TextBlock.ForegroundProperty);
+            tb.ClearValue(TextBlock.ForegroundProperty);
         }
     }
 

--- a/src/Avalonia.Controls.Maui/Extensions/TabbedPageExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/TabbedPageExtensions.cs
@@ -12,11 +12,24 @@ namespace Avalonia.Controls.Maui.Extensions;
 /// </summary>
 public static class TabbedPageExtensions
 {
-    // Resource keys for tab bar styling (used by TabbedPage.axaml DynamicResource bindings)
+    // Resource key for tab bar strip background (used by TabbedPage.axaml DynamicResource binding)
     private const string BarBackgroundResourceKey = "TabbedPageBarBackground";
-    private const string BarTextColorResourceKey = "TabbedPageBarTextColor";
-    private const string SelectedTabColorResourceKey = "TabbedPageSelectedTabColor";
-    private const string UnselectedTabColorResourceKey = "TabbedPageUnselectedTabColor";
+
+    // Fluent theme resource keys we override for tab appearance
+    private static readonly string[] FluentThemeKeys =
+    [
+        "TabItemHeaderSelectedPipeFill",
+        "TabItemHeaderForegroundSelected",
+        "TabItemHeaderForegroundSelectedPointerOver",
+        "TabItemHeaderForegroundSelectedPressed",
+        "TabItemHeaderForegroundUnselected",
+        "TabItemHeaderForegroundUnselectedPointerOver",
+        "TabItemHeaderForegroundUnselectedPressed",
+        "ThemeAccentBrush",
+        "ThemeAccentBrush2",
+        "ThemeAccentBrush3",
+        "ThemeAccentBrush4"
+    ];
 
     /// <summary>
     /// Updates the tab bar background brush from the TabbedPage's BarBackground property.
@@ -71,109 +84,25 @@ public static class TabbedPageExtensions
     /// <summary>
     /// Updates the tab bar text color from the TabbedPage's BarTextColor property.
     /// </summary>
-    /// <param name="tabControl">The Avalonia TabControl to update.</param>
-    /// <param name="tabbedPage">The MAUI TabbedPage containing the BarTextColor value.</param>
-    /// <remarks>
-    /// This sets the text color for tab headers in the bar.
-    /// </remarks>
     public static void UpdateBarTextColor(this TabControl tabControl, TabbedPage tabbedPage)
     {
-        if (tabbedPage.BarTextColor != null)
-        {
-            var brush = new Media.SolidColorBrush(tabbedPage.BarTextColor.ToAvaloniaColor());
-            tabControl.Resources[BarTextColorResourceKey] = brush;
-
-            // Apply to all tab item headers
-            foreach (var item in tabControl.Items)
-            {
-                if (item is TabItem tabItem)
-                {
-                    tabItem.Foreground = brush;
-                }
-            }
-        }
-        else
-        {
-            tabControl.Resources.Remove(BarTextColorResourceKey);
-
-            foreach (var item in tabControl.Items)
-            {
-                if (item is TabItem tabItem)
-                {
-                    tabItem.ClearValue(TabItem.ForegroundProperty);
-                }
-            }
-        }
+        tabControl.UpdateTabColors(tabbedPage);
     }
 
     /// <summary>
     /// Updates the selected tab color from the TabbedPage's SelectedTabColor property.
     /// </summary>
-    /// <param name="tabControl">The Avalonia TabControl to update.</param>
-    /// <param name="tabbedPage">The MAUI TabbedPage containing the SelectedTabColor value.</param>
-    /// <remarks>
-    /// This applies a background color to the currently selected tab header.
-    /// </remarks>
     public static void UpdateSelectedTabColor(this TabControl tabControl, TabbedPage tabbedPage)
     {
-        if (tabbedPage.SelectedTabColor != null)
-        {
-            var brush = new Media.SolidColorBrush(tabbedPage.SelectedTabColor.ToAvaloniaColor());
-            tabControl.Resources[SelectedTabColorResourceKey] = brush;
-
-            // Apply to currently selected tab item
-            if (tabControl.SelectedItem is TabItem selectedTabItem)
-            {
-                selectedTabItem.Background = brush;
-            }
-        }
-        else
-        {
-            tabControl.Resources.Remove(SelectedTabColorResourceKey);
-
-            if (tabControl.SelectedItem is TabItem selectedTabItem)
-            {
-                selectedTabItem.ClearValue(TabItem.BackgroundProperty);
-            }
-        }
+        tabControl.UpdateTabColors(tabbedPage);
     }
 
     /// <summary>
     /// Updates the unselected tab color from the TabbedPage's UnselectedTabColor property.
     /// </summary>
-    /// <param name="tabControl">The Avalonia TabControl to update.</param>
-    /// <param name="tabbedPage">The MAUI TabbedPage containing the UnselectedTabColor value.</param>
-    /// <remarks>
-    /// This applies a background color to tabs that are not currently selected.
-    /// </remarks>
     public static void UpdateUnselectedTabColor(this TabControl tabControl, TabbedPage tabbedPage)
     {
-        if (tabbedPage.UnselectedTabColor != null)
-        {
-            var brush = new Media.SolidColorBrush(tabbedPage.UnselectedTabColor.ToAvaloniaColor());
-            tabControl.Resources[UnselectedTabColorResourceKey] = brush;
-
-            // Apply to all non-selected tab items
-            foreach (var item in tabControl.Items)
-            {
-                if (item is TabItem tabItem && tabItem != tabControl.SelectedItem)
-                {
-                    tabItem.Background = brush;
-                }
-            }
-        }
-        else
-        {
-            tabControl.Resources.Remove(UnselectedTabColorResourceKey);
-
-            foreach (var item in tabControl.Items)
-            {
-                if (item is TabItem tabItem && tabItem != tabControl.SelectedItem)
-                {
-                    tabItem.ClearValue(TabItem.BackgroundProperty);
-                }
-            }
-        }
+        tabControl.UpdateTabColors(tabbedPage);
     }
 
     /// <summary>
@@ -328,11 +257,13 @@ public static class TabbedPageExtensions
     }
 
     /// <summary>
-    /// Reapplies all tab colors from stored resources after tab items are rebuilt or selection changes.
+    /// Reapplies all tab colors after tab items are rebuilt or selection changes.
+    /// Uses Fluent theme resource overrides instead of direct property setting so that
+    /// all states (selected, hover, pressed) are handled correctly by the theme.
     /// </summary>
     public static void UpdateTabColors(this TabControl tabControl, TabbedPage tabbedPage)
     {
-        // Apply bar background resource (template will pick it up via DynamicResource)
+        // Apply bar background resource (template picks it up via DynamicResource)
         if (tabbedPage.BarBackground != null)
         {
             var brush = tabbedPage.BarBackground.ToPlatform();
@@ -343,32 +274,76 @@ public static class TabbedPageExtensions
         }
         else if (tabbedPage.BarBackgroundColor != null)
         {
-            var brush = new Media.SolidColorBrush(tabbedPage.BarBackgroundColor.ToAvaloniaColor());
-            tabControl.Resources[BarBackgroundResourceKey] = brush;
+            tabControl.Resources[BarBackgroundResourceKey] =
+                new Media.SolidColorBrush(tabbedPage.BarBackgroundColor.ToAvaloniaColor());
         }
 
-        // Apply selected tab color
-        if (tabbedPage.SelectedTabColor != null)
-        {
-            tabControl.UpdateSelectedTabColor(tabbedPage);
-        }
+        var selectedTabColor = tabbedPage.SelectedTabColor;
+        var unselectedTabColor = tabbedPage.UnselectedTabColor;
+        var barTextColor = tabbedPage.BarTextColor;
 
-        // Apply unselected tab color
-        if (tabbedPage.UnselectedTabColor != null)
-        {
-            tabControl.UpdateUnselectedTabColor(tabbedPage);
-        }
+        bool hasExplicitColors = selectedTabColor != null || unselectedTabColor != null || barTextColor != null;
 
-        // Apply text color
-        if (tabbedPage.BarTextColor != null)
+        if (hasExplicitColors)
         {
-            var textBrush = new Media.SolidColorBrush(tabbedPage.BarTextColor.ToAvaloniaColor());
-            foreach (var item in tabControl.Items)
+            // SelectedTabColor → pipe fill (selection indicator) and accent.
+            // On Android/iOS this is the indicator tint, not a full background.
+            if (selectedTabColor != null)
             {
-                if (item is TabItem tabItem)
+                var brush = new Media.SolidColorBrush(selectedTabColor.ToAvaloniaColor());
+                tabControl.Resources["TabItemHeaderSelectedPipeFill"] = brush;
+                tabControl.Resources["ThemeAccentBrush"] = brush;
+                tabControl.Resources["ThemeAccentBrush2"] = brush;
+                tabControl.Resources["ThemeAccentBrush3"] = brush;
+                tabControl.Resources["ThemeAccentBrush4"] = brush;
+
+                // Also use as selected text foreground when BarTextColor isn't set
+                if (barTextColor == null)
                 {
-                    tabItem.Foreground = textBrush;
+                    tabControl.Resources["TabItemHeaderForegroundSelected"] = brush;
+                    tabControl.Resources["TabItemHeaderForegroundSelectedPointerOver"] = brush;
+                    tabControl.Resources["TabItemHeaderForegroundSelectedPressed"] = brush;
                 }
+            }
+
+            // BarTextColor → all text foreground states
+            if (barTextColor != null)
+            {
+                var brush = new Media.SolidColorBrush(barTextColor.ToAvaloniaColor());
+                tabControl.Resources["TabItemHeaderForegroundSelected"] = brush;
+                tabControl.Resources["TabItemHeaderForegroundSelectedPointerOver"] = brush;
+                tabControl.Resources["TabItemHeaderForegroundSelectedPressed"] = brush;
+                tabControl.Resources["TabItemHeaderForegroundUnselected"] = brush;
+                tabControl.Resources["TabItemHeaderForegroundUnselectedPointerOver"] = brush;
+                tabControl.Resources["TabItemHeaderForegroundUnselectedPressed"] = brush;
+            }
+
+            // UnselectedTabColor → unselected foreground (overrides BarTextColor for unselected)
+            if (unselectedTabColor != null)
+            {
+                var brush = new Media.SolidColorBrush(unselectedTabColor.ToAvaloniaColor());
+                tabControl.Resources["TabItemHeaderForegroundUnselected"] = brush;
+                tabControl.Resources["TabItemHeaderForegroundUnselectedPointerOver"] = brush;
+                tabControl.Resources["TabItemHeaderForegroundUnselectedPressed"] = brush;
+            }
+        }
+        else
+        {
+            // No explicit colors — clear overrides so Fluent theme defaults apply
+            foreach (var key in FluentThemeKeys)
+            {
+                tabControl.Resources.Remove(key);
+            }
+        }
+
+        // Clear any direct foreground/background overrides on TabItems so
+        // Fluent theme resource inheritance handles all state transitions
+        foreach (var item in tabControl.Items)
+        {
+            if (item is TabItem tabItem)
+            {
+                tabItem.ClearValue(TabItem.ForegroundProperty);
+                tabItem.ClearValue(TabItem.BackgroundProperty);
             }
         }
     }

--- a/src/Avalonia.Controls.Maui/Handlers/Shell/ShellItemHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shell/ShellItemHandler.cs
@@ -65,15 +65,6 @@ public partial class ShellItemHandler : ElementHandler<ShellItem, AvaloniaContro
 
             _tabControl.SelectionChanged += OnTabSelectionChanged;
 
-            var selectedStyle = new Styling.Style(x => x.OfType<TabItem>().Class(":selected"));
-            selectedStyle.Setters.Add(new Styling.Setter(TabItem.BackgroundProperty, new Markup.Xaml.MarkupExtensions.DynamicResourceExtension("ShellTabSelectedBackground")));
-            selectedStyle.Setters.Add(new Styling.Setter(TabItem.ForegroundProperty, new Markup.Xaml.MarkupExtensions.DynamicResourceExtension("ShellTabSelectedForeground")));
-            _tabControl.Styles.Add(selectedStyle);
-
-            var hoverStyle = new Styling.Style(x => x.OfType<TabItem>().Class(":pointerover"));
-            hoverStyle.Setters.Add(new Styling.Setter(TabItem.BackgroundProperty, new Markup.Xaml.MarkupExtensions.DynamicResourceExtension("ShellTabHoverBackground")));
-            _tabControl.Styles.Add(hoverStyle);
-
             return _tabControl;
         }
         else

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/ShellItemHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/ShellItemHandlerTests.cs
@@ -145,7 +145,8 @@ public class ShellItemHandlerTests : HandlerTestBase
         Assert.NotNull(background);
         Assert.Equal(Avalonia.Media.Colors.Red, background.Color);
 
-        var highlight = tabControl.Resources["ShellTabSelectedBackground"] as IBrush;
-        Assert.NotNull(highlight);
+        // TabBarForegroundColor maps to the selection indicator (pipe) and accent, not a background
+        var pipeFill = tabControl.Resources["TabItemHeaderSelectedPipeFill"] as IBrush;
+        Assert.NotNull(pipeFill);
     }
 }

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/TabbedPageHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/TabbedPageHandlerTests.cs
@@ -118,7 +118,8 @@ public class TabbedPageHandlerTests : HandlerTestBase<TabbedPageHandler, TabbedP
             var handler = CreateHandler<TabbedPageHandler>(stub);
             handler.UpdateValue(nameof(TabbedPage.BarTextColor));
 
-            Assert.True(handler.PlatformView.Resources.ContainsKey("TabbedPageBarTextColor"));
+            // BarTextColor is now mapped to Fluent theme foreground resources
+            Assert.True(handler.PlatformView.Resources.ContainsKey("TabItemHeaderForegroundSelected"));
         });
     }
 
@@ -159,12 +160,12 @@ public class TabbedPageHandlerTests : HandlerTestBase<TabbedPageHandler, TabbedP
 
             var handler = CreateHandler<TabbedPageHandler>(stub);
             handler.UpdateValue(nameof(TabbedPage.BarTextColor));
-            Assert.True(handler.PlatformView.Resources.ContainsKey("TabbedPageBarTextColor"));
+            Assert.True(handler.PlatformView.Resources.ContainsKey("TabItemHeaderForegroundSelected"));
 
             stub.BarTextColor = null;
             handler.UpdateValue(nameof(TabbedPage.BarTextColor));
 
-            Assert.False(handler.PlatformView.Resources.ContainsKey("TabbedPageBarTextColor"));
+            Assert.False(handler.PlatformView.Resources.ContainsKey("TabItemHeaderForegroundSelected"));
         });
     }
 
@@ -234,12 +235,13 @@ public class TabbedPageHandlerTests : HandlerTestBase<TabbedPageHandler, TabbedP
             var handler = CreateHandler<TabbedPageHandler>(stub);
             handler.UpdateValue(nameof(TabbedPage.SelectedTabColor));
 
-            Assert.True(handler.PlatformView.Resources.ContainsKey("TabbedPageSelectedTabColor"));
+            // SelectedTabColor is now mapped to Fluent pipe fill and accent resources
+            Assert.True(handler.PlatformView.Resources.ContainsKey("TabItemHeaderSelectedPipeFill"));
         });
     }
 
-    [AvaloniaFact(DisplayName = "MapSelectedTabColor Sets Selected TabItem Background")]
-    public async Task MapSelectedTabColor_Sets_Selected_TabItem_Background()
+    [AvaloniaFact(DisplayName = "MapSelectedTabColor Sets Pipe Fill Resource")]
+    public async Task MapSelectedTabColor_Sets_Pipe_Fill_Resource()
     {
         EnsureHandlerCreated();
 
@@ -255,10 +257,9 @@ public class TabbedPageHandlerTests : HandlerTestBase<TabbedPageHandler, TabbedP
             var handler = CreateHandler<TabbedPageHandler>(stub);
             handler.UpdateValue(nameof(TabbedPage.SelectedTabColor));
 
-            // First tab is selected by default
-            var selectedTab = handler.PlatformView.Items[0] as TabItem;
-            Assert.NotNull(selectedTab);
-            Assert.NotNull(selectedTab.Background);
+            // SelectedTabColor maps to pipe fill and selected foreground, not a tab background
+            Assert.True(handler.PlatformView.Resources.ContainsKey("TabItemHeaderSelectedPipeFill"));
+            Assert.True(handler.PlatformView.Resources.ContainsKey("TabItemHeaderForegroundSelected"));
         });
     }
 
@@ -277,12 +278,12 @@ public class TabbedPageHandlerTests : HandlerTestBase<TabbedPageHandler, TabbedP
 
             var handler = CreateHandler<TabbedPageHandler>(stub);
             handler.UpdateValue(nameof(TabbedPage.SelectedTabColor));
-            Assert.True(handler.PlatformView.Resources.ContainsKey("TabbedPageSelectedTabColor"));
+            Assert.True(handler.PlatformView.Resources.ContainsKey("TabItemHeaderSelectedPipeFill"));
 
             stub.SelectedTabColor = null;
             handler.UpdateValue(nameof(TabbedPage.SelectedTabColor));
 
-            Assert.False(handler.PlatformView.Resources.ContainsKey("TabbedPageSelectedTabColor"));
+            Assert.False(handler.PlatformView.Resources.ContainsKey("TabItemHeaderSelectedPipeFill"));
         });
     }
 
@@ -303,12 +304,13 @@ public class TabbedPageHandlerTests : HandlerTestBase<TabbedPageHandler, TabbedP
             var handler = CreateHandler<TabbedPageHandler>(stub);
             handler.UpdateValue(nameof(TabbedPage.UnselectedTabColor));
 
-            Assert.True(handler.PlatformView.Resources.ContainsKey("TabbedPageUnselectedTabColor"));
+            // UnselectedTabColor is now mapped to Fluent unselected foreground resources
+            Assert.True(handler.PlatformView.Resources.ContainsKey("TabItemHeaderForegroundUnselected"));
         });
     }
 
-    [AvaloniaFact(DisplayName = "MapUnselectedTabColor Sets Unselected TabItem Background")]
-    public async Task MapUnselectedTabColor_Sets_Unselected_TabItem_Background()
+    [AvaloniaFact(DisplayName = "MapUnselectedTabColor Sets Unselected Foreground Resource")]
+    public async Task MapUnselectedTabColor_Sets_Unselected_Foreground_Resource()
     {
         EnsureHandlerCreated();
 
@@ -324,10 +326,8 @@ public class TabbedPageHandlerTests : HandlerTestBase<TabbedPageHandler, TabbedP
             var handler = CreateHandler<TabbedPageHandler>(stub);
             handler.UpdateValue(nameof(TabbedPage.UnselectedTabColor));
 
-            // Second tab is unselected
-            var unselectedTab = handler.PlatformView.Items[1] as TabItem;
-            Assert.NotNull(unselectedTab);
-            Assert.NotNull(unselectedTab.Background);
+            // UnselectedTabColor maps to Fluent foreground resources, not direct Background
+            Assert.True(handler.PlatformView.Resources.ContainsKey("TabItemHeaderForegroundUnselected"));
         });
     }
 
@@ -346,12 +346,12 @@ public class TabbedPageHandlerTests : HandlerTestBase<TabbedPageHandler, TabbedP
 
             var handler = CreateHandler<TabbedPageHandler>(stub);
             handler.UpdateValue(nameof(TabbedPage.UnselectedTabColor));
-            Assert.True(handler.PlatformView.Resources.ContainsKey("TabbedPageUnselectedTabColor"));
+            Assert.True(handler.PlatformView.Resources.ContainsKey("TabItemHeaderForegroundUnselected"));
 
             stub.UnselectedTabColor = null;
             handler.UpdateValue(nameof(TabbedPage.UnselectedTabColor));
 
-            Assert.False(handler.PlatformView.Resources.ContainsKey("TabbedPageUnselectedTabColor"));
+            Assert.False(handler.PlatformView.Resources.ContainsKey("TabItemHeaderForegroundUnselected"));
         });
     }
 
@@ -618,11 +618,11 @@ public class TabbedPageHandlerTests : HandlerTestBase<TabbedPageHandler, TabbedP
             handler.UpdateValue(nameof(TabbedPage.SelectedTabColor));
             handler.UpdateValue(nameof(TabbedPage.UnselectedTabColor));
 
-            // Verify all resources are set
+            // Verify all resources are set (using new Fluent theme resource keys)
             Assert.True(handler.PlatformView.Resources.ContainsKey("TabbedPageBarBackground"));
-            Assert.True(handler.PlatformView.Resources.ContainsKey("TabbedPageBarTextColor"));
-            Assert.True(handler.PlatformView.Resources.ContainsKey("TabbedPageSelectedTabColor"));
-            Assert.True(handler.PlatformView.Resources.ContainsKey("TabbedPageUnselectedTabColor"));
+            Assert.True(handler.PlatformView.Resources.ContainsKey("TabItemHeaderForegroundSelected"));
+            Assert.True(handler.PlatformView.Resources.ContainsKey("TabItemHeaderSelectedPipeFill"));
+            Assert.True(handler.PlatformView.Resources.ContainsKey("TabItemHeaderForegroundUnselected"));
         });
     }
 


### PR DESCRIPTION
This makes some changes for the nugets that are created. Basically, we can't include Avalonia.Desktop inside of the base Avalonia.Controls.Maui project, since that will end up in _every_ project because it's a standard TFM. It's only needed for the single project stuff. For the mobile stuff it's not _bad_, but for Browser it would fail because it can't be trimmed for it. So I created "Avalonia.Controls.Maui.Desktop" that is specifically for the .NET MAUI Single Project case. It'll handle the source gen stuff, and for the mobile projects, once we can fix the internal MAUI stuff blocking it, can be updated to cover those cases too.