### PR TITLE
Enforce comments

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -58,7 +58,6 @@
         <PackageReleaseNotes>https://github.com/AvaloniaUI/Avalonia.Controls.Maui/releases</PackageReleaseNotes>
         <RepositoryType>git</RepositoryType>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageIcon>Icon.png</PackageIcon>
     </PropertyGroup>
 

--- a/src/Avalonia.Controls.Maui.Compatibility/Avalonia.Controls.Maui.Compatibility.csproj
+++ b/src/Avalonia.Controls.Maui.Compatibility/Avalonia.Controls.Maui.Compatibility.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(DotNetTfm)</TargetFramework>
     <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS0618;CS8002</NoWarn>
     <IsAotCompatible>true</IsAotCompatible>
     <AddMauiInternals>true</AddMauiInternals>

--- a/src/Avalonia.Controls.Maui.Compatibility/Controls/MauiListView/MauiListView.cs
+++ b/src/Avalonia.Controls.Maui.Compatibility/Controls/MauiListView/MauiListView.cs
@@ -308,11 +308,29 @@ public class MauiListView : MauiView
         set => SetValue(RefreshControlColorProperty, value);
     }
 
+    /// <summary>
+    /// Occurs when a pull-to-refresh gesture is requested.
+    /// </summary>
     public event EventHandler? RefreshRequested;
 
+    /// <summary>
+    /// Occurs when the list view is scrolled.
+    /// </summary>
     public event EventHandler<ScrolledEventArgs>? Scrolled;
+
+    /// <summary>
+    /// Occurs when an item in the list is tapped.
+    /// </summary>
     public event EventHandler<object?>? ItemTapped;
+
+    /// <summary>
+    /// Occurs when an item is about to appear in the visible area.
+    /// </summary>
     public event EventHandler<object?>? ItemAppearing;
+
+    /// <summary>
+    /// Occurs when an item is about to disappear from the visible area.
+    /// </summary>
     public event EventHandler<object?>? ItemDisappearing;
     
     private void OnListBoxTapped(object? sender, global::Avalonia.Input.TappedEventArgs e)
@@ -459,24 +477,46 @@ public class MauiListView : MauiView
         _listBox.ItemsSource = flattened;
     }
 
+    /// <summary>
+    /// Sets the items source for the list and rebuilds the internal item collection.
+    /// </summary>
+    /// <param name="items">The items source to display in the list.</param>
     public void SetItemsSource(IEnumerable? items)
     {
         _originalItemsSource = items;
         RebuildItemsSource();
     }
 
+    /// <summary>
+    /// Represents a group header item in the flattened list.
+    /// </summary>
     public class GroupHeader
     {
+        /// <summary>
+        /// Gets the data object associated with this group header.
+        /// </summary>
         public object? Data { get; init; }
     }
 
+    /// <summary>
+    /// Represents a list view header item in the flattened list.
+    /// </summary>
     public class ListViewHeader
     {
+        /// <summary>
+        /// Gets the data object associated with this header.
+        /// </summary>
         public object? Data { get; init; }
     }
 
+    /// <summary>
+    /// Represents a list view footer item in the flattened list.
+    /// </summary>
     public class ListViewFooter
     {
+        /// <summary>
+        /// Gets the data object associated with this footer.
+        /// </summary>
         public object? Data { get; init; }
     }
 
@@ -498,6 +538,12 @@ public class MauiListView : MauiView
         return _listBox.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
     }
 
+    /// <summary>
+    /// Scrolls to the specified item at the given position.
+    /// </summary>
+    /// <param name="item">The item to scroll to.</param>
+    /// <param name="position">The scroll position relative to the item.</param>
+    /// <param name="animated">Whether to animate the scroll.</param>
     public void ScrollTo(object item, ScrollToPosition position, bool animated)
     {
         var scrollViewer = GetScrollViewer();

--- a/src/Avalonia.Controls.Maui.Compatibility/Handlers/Cells/EntryCellHandler.cs
+++ b/src/Avalonia.Controls.Maui.Compatibility/Handlers/Cells/EntryCellHandler.cs
@@ -5,8 +5,14 @@ using Microsoft.Maui.Controls;
 
 namespace Avalonia.Controls.Maui.Compatibility;
 
+/// <summary>
+/// Avalonia handler for <see cref="EntryCell"/>.
+/// </summary>
 public class EntryCellHandler : ElementHandler<EntryCell, MauiEntryCell>
 {
+    /// <summary>
+    /// Property mapper for <see cref="EntryCellHandler"/>.
+    /// </summary>
     public static IPropertyMapper<EntryCell, EntryCellHandler> Mapper =
         new PropertyMapper<EntryCell, EntryCellHandler>(ElementMapper)
         {
@@ -21,23 +27,41 @@ public class EntryCellHandler : ElementHandler<EntryCell, MauiEntryCell>
             ["ContextActions"] = MapContextActions,
         };
 
+    /// <summary>
+    /// Command mapper for <see cref="EntryCellHandler"/>.
+    /// </summary>
     public static CommandMapper<EntryCell, EntryCellHandler> CommandMapper =
         new(ElementCommandMapper);
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EntryCellHandler"/> class.
+    /// </summary>
     public EntryCellHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EntryCellHandler"/> class with a custom property mapper.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public EntryCellHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EntryCellHandler"/> class with custom mappers.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public EntryCellHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Creates the Avalonia platform element for this handler.
+    /// </summary>
     protected override MauiEntryCell CreatePlatformElement()
     {
         var cell = new MauiEntryCell();
@@ -48,6 +72,7 @@ public class EntryCellHandler : ElementHandler<EntryCell, MauiEntryCell>
         return cell;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(MauiEntryCell platformView)
     {
         base.DisconnectHandler(platformView);
@@ -86,46 +111,91 @@ public class EntryCellHandler : ElementHandler<EntryCell, MauiEntryCell>
         }
     }
 
+    /// <summary>
+    /// Maps the Label property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the EntryCell.</param>
+    /// <param name="entryCell">The MAUI EntryCell virtual view.</param>
     public static void MapLabel(EntryCellHandler handler, EntryCell entryCell)
     {
         handler.PlatformView.UpdateLabel(entryCell);
     }
 
+    /// <summary>
+    /// Maps the Text property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the EntryCell.</param>
+    /// <param name="entryCell">The MAUI EntryCell virtual view.</param>
     public static void MapText(EntryCellHandler handler, EntryCell entryCell)
     {
         handler.PlatformView.UpdateText(entryCell, false);
     }
 
+    /// <summary>
+    /// Maps the Placeholder property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the EntryCell.</param>
+    /// <param name="entryCell">The MAUI EntryCell virtual view.</param>
     public static void MapPlaceholder(EntryCellHandler handler, EntryCell entryCell)
     {
         handler.PlatformView.UpdatePlaceholder(entryCell);
     }
 
+    /// <summary>
+    /// Maps the LabelColor property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the EntryCell.</param>
+    /// <param name="entryCell">The MAUI EntryCell virtual view.</param>
     public static void MapLabelColor(EntryCellHandler handler, EntryCell entryCell)
     {
         handler.PlatformView.UpdateLabelColor(entryCell);
     }
 
+    /// <summary>
+    /// Maps the HorizontalTextAlignment property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the EntryCell.</param>
+    /// <param name="entryCell">The MAUI EntryCell virtual view.</param>
     public static void MapHorizontalTextAlignment(EntryCellHandler handler, EntryCell entryCell)
     {
         handler.PlatformView.UpdateHorizontalTextAlignment(entryCell);
     }
 
+    /// <summary>
+    /// Maps the VerticalTextAlignment property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the EntryCell.</param>
+    /// <param name="entryCell">The MAUI EntryCell virtual view.</param>
     public static void MapVerticalTextAlignment(EntryCellHandler handler, EntryCell entryCell)
     {
         handler.PlatformView.UpdateVerticalTextAlignment(entryCell);
     }
 
+    /// <summary>
+    /// Maps the Keyboard property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the EntryCell.</param>
+    /// <param name="entryCell">The MAUI EntryCell virtual view.</param>
     public static void MapKeyboard(EntryCellHandler handler, EntryCell entryCell)
     {
         handler.PlatformView.UpdateKeyboard(entryCell);
     }
 
+    /// <summary>
+    /// Maps the IsEnabled property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the EntryCell.</param>
+    /// <param name="entryCell">The MAUI EntryCell virtual view.</param>
     public static void MapIsEnabled(EntryCellHandler handler, EntryCell entryCell)
     {
         handler.PlatformView.UpdateIsEnabled(entryCell);
     }
 
+    /// <summary>
+    /// Maps the ContextActions property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the EntryCell.</param>
+    /// <param name="entryCell">The MAUI EntryCell virtual view.</param>
     public static void MapContextActions(EntryCellHandler handler, EntryCell entryCell)
     {
         handler.PlatformView.UpdateContextActions(entryCell);

--- a/src/Avalonia.Controls.Maui.Compatibility/Handlers/Cells/ImageCellHandler.cs
+++ b/src/Avalonia.Controls.Maui.Compatibility/Handlers/Cells/ImageCellHandler.cs
@@ -6,8 +6,14 @@ using Microsoft.Maui.Controls;
 
 namespace Avalonia.Controls.Maui.Compatibility;
 
+/// <summary>
+/// Avalonia handler for <see cref="ImageCell"/>.
+/// </summary>
 public class ImageCellHandler : ElementHandler<ImageCell, MauiImageCell>
 {
+    /// <summary>
+    /// Property mapper for <see cref="ImageCellHandler"/>.
+    /// </summary>
     public static IPropertyMapper<ImageCell, ImageCellHandler> Mapper =
         new PropertyMapper<ImageCell, ImageCellHandler>(ElementMapper)
         {
@@ -20,23 +26,41 @@ public class ImageCellHandler : ElementHandler<ImageCell, MauiImageCell>
             ["ContextActions"] = MapContextActions,
         };
 
+    /// <summary>
+    /// Command mapper for <see cref="ImageCellHandler"/>.
+    /// </summary>
     public static CommandMapper<ImageCell, ImageCellHandler> CommandMapper =
         new(ElementCommandMapper);
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImageCellHandler"/> class.
+    /// </summary>
     public ImageCellHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImageCellHandler"/> class with a custom property mapper.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public ImageCellHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImageCellHandler"/> class with custom mappers.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public ImageCellHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Creates the Avalonia platform element for this handler.
+    /// </summary>
     protected override MauiImageCell CreatePlatformElement()
     {
         var cell = new MauiImageCell();
@@ -46,6 +70,7 @@ public class ImageCellHandler : ElementHandler<ImageCell, MauiImageCell>
         return cell;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(MauiImageCell platformView)
     {
         platformView.RemoveHandler(global::Avalonia.Input.InputElement.TappedEvent, OnCellTapped);
@@ -75,36 +100,71 @@ public class ImageCellHandler : ElementHandler<ImageCell, MauiImageCell>
         }
     }
 
+    /// <summary>
+    /// Maps the Text property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ImageCell.</param>
+    /// <param name="imageCell">The MAUI ImageCell virtual view.</param>
     public static void MapText(ImageCellHandler handler, ImageCell imageCell)
     {
         handler.PlatformView.UpdateText(imageCell);
     }
 
+    /// <summary>
+    /// Maps the Detail property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ImageCell.</param>
+    /// <param name="imageCell">The MAUI ImageCell virtual view.</param>
     public static void MapDetail(ImageCellHandler handler, ImageCell imageCell)
     {
         handler.PlatformView.UpdateDetail(imageCell);
     }
 
+    /// <summary>
+    /// Maps the TextColor property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ImageCell.</param>
+    /// <param name="imageCell">The MAUI ImageCell virtual view.</param>
     public static void MapTextColor(ImageCellHandler handler, ImageCell imageCell)
     {
         handler.PlatformView.UpdateTextColor(imageCell);
     }
 
+    /// <summary>
+    /// Maps the DetailColor property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ImageCell.</param>
+    /// <param name="imageCell">The MAUI ImageCell virtual view.</param>
     public static void MapDetailColor(ImageCellHandler handler, ImageCell imageCell)
     {
         handler.PlatformView.UpdateDetailColor(imageCell);
     }
 
+    /// <summary>
+    /// Maps the ImageSource property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ImageCell.</param>
+    /// <param name="imageCell">The MAUI ImageCell virtual view.</param>
     public static void MapImageSource(ImageCellHandler handler, ImageCell imageCell)
     {
         handler.PlatformView.UpdateImageSource(imageCell, handler.MauiContext);
     }
 
+    /// <summary>
+    /// Maps the IsEnabled property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ImageCell.</param>
+    /// <param name="imageCell">The MAUI ImageCell virtual view.</param>
     public static void MapIsEnabled(ImageCellHandler handler, ImageCell imageCell)
     {
         handler.PlatformView.UpdateIsEnabled(imageCell);
     }
 
+    /// <summary>
+    /// Maps the ContextActions property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ImageCell.</param>
+    /// <param name="imageCell">The MAUI ImageCell virtual view.</param>
     public static void MapContextActions(ImageCellHandler handler, ImageCell imageCell)
     {
         handler.PlatformView.UpdateContextActions(imageCell);

--- a/src/Avalonia.Controls.Maui.Compatibility/Handlers/Cells/SwitchCellHandler.cs
+++ b/src/Avalonia.Controls.Maui.Compatibility/Handlers/Cells/SwitchCellHandler.cs
@@ -5,8 +5,14 @@ using Microsoft.Maui.Controls;
 
 namespace Avalonia.Controls.Maui.Compatibility;
 
+/// <summary>
+/// Avalonia handler for <see cref="SwitchCell"/>.
+/// </summary>
 public class SwitchCellHandler : ElementHandler<SwitchCell, MauiSwitchCell>
 {
+    /// <summary>
+    /// Property mapper for <see cref="SwitchCellHandler"/>.
+    /// </summary>
     public static IPropertyMapper<SwitchCell, SwitchCellHandler> Mapper =
         new PropertyMapper<SwitchCell, SwitchCellHandler>(ElementMapper)
         {
@@ -17,23 +23,41 @@ public class SwitchCellHandler : ElementHandler<SwitchCell, MauiSwitchCell>
             ["ContextActions"] = MapContextActions,
         };
 
+    /// <summary>
+    /// Command mapper for <see cref="SwitchCellHandler"/>.
+    /// </summary>
     public static CommandMapper<SwitchCell, SwitchCellHandler> CommandMapper =
         new(ElementCommandMapper);
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SwitchCellHandler"/> class.
+    /// </summary>
     public SwitchCellHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SwitchCellHandler"/> class with a custom property mapper.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public SwitchCellHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SwitchCellHandler"/> class with custom mappers.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public SwitchCellHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Creates the Avalonia platform element for this handler.
+    /// </summary>
     protected override MauiSwitchCell CreatePlatformElement()
     {
         var cell = new MauiSwitchCell();
@@ -42,12 +66,14 @@ public class SwitchCellHandler : ElementHandler<SwitchCell, MauiSwitchCell>
         return cell;
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(MauiSwitchCell platformView)
     {
         base.ConnectHandler(platformView);
         platformView.ToggleSwitch.IsCheckedChanged += OnCheckedChanged;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(MauiSwitchCell platformView)
     {
         base.DisconnectHandler(platformView);
@@ -77,26 +103,51 @@ public class SwitchCellHandler : ElementHandler<SwitchCell, MauiSwitchCell>
         }
     }
 
+    /// <summary>
+    /// Maps the Text property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the SwitchCell.</param>
+    /// <param name="switchCell">The MAUI SwitchCell virtual view.</param>
     public static void MapText(SwitchCellHandler handler, SwitchCell switchCell)
     {
         handler.PlatformView.UpdateText(switchCell);
     }
 
+    /// <summary>
+    /// Maps the On property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the SwitchCell.</param>
+    /// <param name="switchCell">The MAUI SwitchCell virtual view.</param>
     public static void MapOn(SwitchCellHandler handler, SwitchCell switchCell)
     {
         handler.PlatformView.UpdateOn(switchCell, false);
     }
 
+    /// <summary>
+    /// Maps the OnColor property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the SwitchCell.</param>
+    /// <param name="switchCell">The MAUI SwitchCell virtual view.</param>
     public static void MapOnColor(SwitchCellHandler handler, SwitchCell switchCell)
     {
         handler.PlatformView.UpdateOnColor(switchCell);
     }
 
+    /// <summary>
+    /// Maps the IsEnabled property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the SwitchCell.</param>
+    /// <param name="switchCell">The MAUI SwitchCell virtual view.</param>
     public static void MapIsEnabled(SwitchCellHandler handler, SwitchCell switchCell)
     {
         handler.PlatformView.UpdateIsEnabled(switchCell);
     }
 
+    /// <summary>
+    /// Maps the ContextActions property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the SwitchCell.</param>
+    /// <param name="switchCell">The MAUI SwitchCell virtual view.</param>
     public static void MapContextActions(SwitchCellHandler handler, SwitchCell switchCell)
     {
         handler.PlatformView.UpdateContextActions(switchCell);

--- a/src/Avalonia.Controls.Maui.Compatibility/Handlers/Cells/TextCellHandler.cs
+++ b/src/Avalonia.Controls.Maui.Compatibility/Handlers/Cells/TextCellHandler.cs
@@ -6,8 +6,14 @@ using Microsoft.Maui.Controls;
 
 namespace Avalonia.Controls.Maui.Compatibility;
 
+/// <summary>
+/// Avalonia handler for <see cref="TextCell"/>.
+/// </summary>
 public class TextCellHandler : ElementHandler<TextCell, MauiTextCell>
 {
+    /// <summary>
+    /// Property mapper for <see cref="TextCellHandler"/>.
+    /// </summary>
     public static IPropertyMapper<TextCell, TextCellHandler> Mapper =
         new PropertyMapper<TextCell, TextCellHandler>(ElementMapper)
         {
@@ -20,23 +26,41 @@ public class TextCellHandler : ElementHandler<TextCell, MauiTextCell>
             ["ContextActions"] = MapContextActions,
         };
 
+    /// <summary>
+    /// Command mapper for <see cref="TextCellHandler"/>.
+    /// </summary>
     public static CommandMapper<TextCell, TextCellHandler> CommandMapper =
         new(ElementCommandMapper);
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TextCellHandler"/> class.
+    /// </summary>
     public TextCellHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TextCellHandler"/> class with a custom property mapper.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public TextCellHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TextCellHandler"/> class with custom mappers.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public TextCellHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Creates the Avalonia platform element for this handler.
+    /// </summary>
     protected override MauiTextCell CreatePlatformElement()
     {
         var cell = new MauiTextCell();
@@ -46,6 +70,7 @@ public class TextCellHandler : ElementHandler<TextCell, MauiTextCell>
         return cell;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(MauiTextCell platformView)
     {
         platformView.RemoveHandler(global::Avalonia.Input.InputElement.TappedEvent, OnCellTapped);
@@ -75,36 +100,71 @@ public class TextCellHandler : ElementHandler<TextCell, MauiTextCell>
         }
     }
 
+    /// <summary>
+    /// Maps the Text property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the TextCell.</param>
+    /// <param name="textCell">The MAUI TextCell virtual view.</param>
     public static void MapText(TextCellHandler handler, TextCell textCell)
     {
         handler.PlatformView.UpdateText(textCell);
     }
 
+    /// <summary>
+    /// Maps the Detail property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the TextCell.</param>
+    /// <param name="textCell">The MAUI TextCell virtual view.</param>
     public static void MapDetail(TextCellHandler handler, TextCell textCell)
     {
         handler.PlatformView.UpdateDetail(textCell);
     }
 
+    /// <summary>
+    /// Maps the TextColor property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the TextCell.</param>
+    /// <param name="textCell">The MAUI TextCell virtual view.</param>
     public static void MapTextColor(TextCellHandler handler, TextCell textCell)
     {
         handler.PlatformView.UpdateTextColor(textCell);
     }
 
+    /// <summary>
+    /// Maps the DetailColor property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the TextCell.</param>
+    /// <param name="textCell">The MAUI TextCell virtual view.</param>
     public static void MapDetailColor(TextCellHandler handler, TextCell textCell)
     {
         handler.PlatformView.UpdateDetailColor(textCell);
     }
 
+    /// <summary>
+    /// Maps the IsEnabled property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the TextCell.</param>
+    /// <param name="textCell">The MAUI TextCell virtual view.</param>
     public static void MapIsEnabled(TextCellHandler handler, TextCell textCell)
     {
         handler.PlatformView.UpdateIsEnabled(textCell);
     }
 
+    /// <summary>
+    /// Maps the Height property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the TextCell.</param>
+    /// <param name="textCell">The MAUI TextCell virtual view.</param>
     public static void MapHeight(TextCellHandler handler, TextCell textCell)
     {
         handler.PlatformView.UpdateHeight(textCell);
     }
 
+    /// <summary>
+    /// Maps the ContextActions property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the TextCell.</param>
+    /// <param name="textCell">The MAUI TextCell virtual view.</param>
     public static void MapContextActions(TextCellHandler handler, TextCell textCell)
     {
         handler.PlatformView.UpdateContextActions(textCell);

--- a/src/Avalonia.Controls.Maui.Compatibility/Handlers/Cells/ViewCellHandler.cs
+++ b/src/Avalonia.Controls.Maui.Compatibility/Handlers/Cells/ViewCellHandler.cs
@@ -5,8 +5,14 @@ using Microsoft.Maui.Controls;
 
 namespace Avalonia.Controls.Maui.Compatibility;
 
+/// <summary>
+/// Avalonia handler for <see cref="ViewCell"/>.
+/// </summary>
 public class ViewCellHandler : ElementHandler<ViewCell, MauiViewCell>
 {
+    /// <summary>
+    /// Property mapper for <see cref="ViewCellHandler"/>.
+    /// </summary>
     public static IPropertyMapper<ViewCell, ViewCellHandler> Mapper =
         new PropertyMapper<ViewCell, ViewCellHandler>(ElementMapper)
         {
@@ -15,23 +21,41 @@ public class ViewCellHandler : ElementHandler<ViewCell, MauiViewCell>
             ["ContextActions"] = MapContextActions,
         };
 
+    /// <summary>
+    /// Command mapper for <see cref="ViewCellHandler"/>.
+    /// </summary>
     public static CommandMapper<ViewCell, ViewCellHandler> CommandMapper =
         new(ElementCommandMapper);
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ViewCellHandler"/> class.
+    /// </summary>
     public ViewCellHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ViewCellHandler"/> class with a custom property mapper.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public ViewCellHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ViewCellHandler"/> class with custom mappers.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public ViewCellHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Creates the Avalonia platform element for this handler.
+    /// </summary>
     protected override MauiViewCell CreatePlatformElement()
     {
         var cell = new MauiViewCell();
@@ -40,6 +64,7 @@ public class ViewCellHandler : ElementHandler<ViewCell, MauiViewCell>
         return cell;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(MauiViewCell platformView)
     {
         platformView.AttachedToVisualTree -= OnCellAttachedToVisualTree;
@@ -57,16 +82,31 @@ public class ViewCellHandler : ElementHandler<ViewCell, MauiViewCell>
         VirtualView?.SendDisappearing();
     }
 
+    /// <summary>
+    /// Maps the IsEnabled property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ViewCell.</param>
+    /// <param name="viewCell">The MAUI ViewCell virtual view.</param>
     public static void MapIsEnabled(ViewCellHandler handler, ViewCell viewCell)
     {
         handler.PlatformView.UpdateIsEnabled(viewCell);
     }
 
+    /// <summary>
+    /// Maps the View property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ViewCell.</param>
+    /// <param name="viewCell">The MAUI ViewCell virtual view.</param>
     public static void MapView(ViewCellHandler handler, ViewCell viewCell)
     {
         handler.PlatformView.UpdateView(viewCell, handler.MauiContext);
     }
 
+    /// <summary>
+    /// Maps the ContextActions property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ViewCell.</param>
+    /// <param name="viewCell">The MAUI ViewCell virtual view.</param>
     public static void MapContextActions(ViewCellHandler handler, ViewCell viewCell)
     {
         handler.PlatformView.UpdateContextActions(viewCell);

--- a/src/Avalonia.Controls.Maui.Compatibility/Handlers/FrameHandler.cs
+++ b/src/Avalonia.Controls.Maui.Compatibility/Handlers/FrameHandler.cs
@@ -5,8 +5,14 @@ using PlatformView = Avalonia.Controls.Border;
 
 namespace Avalonia.Controls.Maui.Compatibility.Handlers;
 
+/// <summary>
+/// Avalonia handler for <see cref="Microsoft.Maui.Controls.Frame"/>.
+/// </summary>
 public class FrameHandler : ViewHandler<Microsoft.Maui.Controls.Frame, PlatformView>
 {
+    /// <summary>
+    /// Property mapper for <see cref="FrameHandler"/>.
+    /// </summary>
     public static IPropertyMapper<Microsoft.Maui.Controls.Frame, FrameHandler> Mapper =
         new PropertyMapper<Microsoft.Maui.Controls.Frame, FrameHandler>(ViewMapper)
         {
@@ -20,23 +26,41 @@ public class FrameHandler : ViewHandler<Microsoft.Maui.Controls.Frame, PlatformV
             [nameof(Microsoft.Maui.Controls.Frame.IsClippedToBounds)] = MapIsClippedToBounds,
         };
 
+    /// <summary>
+    /// Command mapper for <see cref="FrameHandler"/>.
+    /// </summary>
     public static CommandMapper<Microsoft.Maui.Controls.Frame, FrameHandler> CommandMapper =
         new(ViewCommandMapper);
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FrameHandler"/> class.
+    /// </summary>
     public FrameHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FrameHandler"/> class with a custom property mapper.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public FrameHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FrameHandler"/> class with custom mappers.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public FrameHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Creates the Avalonia platform view for this handler.
+    /// </summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView
@@ -46,36 +70,71 @@ public class FrameHandler : ViewHandler<Microsoft.Maui.Controls.Frame, PlatformV
         };
     }
 
+    /// <summary>
+    /// Maps the Content property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the Frame.</param>
+    /// <param name="frame">The MAUI Frame virtual view.</param>
     public static void MapContent(FrameHandler handler, Microsoft.Maui.Controls.Frame frame)
     {
         handler.PlatformView?.UpdateContent(frame, handler.MauiContext);
     }
 
+    /// <summary>
+    /// Maps the BorderColor property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the Frame.</param>
+    /// <param name="frame">The MAUI Frame virtual view.</param>
     public static void MapBorderColor(FrameHandler handler, Microsoft.Maui.Controls.Frame frame)
     {
         handler.PlatformView?.UpdateBorderColor(frame);
     }
 
+    /// <summary>
+    /// Maps the CornerRadius property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the Frame.</param>
+    /// <param name="frame">The MAUI Frame virtual view.</param>
     public static void MapCornerRadius(FrameHandler handler, Microsoft.Maui.Controls.Frame frame)
     {
         handler.PlatformView?.UpdateCornerRadius(frame);
     }
 
+    /// <summary>
+    /// Maps the HasShadow property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the Frame.</param>
+    /// <param name="frame">The MAUI Frame virtual view.</param>
     public static void MapHasShadow(FrameHandler handler, Microsoft.Maui.Controls.Frame frame)
     {
         handler.PlatformView?.UpdateHasShadow(frame);
     }
 
+    /// <summary>
+    /// Maps the Background property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the Frame.</param>
+    /// <param name="frame">The MAUI Frame virtual view.</param>
     public static void MapBackground(FrameHandler handler, Microsoft.Maui.Controls.Frame frame)
     {
         handler.PlatformView?.UpdateBackground(frame);
     }
 
+    /// <summary>
+    /// Maps the Padding property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the Frame.</param>
+    /// <param name="frame">The MAUI Frame virtual view.</param>
     public static void MapPadding(FrameHandler handler, Microsoft.Maui.Controls.Frame frame)
     {
         handler.PlatformView?.UpdatePadding(frame);
     }
 
+    /// <summary>
+    /// Maps the IsClippedToBounds property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the Frame.</param>
+    /// <param name="frame">The MAUI Frame virtual view.</param>
     public static void MapIsClippedToBounds(FrameHandler handler, Microsoft.Maui.Controls.Frame frame)
     {
         handler.PlatformView?.UpdateIsClippedToBounds(frame);

--- a/src/Avalonia.Controls.Maui.Compatibility/Handlers/ListViewHandler.cs
+++ b/src/Avalonia.Controls.Maui.Compatibility/Handlers/ListViewHandler.cs
@@ -7,12 +7,18 @@ using System.Reflection;
 
 namespace Avalonia.Controls.Maui.Compatibility.Handlers;
 
+/// <summary>
+/// Avalonia handler for <see cref="Microsoft.Maui.Controls.ListView"/>.
+/// </summary>
 public class ListViewHandler : ViewHandler<Microsoft.Maui.Controls.ListView, MauiListView>
 {
     private static MethodInfo? _sendItemTappedMethod;
     private static MethodInfo? _sendCellAppearingMethod;
     private static MethodInfo? _sendCellDisappearingMethod;
 
+    /// <summary>
+    /// Property mapper for <see cref="ListViewHandler"/>.
+    /// </summary>
     public static IPropertyMapper<Microsoft.Maui.Controls.ListView, ListViewHandler> Mapper =
         new PropertyMapper<Microsoft.Maui.Controls.ListView, ListViewHandler>(ViewHandler.ViewMapper)
         {
@@ -37,25 +43,43 @@ public class ListViewHandler : ViewHandler<Microsoft.Maui.Controls.ListView, Mau
             [nameof(Microsoft.Maui.Controls.ListView.RefreshControlColor)] = MapRefreshControlColor,
         };
 
+    /// <summary>
+    /// Command mapper for <see cref="ListViewHandler"/>.
+    /// </summary>
     public static CommandMapper<Microsoft.Maui.Controls.ListView, ListViewHandler> CommandMapper =
         new(ViewCommandMapper)
         {
         };
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ListViewHandler"/> class.
+    /// </summary>
     public ListViewHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ListViewHandler"/> class with a custom property mapper.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public ListViewHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ListViewHandler"/> class with custom mappers.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public ListViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Creates the Avalonia platform view for this handler.
+    /// </summary>
     protected override MauiListView CreatePlatformView()
     {
         return new MauiListView(VirtualView.CachingStrategy)
@@ -64,6 +88,7 @@ public class ListViewHandler : ViewHandler<Microsoft.Maui.Controls.ListView, Mau
         };
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(MauiListView platformView)
     {
         base.ConnectHandler(platformView);
@@ -80,6 +105,7 @@ public class ListViewHandler : ViewHandler<Microsoft.Maui.Controls.ListView, Mau
         }
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(MauiListView platformView)
     {
         platformView.ListBox.SelectionChanged -= OnSelectionChanged;
@@ -176,88 +202,174 @@ public class ListViewHandler : ViewHandler<Microsoft.Maui.Controls.ListView, Mau
         }
     }
 
+    /// <inheritdoc/>
     public override bool NeedsContainer => false;
 
+    /// <summary>
+    /// Maps the ItemsSource property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapItemsSource(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdateItemsSource(listView);
     }
 
+    /// <summary>
+    /// Maps the ItemTemplate property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapItemTemplate(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdateItemTemplate(listView, handler);
     }
 
+    /// <summary>
+    /// Maps the SelectedItem property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapSelectedItem(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdateSelectedItem(listView);
     }
 
+    /// <summary>
+    /// Maps the SelectionMode property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapSelectionMode(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdateSelectionMode(listView);
     }
 
+    /// <summary>
+    /// Maps the Header property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapHeader(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdateHeader(listView, handler);
     }
 
+    /// <summary>
+    /// Maps the HeaderTemplate property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapHeaderTemplate(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdateHeaderTemplate(listView, handler);
     }
 
+    /// <summary>
+    /// Maps the Footer property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapFooter(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdateFooter(listView, handler);
     }
 
+    /// <summary>
+    /// Maps the FooterTemplate property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapFooterTemplate(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdateFooterTemplate(listView, handler);
     }
 
+    /// <summary>
+    /// Maps the SeparatorVisibility and SeparatorColor properties to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapSeparators(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdateSeparators(listView, handler);
     }
 
+    /// <summary>
+    /// Maps the RowHeight and HasUnevenRows properties to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapRowHeight(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdateRowHeight(listView);
     }
 
+    /// <summary>
+    /// Maps the IsGroupingEnabled property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapIsGroupingEnabled(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdateIsGroupingEnabled(listView);
     }
 
+    /// <summary>
+    /// Maps the GroupHeaderTemplate property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapGroupHeaderTemplate(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdateGroupHeaderTemplate(listView, handler);
     }
 
+    /// <summary>
+    /// Maps the HorizontalScrollBarVisibility property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapHorizontalScrollBarVisibility(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdateHorizontalScrollBarVisibility(listView);
     }
 
+    /// <summary>
+    /// Maps the VerticalScrollBarVisibility property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapVerticalScrollBarVisibility(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdateVerticalScrollBarVisibility(listView);
     }
 
+    /// <summary>
+    /// Maps the IsPullToRefreshEnabled property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapIsPullToRefreshEnabled(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdatePullToRefreshEnabled(listView);
     }
 
+    /// <summary>
+    /// Maps the IsRefreshing property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapIsRefreshing(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdateIsRefreshing(listView);
     }
 
+    /// <summary>
+    /// Maps the RefreshControlColor property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the ListView.</param>
+    /// <param name="listView">The MAUI ListView virtual view.</param>
     public static void MapRefreshControlColor(ListViewHandler handler, Microsoft.Maui.Controls.ListView listView)
     {
         handler.PlatformView.UpdateRefreshControlColor(listView);

--- a/src/Avalonia.Controls.Maui.Compatibility/Handlers/TableViewHandler.cs
+++ b/src/Avalonia.Controls.Maui.Compatibility/Handlers/TableViewHandler.cs
@@ -4,8 +4,14 @@ using Microsoft.Maui.Controls;
 
 namespace Avalonia.Controls.Maui.Compatibility.Handlers;
 
+/// <summary>
+/// Avalonia handler for <see cref="TableView"/>.
+/// </summary>
 public class TableViewHandler : ViewHandler<TableView, MauiTableView>
 {
+    /// <summary>
+    /// Property mapper for <see cref="TableViewHandler"/>.
+    /// </summary>
     public static IPropertyMapper<TableView, TableViewHandler> Mapper =
         new PropertyMapper<TableView, TableViewHandler>(ViewHandler.ViewMapper)
         {
@@ -15,28 +21,47 @@ public class TableViewHandler : ViewHandler<TableView, MauiTableView>
             [nameof(TableView.Intent)] = MapIntent,
         };
 
+    /// <summary>
+    /// Command mapper for <see cref="TableViewHandler"/>.
+    /// </summary>
     public static CommandMapper<TableView, TableViewHandler> CommandMapper =
         new(ViewCommandMapper);
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TableViewHandler"/> class.
+    /// </summary>
     public TableViewHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TableViewHandler"/> class with a custom property mapper.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public TableViewHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TableViewHandler"/> class with custom mappers.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public TableViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Creates the Avalonia platform view for this handler.
+    /// </summary>
     protected override MauiTableView CreatePlatformView()
     {
         return new MauiTableView();
     }
 
+    /// <inheritdoc/>
     public override void SetVirtualView(IView view)
     {
         base.SetVirtualView(view);
@@ -49,8 +74,14 @@ public class TableViewHandler : ViewHandler<TableView, MauiTableView>
         PlatformView.MauiContext = MauiContext;
     }
 
+    /// <inheritdoc/>
     public override bool NeedsContainer => false;
 
+    /// <summary>
+    /// Maps the Root property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the TableView.</param>
+    /// <param name="tableView">The MAUI TableView virtual view.</param>
     public static void MapRoot(TableViewHandler handler, TableView tableView)
     {
         if (handler.PlatformView is not null)
@@ -59,6 +90,11 @@ public class TableViewHandler : ViewHandler<TableView, MauiTableView>
         }
     }
 
+    /// <summary>
+    /// Maps the RowHeight property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the TableView.</param>
+    /// <param name="tableView">The MAUI TableView virtual view.</param>
     public static void MapRowHeight(TableViewHandler handler, TableView tableView)
     {
         if (handler.PlatformView is not null)
@@ -67,6 +103,11 @@ public class TableViewHandler : ViewHandler<TableView, MauiTableView>
         }
     }
 
+    /// <summary>
+    /// Maps the HasUnevenRows property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the TableView.</param>
+    /// <param name="tableView">The MAUI TableView virtual view.</param>
     public static void MapHasUnevenRows(TableViewHandler handler, TableView tableView)
     {
         if (handler.PlatformView is not null)
@@ -75,6 +116,11 @@ public class TableViewHandler : ViewHandler<TableView, MauiTableView>
         }
     }
 
+    /// <summary>
+    /// Maps the Intent property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the TableView.</param>
+    /// <param name="tableView">The MAUI TableView virtual view.</param>
     public static void MapIntent(TableViewHandler handler, TableView tableView)
     {
         if (handler.PlatformView is not null)

--- a/src/Avalonia.Controls.Maui.Essentials/Avalonia.Controls.Maui.Essentials.csproj
+++ b/src/Avalonia.Controls.Maui.Essentials/Avalonia.Controls.Maui.Essentials.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(DotNetTfm)</TargetFrameworks>
     <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS0618;CS8002</NoWarn>
     <IsAotCompatible>true</IsAotCompatible>
     <AddMauiInternals>true</AddMauiInternals>

--- a/src/Avalonia.Controls.Maui.Essentials/AvaloniaEssentialsPlatformProvider.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/AvaloniaEssentialsPlatformProvider.cs
@@ -8,6 +8,7 @@ namespace Avalonia.Controls.Maui.Essentials;
 /// </summary>
 internal class AvaloniaEssentialsPlatformProvider : IAvaloniaEssentialsPlatformProvider
 {
+    /// <inheritdoc/>
     public TopLevel? GetTopLevel()
     {
         var lifetime = Application.Current?.ApplicationLifetime;

--- a/src/Avalonia.Controls.Maui.Essentials/FilePicker/AvaloniaFilePicker.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/FilePicker/AvaloniaFilePicker.cs
@@ -5,6 +5,9 @@ using MauiFilePickerFileType = Microsoft.Maui.Storage.FilePickerFileType;
 
 namespace Avalonia.Controls.Maui.Essentials;
 
+/// <summary>
+/// Implements IFilePicker using Avalonia's StorageProvider API to present native file picker dialogs on desktop and browser platforms.
+/// </summary>
 public class AvaloniaFilePicker : IFilePicker
 {
     readonly IAvaloniaEssentialsPlatformProvider _platformProvider;
@@ -14,6 +17,11 @@ public class AvaloniaFilePicker : IFilePicker
         _platformProvider = platformProvider;
     }
 
+    /// <summary>
+    /// Displays a file picker dialog that allows the user to select a single file.
+    /// </summary>
+    /// <param name="options">The options that configure the file picker, including title and allowed file types. Can be <c>null</c> for default behavior.</param>
+    /// <returns>A <see cref="FileResult"/> representing the selected file, or <c>null</c> if the user cancelled the dialog or no local path was available.</returns>
     public async Task<FileResult?> PickAsync(PickOptions? options)
     {
         var topLevel = _platformProvider.GetTopLevel()
@@ -29,6 +37,11 @@ public class AvaloniaFilePicker : IFilePicker
         return path is not null ? new FileResult(path) : null;
     }
 
+    /// <summary>
+    /// Displays a file picker dialog that allows the user to select multiple files.
+    /// </summary>
+    /// <param name="options">The options that configure the file picker, including title and allowed file types. Can be <c>null</c> for default behavior.</param>
+    /// <returns>A collection of FileResult objects representing the selected files, or an empty collection if the user cancelled the dialog.</returns>
     public async Task<IEnumerable<FileResult?>> PickMultipleAsync(PickOptions? options)
     {
         var topLevel = _platformProvider.GetTopLevel()

--- a/src/Avalonia.Controls.Maui.Essentials/FileSystem/AvaloniaFileSystem.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/FileSystem/AvaloniaFileSystem.cs
@@ -4,11 +4,17 @@ using Microsoft.Maui.Storage;
 
 namespace Avalonia.Controls.Maui.Essentials;
 
+/// <summary>
+/// Avalonia implementation of IFileSystem that provides access to standard OS directories for cache and application data, and uses Avalonia's AssetLoader for embedded app package files.
+/// </summary>
 public class AvaloniaFileSystem : IFileSystem
 {
     readonly string _cacheDirectory;
     readonly string _appDataDirectory;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AvaloniaFileSystem"/> class, resolving cache and app data directory paths based on the entry assembly name.
+    /// </summary>
     public AvaloniaFileSystem()
     {
         var appName = Assembly.GetEntryAssembly()?.GetName().Name ?? "AvaloniaApp";
@@ -23,6 +29,9 @@ public class AvaloniaFileSystem : IFileSystem
             appName);
     }
 
+    /// <summary>
+    /// Gets the path to the application's cache directory under LocalApplicationData, creating the directory if it does not exist.
+    /// </summary>
     public string CacheDirectory
     {
         get
@@ -32,6 +41,9 @@ public class AvaloniaFileSystem : IFileSystem
         }
     }
 
+    /// <summary>
+    /// Gets the path to the application's data directory under ApplicationData, creating the directory if it does not exist.
+    /// </summary>
     public string AppDataDirectory
     {
         get
@@ -41,11 +53,22 @@ public class AvaloniaFileSystem : IFileSystem
         }
     }
 
+    /// <summary>
+    /// Determines whether a file with the specified name exists as an embedded Avalonia asset in the app package.
+    /// </summary>
+    /// <param name="filename">The name or relative path of the file to check.</param>
+    /// <returns><see langword="true"/> if the file exists as an embedded asset; otherwise, <see langword="false"/>.</returns>
     public Task<bool> AppPackageFileExistsAsync(string filename)
     {
         return Task.FromResult(TryGetAssetUri(filename, out _));
     }
 
+    /// <summary>
+    /// Opens a read-only stream for the specified file from the app package using Avalonia's AssetLoader.
+    /// </summary>
+    /// <param name="filename">The name or relative path of the file to open.</param>
+    /// <returns>A stream containing the contents of the specified app package file.</returns>
+    /// <exception cref="FileNotFoundException">Thrown when the specified file cannot be found in the app package.</exception>
     public Task<Stream> OpenAppPackageFileAsync(string filename)
     {
         if (!TryGetAssetUri(filename, out var uri))

--- a/src/Avalonia.Controls.Maui.Essentials/HapticFeedback/AvaloniaHapticFeedback.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/HapticFeedback/AvaloniaHapticFeedback.cs
@@ -3,10 +3,20 @@ using Microsoft.Maui.Devices;
 
 namespace Avalonia.Controls.Maui.Essentials;
 
+/// <summary>
+/// Provides a no-op implementation of IHapticFeedback for Avalonia desktop platforms where haptic feedback hardware is not available.
+/// </summary>
 public class AvaloniaHapticFeedback : IHapticFeedback
 {
+    /// <summary>
+    /// Gets a value indicating whether haptic feedback is supported on the current platform. Always returns <c>false</c> for Avalonia desktop platforms.
+    /// </summary>
     public bool IsSupported => false;
 
+    /// <summary>
+    /// Performs a haptic feedback action. This method is a no-op on Avalonia desktop platforms because haptic feedback is not supported.
+    /// </summary>
+    /// <param name="type">The type of haptic feedback to perform.</param>
     public void Perform(HapticFeedbackType type)
     {
         // No-op on Avalonia desktop platforms, as haptic feedback is not supported.

--- a/src/Avalonia.Controls.Maui.Essentials/IAvaloniaEssentialsPlatformProvider.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/IAvaloniaEssentialsPlatformProvider.cs
@@ -2,7 +2,14 @@ using Avalonia.Controls;
 
 namespace Avalonia.Controls.Maui.Essentials;
 
+/// <summary>
+/// Provides access to the Avalonia TopLevel for Essentials implementations that require platform-level access, such as file pickers and screenshots.
+/// </summary>
 public interface IAvaloniaEssentialsPlatformProvider
 {
+    /// <summary>
+    /// Gets the current Avalonia TopLevel, which provides access to platform services such as the storage provider, clipboard, and screen information.
+    /// </summary>
+    /// <returns>The current TopLevel instance, or <c>null</c> if the application has not been fully initialized or no TopLevel is available.</returns>
     TopLevel? GetTopLevel();
 }

--- a/src/Avalonia.Controls.Maui.Essentials/MauiEssentialsBuilderExtensions.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/MauiEssentialsBuilderExtensions.cs
@@ -3,6 +3,9 @@ using Microsoft.Maui.Storage;
 
 namespace Avalonia.Controls.Maui.Essentials;
 
+/// <summary>
+/// Extension methods for configuring Avalonia-based Microsoft.Maui.Essentials services.
+/// </summary>
 public static class MauiEssentialsBuilderExtensions
 {
     /// <summary>

--- a/src/Avalonia.Controls.Maui.Essentials/MediaPicker/AvaloniaMediaPicker.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/MediaPicker/AvaloniaMediaPicker.cs
@@ -5,6 +5,9 @@ using AvaloniaFilePickerFileType = Avalonia.Platform.Storage.FilePickerFileType;
 
 namespace Avalonia.Controls.Maui.Essentials;
 
+/// <summary>
+/// Avalonia implementation of IMediaPicker that uses the StorageProvider file picker for photo and video selection on desktop platforms.
+/// </summary>
 public class AvaloniaMediaPicker : IMediaPicker
 {
     readonly IAvaloniaEssentialsPlatformProvider _platformProvider;
@@ -14,18 +17,38 @@ public class AvaloniaMediaPicker : IMediaPicker
         _platformProvider = platformProvider;
     }
 
+    /// <summary>
+    /// Gets a value indicating whether camera capture is supported; always returns <see langword="false"/> because Avalonia desktop platforms do not support camera capture.
+    /// </summary>
     public bool IsCaptureSupported => false;
 
+    /// <summary>
+    /// Captures a photo using the device camera. This operation is not supported on Avalonia desktop platforms and always throws NotSupportedException.
+    /// </summary>
+    /// <param name="options">Optional media picker options such as a title for the picker dialog.</param>
+    /// <returns>This method never returns; it always throws.</returns>
+    /// <exception cref="NotSupportedException">Always thrown because camera capture is not available on desktop.</exception>
     public Task<FileResult?> CapturePhotoAsync(MediaPickerOptions? options = null)
     {
         throw new NotSupportedException("Camera capture is not supported on Avalonia desktop platforms.");
     }
 
+    /// <summary>
+    /// Captures a video using the device camera. This operation is not supported on Avalonia desktop platforms and always throws NotSupportedException.
+    /// </summary>
+    /// <param name="options">Optional media picker options such as a title for the picker dialog.</param>
+    /// <returns>This method never returns; it always throws.</returns>
+    /// <exception cref="NotSupportedException">Always thrown because camera capture is not available on desktop.</exception>
     public Task<FileResult?> CaptureVideoAsync(MediaPickerOptions? options = null)
     {
         throw new NotSupportedException("Camera capture is not supported on Avalonia desktop platforms.");
     }
 
+    /// <summary>
+    /// Opens a file picker dialog filtered to image file types and returns the selected photo.
+    /// </summary>
+    /// <param name="options">Optional media picker options such as a title for the picker dialog.</param>
+    /// <returns>A FileResult representing the selected photo, or <see langword="null"/> if the user cancelled the dialog.</returns>
     public async Task<FileResult?> PickPhotoAsync(MediaPickerOptions? options = null)
     {
         var topLevel = _platformProvider.GetTopLevel()
@@ -41,6 +64,11 @@ public class AvaloniaMediaPicker : IMediaPicker
         return path is not null ? new FileResult(path) : null;
     }
 
+    /// <summary>
+    /// Opens a file picker dialog filtered to image file types and allows the user to select multiple photos.
+    /// </summary>
+    /// <param name="options">Optional media picker options such as a title for the picker dialog.</param>
+    /// <returns>A list of FileResult objects representing the selected photos, or an empty list if the user cancelled the dialog.</returns>
     public async Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions? options = null)
     {
         var topLevel = _platformProvider.GetTopLevel()
@@ -60,6 +88,11 @@ public class AvaloniaMediaPicker : IMediaPicker
         return fileResults;
     }
 
+    /// <summary>
+    /// Opens a file picker dialog filtered to video file types and returns the selected video.
+    /// </summary>
+    /// <param name="options">Optional media picker options such as a title for the picker dialog.</param>
+    /// <returns>A FileResult representing the selected video, or <see langword="null"/> if the user cancelled the dialog.</returns>
     public async Task<FileResult?> PickVideoAsync(MediaPickerOptions? options = null)
     {
         var topLevel = _platformProvider.GetTopLevel()
@@ -75,6 +108,11 @@ public class AvaloniaMediaPicker : IMediaPicker
         return path is not null ? new FileResult(path) : null;
     }
 
+    /// <summary>
+    /// Opens a file picker dialog filtered to video file types and allows the user to select multiple videos.
+    /// </summary>
+    /// <param name="options">Optional media picker options such as a title for the picker dialog.</param>
+    /// <returns>A list of FileResult objects representing the selected videos, or an empty list if the user cancelled the dialog.</returns>
     public async Task<List<FileResult>> PickVideosAsync(MediaPickerOptions? options = null)
     {
         var topLevel = _platformProvider.GetTopLevel()

--- a/src/Avalonia.Controls.Maui.Essentials/Screenshot/AvaloniaScreenshot.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/Screenshot/AvaloniaScreenshot.cs
@@ -4,17 +4,32 @@ using Microsoft.Maui.Media;
 
 namespace Avalonia.Controls.Maui.Essentials;
 
+/// <summary>
+/// Avalonia implementation of IScreenshot that captures the current TopLevel window by rendering it to a RenderTargetBitmap.
+/// </summary>
 public class AvaloniaScreenshot : IScreenshot
 {
     readonly IAvaloniaEssentialsPlatformProvider _platformProvider;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AvaloniaScreenshot"/> class with the specified platform provider.
+    /// </summary>
+    /// <param name="platformProvider">The platform provider used to retrieve the Avalonia TopLevel window for screen capture.</param>
     public AvaloniaScreenshot(IAvaloniaEssentialsPlatformProvider platformProvider)
     {
         _platformProvider = platformProvider;
     }
 
+    /// <summary>
+    /// Gets a value indicating whether screen capture is supported; always returns <see langword="true"/> for Avalonia platforms.
+    /// </summary>
     public bool IsCaptureSupported => true;
 
+    /// <summary>
+    /// Captures a screenshot of the current TopLevel window by rendering it to a bitmap on the UI thread.
+    /// </summary>
+    /// <returns>An IScreenshotResult containing the captured image data and its pixel dimensions.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the TopLevel cannot be retrieved or the window has zero size.</exception>
     public async Task<IScreenshotResult> CaptureAsync()
     {
         var topLevel = _platformProvider.GetTopLevel()

--- a/src/Avalonia.Controls.Maui.Essentials/Screenshot/AvaloniaScreenshotResult.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/Screenshot/AvaloniaScreenshotResult.cs
@@ -3,10 +3,22 @@ using Microsoft.Maui.Media;
 
 namespace Avalonia.Controls.Maui.Essentials;
 
+/// <summary>
+/// Wraps an Avalonia RenderTargetBitmap as an IScreenshotResult, providing stream-based access to the captured image data.
+/// </summary>
+/// <remarks>
+/// The output is always PNG regardless of the requested ScreenshotFormat, because Avalonia's bitmap Save method only supports PNG encoding.
+/// </remarks>
 public class AvaloniaScreenshotResult : IScreenshotResult
 {
     readonly RenderTargetBitmap _bitmap;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AvaloniaScreenshotResult"/> class with the specified rendered bitmap and dimensions.
+    /// </summary>
+    /// <param name="bitmap">The Avalonia RenderTargetBitmap containing the captured screenshot.</param>
+    /// <param name="width">The width of the screenshot in pixels.</param>
+    /// <param name="height">The height of the screenshot in pixels.</param>
     public AvaloniaScreenshotResult(RenderTargetBitmap bitmap, int width, int height)
     {
         _bitmap = bitmap;
@@ -14,9 +26,22 @@ public class AvaloniaScreenshotResult : IScreenshotResult
         Height = height;
     }
 
+    /// <summary>
+    /// Gets the width of the screenshot in pixels.
+    /// </summary>
     public int Width { get; }
+
+    /// <summary>
+    /// Gets the height of the screenshot in pixels.
+    /// </summary>
     public int Height { get; }
 
+    /// <summary>
+    /// Opens a readable stream containing the screenshot image data encoded as PNG.
+    /// </summary>
+    /// <param name="format">The desired screenshot format. This parameter is accepted but ignored; output is always PNG.</param>
+    /// <param name="quality">The desired image quality (0-100). This parameter is accepted but ignored for PNG output.</param>
+    /// <returns>A stream positioned at the beginning containing the PNG-encoded screenshot data.</returns>
     public Task<Stream> OpenReadAsync(ScreenshotFormat format = ScreenshotFormat.Png, int quality = 100)
     {
         // Avalonia's Save() only supports PNG; format parameter is acknowledged but always produces PNG.
@@ -27,6 +52,13 @@ public class AvaloniaScreenshotResult : IScreenshotResult
         return Task.FromResult<Stream>(stream);
     }
 
+    /// <summary>
+    /// Copies the screenshot image data encoded as PNG to the specified destination stream.
+    /// </summary>
+    /// <param name="destination">The stream to copy the screenshot data to.</param>
+    /// <param name="format">The desired screenshot format. This parameter is accepted but ignored; output is always PNG.</param>
+    /// <param name="quality">The desired image quality (0-100). This parameter is accepted but ignored for PNG output.</param>
+    /// <returns>A task that represents the asynchronous copy operation.</returns>
     public async Task CopyToAsync(Stream destination, ScreenshotFormat format = ScreenshotFormat.Png, int quality = 100)
     {
         using var stream = await OpenReadAsync(format, quality).ConfigureAwait(false);

--- a/src/Avalonia.Controls.Maui.Graphics/Avalonia.Controls.Maui.Graphics.csproj
+++ b/src/Avalonia.Controls.Maui.Graphics/Avalonia.Controls.Maui.Graphics.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(DotNetTfm)</TargetFramework>
     <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS0618;CS8002</NoWarn>
     <IsAotCompatible>true</IsAotCompatible>
     <AddMauiInternals>true</AddMauiInternals>

--- a/src/Avalonia.Controls.Maui.Graphics/Extensions/MauiAppBuilderExtensions.cs
+++ b/src/Avalonia.Controls.Maui.Graphics/Extensions/MauiAppBuilderExtensions.cs
@@ -1,5 +1,8 @@
 using Microsoft.Maui.Hosting;
 
+/// <summary>
+/// Provides extension methods for configuring Avalonia graphics services in a .NET MAUI application.
+/// </summary>
 public static class MauiAppBuilderExtensions
 {
     /// <summary>

--- a/src/Avalonia.Controls.Maui.Graphics/Handlers/GraphicsViewHandler.cs
+++ b/src/Avalonia.Controls.Maui.Graphics/Handlers/GraphicsViewHandler.cs
@@ -6,8 +6,14 @@ using PlatformView = System.Object;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>
+/// Avalonia handler for <see cref="IGraphicsView"/>.
+/// </summary>
 public partial class GraphicsViewHandler : ViewHandler<IGraphicsView, PlatformTouchGraphicsView>
 {
+    /// <summary>
+    /// The property mapper that maps <see cref="IGraphicsView"/> properties to <see cref="GraphicsViewHandler"/> methods.
+    /// </summary>
     public static IPropertyMapper<IGraphicsView, GraphicsViewHandler> Mapper = new PropertyMapper<IGraphicsView, GraphicsViewHandler>(ViewMapper)
     {
         [nameof(IView.Background)] = MapBackground,
@@ -15,58 +21,97 @@ public partial class GraphicsViewHandler : ViewHandler<IGraphicsView, PlatformTo
         [nameof(IView.FlowDirection)] = MapFlowDirection
     };
 
+    /// <summary>
+    /// The command mapper that maps <see cref="IGraphicsView"/> commands to <see cref="GraphicsViewHandler"/> methods.
+    /// </summary>
     public static CommandMapper<IGraphicsView, GraphicsViewHandler> CommandMapper = new(ViewCommandMapper)
     {
         [nameof(IGraphicsView.Invalidate)] = MapInvalidate
     };
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GraphicsViewHandler"/> class with default mappers.
+    /// </summary>
     public GraphicsViewHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GraphicsViewHandler"/> class with a custom property mapper.
+    /// </summary>
+    /// <param name="mapper">The custom property mapper to use, or <see langword="null"/> to use the default mapper.</param>
     public GraphicsViewHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GraphicsViewHandler"/> class with custom mappers.
+    /// </summary>
+    /// <param name="mapper">The custom property mapper to use, or <see langword="null"/> to use the default mapper.</param>
+    /// <param name="commandMapper">The custom command mapper to use, or <see langword="null"/> to use the default command mapper.</param>
     public GraphicsViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <inheritdoc/>
     protected override PlatformTouchGraphicsView CreatePlatformView()
     {
         return new PlatformTouchGraphicsView();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformTouchGraphicsView platformView)
     {
         platformView.Connect(VirtualView);
         base.ConnectHandler(platformView);
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformTouchGraphicsView platformView)
     {
         platformView.Disconnect();
         base.DisconnectHandler(platformView);
     }
 
+    /// <summary>
+    /// Maps the Background property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the graphics view.</param>
+    /// <param name="graphicsView">The virtual view to map from.</param>
     public static void MapBackground(GraphicsViewHandler handler, IGraphicsView graphicsView)
     {
         (handler.PlatformView as PlatformTouchGraphicsView)?.UpdateBackground(graphicsView);
     }
 
+    /// <summary>
+    /// Maps the Drawable property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the graphics view.</param>
+    /// <param name="graphicsView">The virtual view to map from.</param>
     public static void MapDrawable(GraphicsViewHandler handler, IGraphicsView graphicsView)
     {
         (handler.PlatformView as PlatformTouchGraphicsView)?.UpdateDrawable(graphicsView);
     }
 
+    /// <summary>
+    /// Maps the FlowDirection property to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the graphics view.</param>
+    /// <param name="graphicsView">The virtual view to map from.</param>
     public static void MapFlowDirection(GraphicsViewHandler handler, IGraphicsView graphicsView)
     {
         (handler.PlatformView as PlatformTouchGraphicsView)?.UpdateFlowDirection(graphicsView);
         (handler.PlatformView as PlatformTouchGraphicsView)?.Invalidate();
     }
 
+    /// <summary>
+    /// Maps the Invalidate command to the platform view.
+    /// </summary>
+    /// <param name="handler">The handler for the graphics view.</param>
+    /// <param name="graphicsView">The virtual view to map from.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapInvalidate(GraphicsViewHandler handler, IGraphicsView graphicsView, object? arg)
     {
         (handler.PlatformView as PlatformTouchGraphicsView)?.Invalidate();

--- a/src/Avalonia.Controls.Maui.Graphics/Platform/PlatformGraphicsView.cs
+++ b/src/Avalonia.Controls.Maui.Graphics/Platform/PlatformGraphicsView.cs
@@ -19,6 +19,10 @@ public class PlatformGraphicsView : Control
     private IGraphicsView? _graphicsView;
     private IDrawable? _drawable;
 
+    /// <summary>
+    /// Updates the drawable from the specified MAUI graphics view, triggering a re-render.
+    /// </summary>
+    /// <param name="graphicsView">The MAUI graphics view whose drawable should be rendered.</param>
     public void UpdateDrawable(IGraphicsView graphicsView)
     {
         _graphicsView = graphicsView;
@@ -26,6 +30,9 @@ public class PlatformGraphicsView : Control
         InvalidateVisual();
     }
 
+    /// <summary>
+    /// Triggers a re-render of the graphics view by posting an invalidation to the UI thread.
+    /// </summary>
     public new void InvalidateVisual()
     {
         Avalonia.Threading.Dispatcher.UIThread.Post(() =>
@@ -34,6 +41,7 @@ public class PlatformGraphicsView : Control
         });
     }
 
+    /// <inheritdoc/>
     public override void Render(DrawingContext context)
     {
         base.Render(context);

--- a/src/Avalonia.Controls.Maui.Graphics/Platform/PlatformTouchGraphicsView.cs
+++ b/src/Avalonia.Controls.Maui.Graphics/Platform/PlatformTouchGraphicsView.cs
@@ -14,17 +14,27 @@ public class PlatformTouchGraphicsView : UserControl
     private bool _isTouching;
     private bool _isInBounds;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlatformTouchGraphicsView"/> class with an embedded <see cref="PlatformGraphicsView"/> for rendering.
+    /// </summary>
     public PlatformTouchGraphicsView()
     {
         Content = _platformGraphicsView = new PlatformGraphicsView();
     }
 
+    /// <summary>
+    /// Updates the drawable from the specified MAUI graphics view, triggering a re-render.
+    /// </summary>
+    /// <param name="graphicsView">The MAUI graphics view whose drawable should be rendered.</param>
     public void UpdateDrawable(IGraphicsView graphicsView)
     {
         _platformGraphicsView.UpdateDrawable(graphicsView);
         _graphicsView = graphicsView;
     }
 
+    /// <summary>
+    /// Triggers a re-render of the underlying graphics view.
+    /// </summary>
     public void InvalidateDrawable() => _platformGraphicsView.InvalidateVisual();
 
     private PointF[] GetViewPoints(PointerEventArgs e)
@@ -33,6 +43,7 @@ public class PlatformTouchGraphicsView : UserControl
         return [new PointF((float)point.X, (float)point.Y)];
     }
 
+    /// <inheritdoc/>
     protected override void OnPointerEntered(PointerEventArgs e)
     {
         base.OnPointerEntered(e);
@@ -40,6 +51,7 @@ public class PlatformTouchGraphicsView : UserControl
         _graphicsView?.StartHoverInteraction(GetViewPoints(e));
     }
 
+    /// <inheritdoc/>
     protected override void OnPointerExited(PointerEventArgs e)
     {
         base.OnPointerExited(e);
@@ -54,6 +66,7 @@ public class PlatformTouchGraphicsView : UserControl
         }
     }
 
+    /// <inheritdoc/>
     protected override void OnPointerMoved(PointerEventArgs e)
     {
         base.OnPointerMoved(e);
@@ -65,6 +78,7 @@ public class PlatformTouchGraphicsView : UserControl
             _graphicsView?.DragInteraction(points);
     }
 
+    /// <inheritdoc/>
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
         base.OnPointerPressed(e);
@@ -73,6 +87,7 @@ public class PlatformTouchGraphicsView : UserControl
         _graphicsView?.StartInteraction(points);
     }
 
+    /// <inheritdoc/>
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {
         base.OnPointerReleased(e);
@@ -85,6 +100,7 @@ public class PlatformTouchGraphicsView : UserControl
         }
     }
 
+    /// <inheritdoc/>
     protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
     {
         base.OnPointerCaptureLost(e);
@@ -95,7 +111,14 @@ public class PlatformTouchGraphicsView : UserControl
         }
     }
 
+    /// <summary>
+    /// Connects this view to the specified MAUI graphics view for receiving touch and hover events.
+    /// </summary>
+    /// <param name="graphicsView">The MAUI graphics view to connect to.</param>
     public void Connect(IGraphicsView graphicsView) => _graphicsView = graphicsView;
 
+    /// <summary>
+    /// Disconnects from the current MAUI graphics view, stopping touch and hover event forwarding.
+    /// </summary>
     public void Disconnect() => _graphicsView = null;
 }

--- a/src/Avalonia.Controls.Maui.Maps.Mapsui/Avalonia.Controls.Maui.Maps.Mapsui.csproj
+++ b/src/Avalonia.Controls.Maui.Maps.Mapsui/Avalonia.Controls.Maui.Maps.Mapsui.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(DotNetTfm)</TargetFramework>
     <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS0618;CS8002</NoWarn>
     <IsAotCompatible>true</IsAotCompatible>
     <AddMauiInternals>true</AddMauiInternals>

--- a/src/Avalonia.Controls.Maui.Maps.Mapsui/Extensions/MapsuiMapExtensions.cs
+++ b/src/Avalonia.Controls.Maui.Maps.Mapsui/Extensions/MapsuiMapExtensions.cs
@@ -12,7 +12,7 @@ using MapsuiMapControl = Mapsui.UI.Avalonia.MapControl;
 namespace Avalonia.Controls.Maui.Maps.Mapsui.Extensions;
 
 /// <summary>
-/// Extension methods for <see cref="Mapsui.UI.Avalonia.MapControl"/>.
+/// Extension methods for the Mapsui MapControl.
 /// </summary>
 public static class MapsuiMapExtensions
 {

--- a/src/Avalonia.Controls.Maui/Avalonia.Controls.Maui.csproj
+++ b/src/Avalonia.Controls.Maui/Avalonia.Controls.Maui.csproj
@@ -10,6 +10,7 @@
     <!-- Windows available on Windows -->
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);$(DotNetTfm)-windows10.0.19041.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS0618;CS8002</NoWarn>
     <IsAotCompatible>true</IsAotCompatible>
     <AddMauiInternals>true</AddMauiInternals>

--- a/src/Avalonia.Controls.Maui/Controls/Button/MauiButton.cs
+++ b/src/Avalonia.Controls.Maui/Controls/Button/MauiButton.cs
@@ -11,24 +11,32 @@ namespace Avalonia.Controls.Maui;
 /// </summary>
 public class MauiButton : Button
 {
+    /// <summary>
+    /// Gets the style key override, resolving to the base <see cref="Button"/> type.
+    /// </summary>
     protected override Type StyleKeyOverride => typeof(Button);
     private DockPanel? _contentPanel;
     private TextBlock? _textBlock;
     private Image? _image;
     private MauiContentLayout _contentLayout = new(MauiContentLayout.ImagePosition.Left, 10);
 
+    /// <summary>Defines the <see cref="Text"/> property.</summary>
     public static readonly StyledProperty<string?> TextProperty =
         AvaloniaProperty.Register<MauiButton, string?>(nameof(Text));
 
+    /// <summary>Defines the <see cref="ImageSource"/> property.</summary>
     public static readonly StyledProperty<global::Avalonia.Media.IImage?> ImageSourceProperty =
         AvaloniaProperty.Register<MauiButton, global::Avalonia.Media.IImage?>(nameof(ImageSource));
 
+    /// <summary>Defines the <see cref="CharacterSpacing"/> property.</summary>
     public static readonly StyledProperty<double> CharacterSpacingProperty =
         AvaloniaProperty.Register<MauiButton, double>(nameof(CharacterSpacing));
 
+    /// <summary>Defines the <see cref="ContentLayout"/> property.</summary>
     public static readonly StyledProperty<MauiContentLayout> ContentLayoutProperty =
         AvaloniaProperty.Register<MauiButton, MauiContentLayout>(nameof(ContentLayout), new MauiContentLayout(MauiContentLayout.ImagePosition.Left, 10));
 
+    /// <summary>Defines the <see cref="LineBreakMode"/> property.</summary>
     public static readonly StyledProperty<Microsoft.Maui.LineBreakMode> LineBreakModeProperty =
         AvaloniaProperty.Register<MauiButton, Microsoft.Maui.LineBreakMode>(nameof(LineBreakMode), Microsoft.Maui.LineBreakMode.NoWrap);
 
@@ -40,36 +48,54 @@ public class MauiButton : Button
         LineBreakModeProperty.Changed.AddClassHandler<MauiButton>((button, e) => button.UpdateContent());
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="MauiButton"/>.
+    /// </summary>
     public MauiButton()
     {
         HorizontalAlignment = HorizontalAlignment.Stretch;
         InitializeContent();
     }
 
+    /// <summary>
+    /// Gets or sets the button text.
+    /// </summary>
     public string? Text
     {
         get => GetValue(TextProperty);
         set => SetValue(TextProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the image displayed on the button.
+    /// </summary>
     public global::Avalonia.Media.IImage? ImageSource
     {
         get => GetValue(ImageSourceProperty);
         set => SetValue(ImageSourceProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the character spacing for the button text.
+    /// </summary>
     public double CharacterSpacing
     {
         get => GetValue(CharacterSpacingProperty);
         set => SetValue(CharacterSpacingProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the layout of the button's image and text content.
+    /// </summary>
     public MauiContentLayout ContentLayout
     {
         get => GetValue(ContentLayoutProperty);
         set => SetValue(ContentLayoutProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the line break mode for the button text.
+    /// </summary>
     public Microsoft.Maui.LineBreakMode LineBreakMode
     {
         get => GetValue(LineBreakModeProperty);
@@ -252,6 +278,10 @@ public class MauiButton : Button
         }
     }
 
+    /// <summary>
+    /// Updates the content layout of the button, controlling image and text positioning.
+    /// </summary>
+    /// <param name="layout">The content layout specifying image position and spacing.</param>
     public void UpdateContentLayout(MauiContentLayout layout)
     {
         if (!ContentLayout.Equals(layout))
@@ -270,7 +300,15 @@ public class MauiButton : Button
         UpdateContent();
     }
 
+    /// <summary>
+    /// Gets the internal <see cref="TextBlock"/> used to display the button text.
+    /// </summary>
+    /// <returns>The text block, or <c>null</c> if not initialized.</returns>
     public TextBlock? GetTextBlock() => _textBlock;
 
+    /// <summary>
+    /// Gets the internal <see cref="Image"/> used to display the button image.
+    /// </summary>
+    /// <returns>The image control, or <c>null</c> if not initialized.</returns>
     public Image? GetImage() => _image;
 }

--- a/src/Avalonia.Controls.Maui/Controls/CollectionView/MauiCollectionView.cs
+++ b/src/Avalonia.Controls.Maui/Controls/CollectionView/MauiCollectionView.cs
@@ -15,6 +15,9 @@ using System.Collections.Specialized;
 
 namespace Avalonia.Controls.Maui;
 
+/// <summary>
+/// Avalonia templated control that implements MAUI's CollectionView with support for selection, grouping, and virtualized scrolling.
+/// </summary>
 public class MauiCollectionView : TemplatedControl
 {
     private ItemsControl? _itemsControl;
@@ -25,77 +28,101 @@ public class MauiCollectionView : TemplatedControl
     private Panel? _rootPanel;
     private StackPanel? _mainContainer;
 
+    /// <summary>Defines the <see cref="ItemsSource"/> property.</summary>
     public static readonly StyledProperty<IEnumerable?> ItemsSourceProperty =
         AvaloniaProperty.Register<MauiCollectionView, IEnumerable?>(nameof(ItemsSource));
 
+    /// <summary>Defines the <see cref="ItemTemplate"/> property.</summary>
     public static readonly StyledProperty<IDataTemplate?> ItemTemplateProperty =
         AvaloniaProperty.Register<MauiCollectionView, IDataTemplate?>(nameof(ItemTemplate));
 
+    /// <summary>Defines the <see cref="EmptyView"/> property.</summary>
     public static readonly StyledProperty<object?> EmptyViewProperty =
         AvaloniaProperty.Register<MauiCollectionView, object?>(nameof(EmptyView));
 
+    /// <summary>Defines the <see cref="EmptyViewTemplate"/> property.</summary>
     public static readonly StyledProperty<IDataTemplate?> EmptyViewTemplateProperty =
         AvaloniaProperty.Register<MauiCollectionView, IDataTemplate?>(nameof(EmptyViewTemplate));
 
+    /// <summary>Defines the <see cref="HorizontalScrollBarVisibility"/> property.</summary>
     public static readonly StyledProperty<ScrollBarVisibility> HorizontalScrollBarVisibilityProperty =
         AvaloniaProperty.Register<MauiCollectionView, ScrollBarVisibility>(
             nameof(HorizontalScrollBarVisibility),
             ScrollBarVisibility.Auto);
 
+    /// <summary>Defines the <see cref="VerticalScrollBarVisibility"/> property.</summary>
     public static readonly StyledProperty<ScrollBarVisibility> VerticalScrollBarVisibilityProperty =
         AvaloniaProperty.Register<MauiCollectionView, ScrollBarVisibility>(
             nameof(VerticalScrollBarVisibility),
             ScrollBarVisibility.Auto);
 
+    /// <summary>Defines the <see cref="SelectedItem"/> property.</summary>
     public static readonly StyledProperty<object?> SelectedItemProperty =
         AvaloniaProperty.Register<MauiCollectionView, object?>(
             nameof(SelectedItem),
             defaultBindingMode: Data.BindingMode.TwoWay);
 
+    /// <summary>Defines the <see cref="SelectionMode"/> property.</summary>
     public static readonly StyledProperty<SelectionMode> SelectionModeProperty =
         AvaloniaProperty.Register<MauiCollectionView, SelectionMode>(
             nameof(SelectionMode),
             SelectionMode.Single);
 
+    /// <summary>Defines the <see cref="ItemsLayout"/> property.</summary>
     public static readonly StyledProperty<IItemsLayout?> ItemsLayoutProperty =
         AvaloniaProperty.Register<MauiCollectionView, IItemsLayout?>(
             nameof(ItemsLayout),
             LinearItemsLayout.Vertical);
 
+    /// <summary>Defines the <see cref="IsGrouped"/> property.</summary>
     public static readonly StyledProperty<bool> IsGroupedProperty =
         AvaloniaProperty.Register<MauiCollectionView, bool>(nameof(IsGrouped), false);
 
+    /// <summary>Defines the <see cref="GroupHeaderTemplate"/> property.</summary>
     public static readonly StyledProperty<IDataTemplate?> GroupHeaderTemplateProperty =
         AvaloniaProperty.Register<MauiCollectionView, IDataTemplate?>(nameof(GroupHeaderTemplate));
 
+    /// <summary>Defines the <see cref="GroupFooterTemplate"/> property.</summary>
     public static readonly StyledProperty<IDataTemplate?> GroupFooterTemplateProperty =
         AvaloniaProperty.Register<MauiCollectionView, IDataTemplate?>(nameof(GroupFooterTemplate));
 
+    /// <summary>Defines the <see cref="Header"/> property.</summary>
     public static readonly StyledProperty<object?> HeaderProperty =
         AvaloniaProperty.Register<MauiCollectionView, object?>(nameof(Header));
 
+    /// <summary>Defines the <see cref="HeaderTemplate"/> property.</summary>
     public static readonly StyledProperty<IDataTemplate?> HeaderTemplateProperty =
         AvaloniaProperty.Register<MauiCollectionView, IDataTemplate?>(nameof(HeaderTemplate));
 
+    /// <summary>Defines the <see cref="Footer"/> property.</summary>
     public static readonly StyledProperty<object?> FooterProperty =
         AvaloniaProperty.Register<MauiCollectionView, object?>(nameof(Footer));
 
+    /// <summary>Defines the <see cref="FooterTemplate"/> property.</summary>
     public static readonly StyledProperty<IDataTemplate?> FooterTemplateProperty =
         AvaloniaProperty.Register<MauiCollectionView, IDataTemplate?>(nameof(FooterTemplate));
 
+    /// <summary>Defines the <see cref="SelectedItems"/> property.</summary>
     public static readonly StyledProperty<IList<object>?> SelectedItemsProperty =
         AvaloniaProperty.Register<MauiCollectionView, IList<object>?>(nameof(SelectedItems));
 
+    /// <summary>Defines the <see cref="ItemsUpdatingScrollMode"/> property.</summary>
     public static readonly StyledProperty<ItemsUpdatingScrollMode> ItemsUpdatingScrollModeProperty =
         AvaloniaProperty.Register<MauiCollectionView, ItemsUpdatingScrollMode>(
             nameof(ItemsUpdatingScrollMode),
             ItemsUpdatingScrollMode.KeepItemsInView);
 
+    /// <summary>Defines the <see cref="RemainingItemsThreshold"/> property.</summary>
     public static readonly StyledProperty<int> RemainingItemsThresholdProperty =
         AvaloniaProperty.Register<MauiCollectionView, int>(nameof(RemainingItemsThreshold), -1);
 
+    /// <summary>Occurs when the current selection changes.</summary>
     public event EventHandler? SelectionChanged;
+
+    /// <summary>Occurs when the user has scrolled close enough to the end of the items that the remaining items threshold has been reached.</summary>
     public event EventHandler? RemainingItemsThresholdReached;
+
+    /// <summary>Occurs when the scroll position changes within the underlying <see cref="ScrollViewer"/>.</summary>
     public event EventHandler<ScrollChangedEventArgs>? ScrollChanged;
 
     static MauiCollectionView()
@@ -117,6 +144,9 @@ public class MauiCollectionView : TemplatedControl
         FooterTemplateProperty.Changed.AddClassHandler<MauiCollectionView>((cv, _) => cv.UpdateHeaderFooter());
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="MauiCollectionView"/>.
+    /// </summary>
     public MauiCollectionView()
     {
         InitializeDefaultTemplate();
@@ -143,120 +173,178 @@ public class MauiCollectionView : TemplatedControl
         LogicalChildren.Add(_rootPanel);
     }
 
+    /// <summary>
+    /// Gets or sets the data source for the collection view.
+    /// </summary>
     public IEnumerable? ItemsSource
     {
         get => GetValue(ItemsSourceProperty);
         set => SetValue(ItemsSourceProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the data template used to render each item in the collection.
+    /// </summary>
     public IDataTemplate? ItemTemplate
     {
         get => GetValue(ItemTemplateProperty);
         set => SetValue(ItemTemplateProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the content displayed when the items source is empty.
+    /// </summary>
     public object? EmptyView
     {
         get => GetValue(EmptyViewProperty);
         set => SetValue(EmptyViewProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the data template used to render the empty view.
+    /// </summary>
     public IDataTemplate? EmptyViewTemplate
     {
         get => GetValue(EmptyViewTemplateProperty);
         set => SetValue(EmptyViewTemplateProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the horizontal scroll bar visibility for the collection view.
+    /// </summary>
     public ScrollBarVisibility HorizontalScrollBarVisibility
     {
         get => GetValue(HorizontalScrollBarVisibilityProperty);
         set => SetValue(HorizontalScrollBarVisibilityProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the vertical scroll bar visibility for the collection view.
+    /// </summary>
     public ScrollBarVisibility VerticalScrollBarVisibility
     {
         get => GetValue(VerticalScrollBarVisibilityProperty);
         set => SetValue(VerticalScrollBarVisibilityProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the currently selected item.
+    /// </summary>
     public object? SelectedItem
     {
         get => GetValue(SelectedItemProperty);
         set => SetValue(SelectedItemProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the selection behavior for the collection view.
+    /// </summary>
     public SelectionMode SelectionMode
     {
         get => GetValue(SelectionModeProperty);
         set => SetValue(SelectionModeProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the layout specification that determines how items are arranged in the collection.
+    /// </summary>
     public IItemsLayout? ItemsLayout
     {
         get => GetValue(ItemsLayoutProperty);
         set => SetValue(ItemsLayoutProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether items in the collection are grouped.
+    /// </summary>
     public bool IsGrouped
     {
         get => GetValue(IsGroupedProperty);
         set => SetValue(IsGroupedProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the data template used to render the header for each group.
+    /// </summary>
     public IDataTemplate? GroupHeaderTemplate
     {
         get => GetValue(GroupHeaderTemplateProperty);
         set => SetValue(GroupHeaderTemplateProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the data template used to render the footer for each group.
+    /// </summary>
     public IDataTemplate? GroupFooterTemplate
     {
         get => GetValue(GroupFooterTemplateProperty);
         set => SetValue(GroupFooterTemplateProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the content displayed at the top of the collection view.
+    /// </summary>
     public object? Header
     {
         get => GetValue(HeaderProperty);
         set => SetValue(HeaderProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the data template used to render the header content.
+    /// </summary>
     public IDataTemplate? HeaderTemplate
     {
         get => GetValue(HeaderTemplateProperty);
         set => SetValue(HeaderTemplateProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the content displayed at the bottom of the collection view.
+    /// </summary>
     public object? Footer
     {
         get => GetValue(FooterProperty);
         set => SetValue(FooterProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the data template used to render the footer content.
+    /// </summary>
     public IDataTemplate? FooterTemplate
     {
         get => GetValue(FooterTemplateProperty);
         set => SetValue(FooterTemplateProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the list of currently selected items when using multiple selection mode.
+    /// </summary>
     public IList<object>? SelectedItems
     {
         get => GetValue(SelectedItemsProperty);
         set => SetValue(SelectedItemsProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the scroll behavior when items are updated in the collection.
+    /// </summary>
     public ItemsUpdatingScrollMode ItemsUpdatingScrollMode
     {
         get => GetValue(ItemsUpdatingScrollModeProperty);
         set => SetValue(ItemsUpdatingScrollModeProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the number of items remaining before the <see cref="RemainingItemsThresholdReached"/> event fires.
+    /// </summary>
     public int RemainingItemsThreshold
     {
         get => GetValue(RemainingItemsThresholdProperty);
         set => SetValue(RemainingItemsThresholdProperty, value);
     }
 
+    /// <inheritdoc/>
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
@@ -281,6 +369,7 @@ public class MauiCollectionView : TemplatedControl
         UpdateEmptyView();
     }
 
+    /// <inheritdoc/>
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);
@@ -774,8 +863,16 @@ public class MauiCollectionView : TemplatedControl
         }
     }
 
+    /// <summary>
+    /// Gets the underlying <see cref="ItemsControl"/> used to display items.
+    /// </summary>
+    /// <returns>The <see cref="ItemsControl"/> instance, or <c>null</c> if the control has not been initialized.</returns>
     public ItemsControl? GetItemsControl() => _itemsControl;
 
+    /// <summary>
+    /// Gets the underlying <see cref="ScrollViewer"/> used for scrolling the collection.
+    /// </summary>
+    /// <returns>The <see cref="ScrollViewer"/> instance, or <c>null</c> if the control has not been initialized.</returns>
     public ScrollViewer? GetScrollViewer() => _scrollViewer;
 
     private void UpdateHeaderFooter()
@@ -864,6 +961,13 @@ public class MauiCollectionView : TemplatedControl
         }
     }
 
+    /// <summary>
+    /// Scrolls the collection view to bring the specified item into view.
+    /// </summary>
+    /// <param name="item">The item to scroll to.</param>
+    /// <param name="group">The group that contains the item.</param>
+    /// <param name="position">The desired scroll position for the item.</param>
+    /// <param name="animate">Whether to animate the scroll operation.</param>
     public void ScrollTo(object item, object group, ScrollToPosition position = ScrollToPosition.MakeVisible, bool animate = true)
     {
         if (_itemsControl == null || _scrollViewer == null)
@@ -879,6 +983,13 @@ public class MauiCollectionView : TemplatedControl
         }, DispatcherPriority.Background);
     }
 
+    /// <summary>
+    /// Scrolls the collection view to bring the item at the specified index into view.
+    /// </summary>
+    /// <param name="index">The zero-based index of the item to scroll to.</param>
+    /// <param name="groupIndex">The zero-based index of the group that contains the item.</param>
+    /// <param name="position">The desired scroll position for the item.</param>
+    /// <param name="animate">Whether to animate the scroll operation.</param>
     public void ScrollTo(int index, int groupIndex, ScrollToPosition position = ScrollToPosition.MakeVisible, bool animate = true)
     {
         if (_itemsControl == null || _scrollViewer == null)

--- a/src/Avalonia.Controls.Maui/Controls/ImageButton/MauiImageButton.cs
+++ b/src/Avalonia.Controls.Maui/Controls/ImageButton/MauiImageButton.cs
@@ -12,13 +12,18 @@ namespace Avalonia.Controls.Maui;
 /// </summary>
 public class MauiImageButton : Button
 {
+    /// <summary>
+    /// Gets the style key override, resolving to the base <see cref="Button"/> type.
+    /// </summary>
     protected override Type StyleKeyOverride => typeof(Button);
     private Image? _image;
     private MauiAspect _aspect = MauiAspect.AspectFit;
 
+    /// <summary>Defines the <see cref="ImageSource"/> property.</summary>
     public static readonly StyledProperty<IImage?> ImageSourceProperty =
         AvaloniaProperty.Register<MauiImageButton, IImage?>(nameof(ImageSource));
 
+    /// <summary>Defines the <see cref="Aspect"/> property.</summary>
     public static readonly StyledProperty<MauiAspect> AspectProperty =
         AvaloniaProperty.Register<MauiImageButton, MauiAspect>(nameof(Aspect), MauiAspect.AspectFit);
 
@@ -28,17 +33,26 @@ public class MauiImageButton : Button
         AspectProperty.Changed.AddClassHandler<MauiImageButton>((button, e) => button.ApplyAspect(e.GetNewValue<MauiAspect>()));
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="MauiImageButton"/>.
+    /// </summary>
     public MauiImageButton()
     {
         InitializeContent();
     }
 
+    /// <summary>
+    /// Gets or sets the image displayed on the button.
+    /// </summary>
     public IImage? ImageSource
     {
         get => GetValue(ImageSourceProperty);
         set => SetValue(ImageSourceProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the aspect ratio mode for the image.
+    /// </summary>
     public MauiAspect Aspect
     {
         get => GetValue(AspectProperty);
@@ -67,6 +81,10 @@ public class MauiImageButton : Button
         _image.Source = ImageSource;
     }
 
+    /// <summary>
+    /// Updates the aspect ratio mode used to display the image.
+    /// </summary>
+    /// <param name="aspect">The aspect ratio mode to apply.</param>
     public void UpdateAspect(MauiAspect aspect)
     {
         if (!Aspect.Equals(aspect))
@@ -95,5 +113,9 @@ public class MauiImageButton : Button
         };
     }
 
+    /// <summary>
+    /// Gets the internal <see cref="Image"/> used to display the button image.
+    /// </summary>
+    /// <returns>The image control, or <c>null</c> if not initialized.</returns>
     public Image? GetImage() => _image;
 }

--- a/src/Avalonia.Controls.Maui/Controls/MauiBorder/MauiBorder.cs
+++ b/src/Avalonia.Controls.Maui/Controls/MauiBorder/MauiBorder.cs
@@ -170,6 +170,7 @@ namespace Avalonia.Controls.Maui
             set => SetValue(StrokeMiterLimitProperty, value);
         }
 
+        /// <inheritdoc/>
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
             base.OnPropertyChanged(change);
@@ -216,6 +217,7 @@ namespace Avalonia.Controls.Maui
             InvalidateShape();
         }
 
+        /// <inheritdoc/>
         protected override Size ArrangeOverride(Size finalSize)
         {
             var arrangedSize = base.ArrangeOverride(finalSize);
@@ -259,6 +261,7 @@ namespace Avalonia.Controls.Maui
             return arrangedSize;
         }
 
+        /// <inheritdoc/>
         public override void Render(DrawingContext context)
         {
             var bounds = new Rect(Bounds.Size);
@@ -342,6 +345,9 @@ namespace Avalonia.Controls.Maui
             return pen;
         }
 
+        /// <summary>
+        /// Invalidates the cached shape geometry, forcing the border to recalculate and re-render its shape.
+        /// </summary>
         public void InvalidateShape()
         {
             _backgroundGeometry = null;

--- a/src/Avalonia.Controls.Maui/Controls/MauiEditor.cs
+++ b/src/Avalonia.Controls.Maui/Controls/MauiEditor.cs
@@ -8,6 +8,9 @@ namespace Avalonia.Controls.Maui.Controls
     /// </summary>
     public class MauiEditor : TextBox
     {
+        /// <summary>
+        /// Occurs when the text selection changes.
+        /// </summary>
         public event EventHandler<Interactivity.RoutedEventArgs>? SelectionChanged;
 
         /// <summary>
@@ -23,6 +26,7 @@ namespace Avalonia.Controls.Maui.Controls
             SelectionForegroundBrush = Brushes.White;
         }
 
+        /// <inheritdoc/>
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
             base.OnPropertyChanged(change);
@@ -35,6 +39,9 @@ namespace Avalonia.Controls.Maui.Controls
             }
         }
 
+        /// <summary>
+        /// Raises the <see cref="SelectionChanged"/> event.
+        /// </summary>
         public void RaiseSelectionChanged()
         {
             SelectionChanged?.Invoke(this, new Interactivity.RoutedEventArgs());

--- a/src/Avalonia.Controls.Maui/Controls/MauiEntry/MauiEntry.cs
+++ b/src/Avalonia.Controls.Maui/Controls/MauiEntry/MauiEntry.cs
@@ -24,6 +24,9 @@ public class MauiEntry : TextBox
         set => SetValue(ClearButtonVisibilityProperty, value);
     }
 
+    /// <summary>
+    /// Occurs when the text selection changes.
+    /// </summary>
     public event EventHandler<Interactivity.RoutedEventArgs>? SelectionChanged;
 
     /// <summary>
@@ -56,6 +59,7 @@ public class MauiEntry : TextBox
         private set => SetAndRaise(IsClearButtonVisibleProperty, ref _isClearButtonVisible, value);
     }
 
+    /// <inheritdoc/>
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
@@ -82,6 +86,9 @@ public class MauiEntry : TextBox
                                && IsFocused;
     }
 
+    /// <summary>
+    /// Raises the <see cref="SelectionChanged"/> event.
+    /// </summary>
     public void RaiseSelectionChanged()
     {
         SelectionChanged?.Invoke(this, new Interactivity.RoutedEventArgs());

--- a/src/Avalonia.Controls.Maui/Controls/PlaceholderControl.cs
+++ b/src/Avalonia.Controls.Maui/Controls/PlaceholderControl.cs
@@ -11,6 +11,10 @@ public class PlaceholderControl : Border
 {
     private readonly TextBlock _textBlock;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlaceholderControl"/> class.
+    /// </summary>
+    /// <param name="message">The placeholder message to display.</param>
     public PlaceholderControl(string message = "This control is not available")
     {
         _textBlock = new TextBlock
@@ -25,6 +29,9 @@ public class PlaceholderControl : Border
         Child = _textBlock;
     }
 
+    /// <summary>
+    /// Gets or sets the placeholder message text.
+    /// </summary>
     public string Message
     {
         get => _textBlock.Text ?? string.Empty;

--- a/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRingAutomationPeer.cs
+++ b/src/Avalonia.Controls.Maui/Controls/ProgressRing/ProgressRingAutomationPeer.cs
@@ -21,11 +21,14 @@ namespace Avalonia.Controls.Maui
         /// </summary>
         public new ProgressRing Owner => (ProgressRing)base.Owner;
 
+        /// <inheritdoc/>
         protected override string GetClassNameCore() => "ProgressRing";
 
+        /// <inheritdoc/>
         protected override AutomationControlType GetAutomationControlTypeCore() =>
             AutomationControlType.ProgressBar;
 
+        /// <inheritdoc/>
         protected override string GetNameCore()
         {
             var baseName = base.GetNameCore();

--- a/src/Avalonia.Controls.Maui/Controls/SearchBar/MauiSearchBar.cs
+++ b/src/Avalonia.Controls.Maui/Controls/SearchBar/MauiSearchBar.cs
@@ -24,72 +24,95 @@ public partial class MauiSearchBar : TemplatedControl
     private PathIcon? _clearIcon;
     private PathIcon? _searchIcon;
 
+    /// <summary>Defines the <see cref="Text"/> property.</summary>
     public static readonly StyledProperty<string> TextProperty =
         AvaloniaProperty.Register<MauiSearchBar, string>(nameof(Text), defaultValue: string.Empty);
 
+    /// <summary>Defines the <see cref="Placeholder"/> property.</summary>
     public static readonly StyledProperty<string> PlaceholderProperty =
         AvaloniaProperty.Register<MauiSearchBar, string>(nameof(Placeholder), defaultValue: string.Empty);
 
+    /// <summary>Defines the <see cref="PlaceholderForeground"/> property.</summary>
     public static readonly StyledProperty<IBrush?> PlaceholderForegroundProperty =
         AvaloniaProperty.Register<MauiSearchBar, IBrush?>(nameof(PlaceholderForeground));
 
+    /// <summary>Defines the <see cref="CancelButtonColor"/> property.</summary>
     public static readonly StyledProperty<IBrush?> CancelButtonColorProperty =
         AvaloniaProperty.Register<MauiSearchBar, IBrush?>(nameof(CancelButtonColor));
 
+    /// <summary>Defines the <see cref="IsReadOnly"/> property.</summary>
     public static readonly StyledProperty<bool> IsReadOnlyProperty =
         AvaloniaProperty.Register<MauiSearchBar, bool>(nameof(IsReadOnly), defaultValue: false);
 
+    /// <summary>Defines the <see cref="MaxLength"/> property.</summary>
     public static readonly StyledProperty<int> MaxLengthProperty =
         AvaloniaProperty.Register<MauiSearchBar, int>(nameof(MaxLength), defaultValue: 0);
 
+    /// <summary>Defines the <see cref="CharacterSpacing"/> property.</summary>
     public static readonly StyledProperty<double> CharacterSpacingProperty =
         AvaloniaProperty.Register<MauiSearchBar, double>(nameof(CharacterSpacing), defaultValue: 0.0);
 
+    /// <summary>Defines the <see cref="CursorPosition"/> property.</summary>
     public static readonly StyledProperty<int> CursorPositionProperty =
         AvaloniaProperty.Register<MauiSearchBar, int>(nameof(CursorPosition), defaultValue: 0);
 
+    /// <summary>Defines the <see cref="SelectionLength"/> property.</summary>
     public static readonly StyledProperty<int> SelectionLengthProperty =
         AvaloniaProperty.Register<MauiSearchBar, int>(nameof(SelectionLength), defaultValue: 0);
 
+    /// <summary>Defines the <see cref="HorizontalTextAlignment"/> property.</summary>
     public static readonly StyledProperty<AvaloniaTextAlignment> HorizontalTextAlignmentProperty =
         AvaloniaProperty.Register<MauiSearchBar, AvaloniaTextAlignment>(nameof(HorizontalTextAlignment), defaultValue: AvaloniaTextAlignment.Left);
 
+    /// <summary>Defines the <see cref="VerticalContentAlignment"/> property.</summary>
     public static readonly StyledProperty<VerticalAlignment> VerticalContentAlignmentProperty =
         AvaloniaProperty.Register<MauiSearchBar, VerticalAlignment>(nameof(VerticalContentAlignment), defaultValue: VerticalAlignment.Center);
 
+    /// <summary>Defines the <see cref="SearchIconColor"/> property.</summary>
     public static readonly StyledProperty<IBrush?> SearchIconColorProperty =
         AvaloniaProperty.Register<MauiSearchBar, IBrush?>(nameof(SearchIconColor));
 
+    /// <summary>Defines the <see cref="SearchIcon"/> property.</summary>
     public static readonly StyledProperty<object?> SearchIconProperty =
         AvaloniaProperty.Register<MauiSearchBar, object?>(nameof(SearchIcon));
 
+    /// <summary>Defines the <see cref="ClearIcon"/> property.</summary>
     public static readonly StyledProperty<object?> ClearIconProperty =
         AvaloniaProperty.Register<MauiSearchBar, object?>(nameof(ClearIcon));
 
+    /// <summary>Defines the <see cref="ClearCommand"/> property.</summary>
     public static readonly StyledProperty<System.Windows.Input.ICommand?> ClearCommandProperty =
         AvaloniaProperty.Register<MauiSearchBar, System.Windows.Input.ICommand?>(nameof(ClearCommand));
 
+    /// <summary>Defines the <see cref="ClearCommandParameter"/> property.</summary>
     public static readonly StyledProperty<object?> ClearCommandParameterProperty =
         AvaloniaProperty.Register<MauiSearchBar, object?>(nameof(ClearCommandParameter));
 
+    /// <summary>Defines the <see cref="IsClearEnabled"/> property.</summary>
     public static readonly StyledProperty<bool> IsClearEnabledProperty =
         AvaloniaProperty.Register<MauiSearchBar, bool>(nameof(IsClearEnabled), defaultValue: true);
 
+    /// <summary>Defines the <see cref="Keyboard"/> property.</summary>
     public static readonly StyledProperty<Keyboard?> KeyboardProperty =
         AvaloniaProperty.Register<MauiSearchBar, Keyboard?>(nameof(Keyboard));
 
+    /// <summary>Defines the <see cref="SearchBoxVisibility"/> property.</summary>
     public static readonly StyledProperty<SearchBoxVisibility> SearchBoxVisibilityProperty =
         AvaloniaProperty.Register<MauiSearchBar, SearchBoxVisibility>(nameof(SearchBoxVisibility), defaultValue: SearchBoxVisibility.Expanded);
 
+    /// <summary>Defines the <see cref="IsExpanded"/> property.</summary>
     public static readonly StyledProperty<bool> IsExpandedProperty =
         AvaloniaProperty.Register<MauiSearchBar, bool>(nameof(IsExpanded), defaultValue: true);
 
+    /// <summary>Defines the <see cref="QueryIconHelpText"/> property.</summary>
     public static readonly StyledProperty<string?> QueryIconHelpTextProperty =
         AvaloniaProperty.Register<MauiSearchBar, string?>(nameof(QueryIconHelpText));
 
+    /// <summary>Defines the <see cref="ClearIconHelpText"/> property.</summary>
     public static readonly StyledProperty<string?> ClearIconHelpTextProperty =
         AvaloniaProperty.Register<MauiSearchBar, string?>(nameof(ClearIconHelpText));
 
+    /// <summary>Defines the <see cref="ClearPlaceholderHelpText"/> property.</summary>
     public static readonly StyledProperty<string?> ClearPlaceholderHelpTextProperty =
         AvaloniaProperty.Register<MauiSearchBar, string?>(nameof(ClearPlaceholderHelpText));
 
@@ -312,10 +335,11 @@ public partial class MauiSearchBar : TemplatedControl
     /// </summary>
     public event EventHandler<TextChangedEventArgs>? TextChanged;
 
+    /// <inheritdoc/>
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);
-        
+
         if (_textBox != null)
         {
             _textBox.TextChanged -= OnTextBoxTextChanged;
@@ -371,6 +395,7 @@ public partial class MauiSearchBar : TemplatedControl
         // No code-behind assignment needed, local values would override bindings
     }
 
+    /// <inheritdoc/>
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);

--- a/src/Avalonia.Controls.Maui/Controls/Shell/FlyoutContainer.cs
+++ b/src/Avalonia.Controls.Maui/Controls/Shell/FlyoutContainer.cs
@@ -23,28 +23,41 @@ public class FlyoutContainer : Panel
     private double _animTargetX;
     private bool _animShowScrim;
 
+    /// <summary>
+    /// The default width of the flyout panel in device-independent pixels.
+    /// </summary>
     public const double DefaultFlyoutWidth = 320;
+
     internal const double GestureEdgeThreshold = 50.0;
     internal const double GestureVelocityRatio = 1.0 / 3.0;
     internal static readonly TimeSpan DefaultTransitionDuration = TimeSpan.FromMilliseconds(250);
-    
+
+    /// <summary>
+    /// Gets the current detail content control.
+    /// </summary>
     public Control? DetailContent => _detailContent;
-    
+
+    /// <summary>Defines the <see cref="IsFlyoutOpen"/> property.</summary>
     public static readonly StyledProperty<bool> IsFlyoutOpenProperty =
         AvaloniaProperty.Register<FlyoutContainer, bool>(nameof(IsFlyoutOpen), false);
-    
+
+    /// <summary>Defines the <see cref="FlyoutWidth"/> property.</summary>
     public static readonly StyledProperty<double> FlyoutWidthProperty =
         AvaloniaProperty.Register<FlyoutContainer, double>(nameof(FlyoutWidth), DefaultFlyoutWidth);
-    
+
+    /// <summary>Defines the <see cref="FlyoutBehavior"/> property.</summary>
     public static readonly StyledProperty<FlyoutBehavior> FlyoutBehaviorProperty =
         AvaloniaProperty.Register<FlyoutContainer, FlyoutBehavior>(nameof(FlyoutBehavior), FlyoutBehavior.Default);
-    
+
+    /// <summary>Defines the <see cref="FlyoutHeight"/> property.</summary>
     public static readonly StyledProperty<double> FlyoutHeightProperty =
         AvaloniaProperty.Register<FlyoutContainer, double>(nameof(FlyoutHeight), -1);
-    
+
+    /// <summary>Defines the <see cref="FlyoutBackdrop"/> property.</summary>
     public static readonly StyledProperty<IBrush?> FlyoutBackdropProperty =
         AvaloniaProperty.Register<FlyoutContainer, IBrush?>(nameof(FlyoutBackdrop));
-    
+
+    /// <summary>Defines the <see cref="IsGestureEnabled"/> property.</summary>
     public static readonly StyledProperty<bool> IsGestureEnabledProperty =
         AvaloniaProperty.Register<FlyoutContainer, bool>(nameof(IsGestureEnabled), true);
 
@@ -238,6 +251,7 @@ public class FlyoutContainer : Panel
         };
     }
 
+    /// <inheritdoc/>
     protected override Size MeasureOverride(Size availableSize)
     {
         var flyoutWidth = FlyoutWidth;
@@ -271,6 +285,7 @@ public class FlyoutContainer : Panel
         return availableSize;
     }
 
+    /// <inheritdoc/>
     protected override Size ArrangeOverride(Size finalSize)
     {
         var flyoutWidth = FlyoutWidth;

--- a/src/Avalonia.Controls.Maui/Controls/Shell/ShellSearchControl.cs
+++ b/src/Avalonia.Controls.Maui/Controls/Shell/ShellSearchControl.cs
@@ -16,11 +16,17 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Avalonia.Controls.Maui.Handlers.Shell
 {
+    /// <summary>
+    /// An Avalonia content control that wraps a MAUI SearchHandler, providing search bar UI with results overlay.
+    /// </summary>
     public class ShellSearchControl : ContentControl
     {
         private readonly MauiSearchHandler _mauiSearchHandler;
         private readonly IMauiContext _mauiContext;
-        
+
+        /// <summary>
+        /// Gets the underlying MAUI SearchHandler.
+        /// </summary>
         public MauiSearchHandler SearchHandler => _mauiSearchHandler;
 
         private MauiSearchBar? _searchBar;
@@ -29,6 +35,11 @@ namespace Avalonia.Controls.Maui.Handlers.Shell
         private bool _isNavigating;
         private IDisposable? _clickObserver;
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="ShellSearchControl"/> with the specified search handler and MAUI context.
+        /// </summary>
+        /// <param name="mauiSearchHandler">The MAUI search handler to wrap.</param>
+        /// <param name="mauiContext">The MAUI context for service resolution.</param>
         public ShellSearchControl(MauiSearchHandler mauiSearchHandler, IMauiContext mauiContext)
         {
             _mauiSearchHandler = mauiSearchHandler ?? throw new ArgumentNullException(nameof(mauiSearchHandler));
@@ -121,6 +132,7 @@ namespace Avalonia.Controls.Maui.Handlers.Shell
             UpdateHelpText();
         }
 
+        /// <inheritdoc/>
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
             base.OnPropertyChanged(change);
@@ -131,6 +143,7 @@ namespace Avalonia.Controls.Maui.Handlers.Shell
             }
         }
 
+        /// <inheritdoc/>
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
@@ -138,6 +151,9 @@ namespace Avalonia.Controls.Maui.Handlers.Shell
             UpdateShowsResults();
         }
 
+        /// <summary>
+        /// Cleans up event handlers and resources associated with this control.
+        /// </summary>
         public void CleanUp()
         {
              if (_mauiSearchHandler != null)
@@ -678,17 +694,30 @@ namespace Avalonia.Controls.Maui.Handlers.Shell
         }
     }
     
+    /// <summary>
+    /// Wraps a MAUI DataTemplate as an Avalonia IDataTemplate, enabling MAUI templates to be used in Avalonia controls.
+    /// </summary>
     public class MauiDataTemplateWrapper : IDataTemplate
     {
         private readonly DataTemplate _mauiTemplate;
         private readonly IMauiContext _mauiContext;
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="MauiDataTemplateWrapper"/> with the specified MAUI template and context.
+        /// </summary>
+        /// <param name="mauiTemplate">The MAUI data template to wrap.</param>
+        /// <param name="mauiContext">The MAUI context for handler creation.</param>
         public MauiDataTemplateWrapper(DataTemplate mauiTemplate, IMauiContext mauiContext)
         {
             _mauiTemplate = mauiTemplate;
             _mauiContext = mauiContext;
         }
 
+        /// <summary>
+        /// Builds an Avalonia control from the wrapped MAUI data template for the given data object.
+        /// </summary>
+        /// <param name="param">The data object to use as the binding context for the template.</param>
+        /// <returns>An Avalonia control rendered from the MAUI template.</returns>
         public AvaloniaControl Build(object? param)
         {
             var content = _mauiTemplate.CreateContent();
@@ -706,6 +735,11 @@ namespace Avalonia.Controls.Maui.Handlers.Shell
             return new TextBlock { Text = "Template Error" };
         }
 
+        /// <summary>
+        /// Returns whether this template can be applied to the specified data object.
+        /// </summary>
+        /// <param name="data">The data object to check.</param>
+        /// <returns>Always returns <see langword="true"/>.</returns>
         public bool Match(object? data) => true;
 
         private static void DetachFromVisualParent(AvaloniaControl control)

--- a/src/Avalonia.Controls.Maui/Controls/Stepper/Stepper.cs
+++ b/src/Avalonia.Controls.Maui/Controls/Stepper/Stepper.cs
@@ -5,6 +5,9 @@ using Avalonia.Interactivity;
 
 namespace Avalonia.Controls.Maui;
 
+/// <summary>
+/// An Avalonia templated control that implements MAUI's Stepper with increment and decrement buttons.
+/// </summary>
 public class Stepper : TemplatedControl
 {
     private Button? _plusButton;
@@ -50,6 +53,7 @@ public class Stepper : TemplatedControl
     /// </summary>
     public event EventHandler? ValueChanged;
 
+    /// <inheritdoc/>
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);

--- a/src/Avalonia.Controls.Maui/Controls/SwipeView/PanGestureRecognizer.cs
+++ b/src/Avalonia.Controls.Maui/Controls/SwipeView/PanGestureRecognizer.cs
@@ -18,11 +18,20 @@ public class PanGestureRecognizer : GestureRecognizer
     private Visual? _visual;
     private Visual? _parent;
 
+    /// <summary>
+    /// Occurs during the pan gesture lifecycle, including started, running, and completed states.
+    /// </summary>
     public event EventHandler<PanUpdatedEventArgs>? OnPan;
 
+    /// <summary>
+    /// Gets or sets the allowed pan directions for this gesture recognizer.
+    /// </summary>
     public PanDirection Direction { get; set; } =
         PanDirection.Left | PanDirection.Right | PanDirection.Up | PanDirection.Down;
 
+    /// <summary>
+    /// Gets or sets the minimum distance in pixels the pointer must move before the gesture starts.
+    /// </summary>
     public float Threshold { get; set; } = 5;
 
     /// <inheritdoc />

--- a/src/Avalonia.Controls.Maui/Controls/SwipeView/PanGestureStatus.cs
+++ b/src/Avalonia.Controls.Maui/Controls/SwipeView/PanGestureStatus.cs
@@ -5,7 +5,18 @@ namespace Avalonia.Controls.Maui;
 /// </summary>
 public enum PanGestureStatus
 {
+    /// <summary>
+    /// The pan gesture has started.
+    /// </summary>
     Started,
+
+    /// <summary>
+    /// The pan gesture is currently in progress.
+    /// </summary>
     Running,
+
+    /// <summary>
+    /// The pan gesture has completed.
+    /// </summary>
     Completed
 }

--- a/src/Avalonia.Controls.Maui/Controls/SwipeView/PanUpdatedEventArgs.cs
+++ b/src/Avalonia.Controls.Maui/Controls/SwipeView/PanUpdatedEventArgs.cs
@@ -7,6 +7,12 @@ namespace Avalonia.Controls.Maui;
 /// </summary>
 public class PanUpdatedEventArgs : EventArgs
 {
+    /// <summary>
+    /// Initializes a new instance of <see cref="PanUpdatedEventArgs"/> with the specified status, and total X and Y offsets.
+    /// </summary>
+    /// <param name="statusType">The current status of the pan gesture.</param>
+    /// <param name="totalX">The total horizontal distance of the pan gesture.</param>
+    /// <param name="totalY">The total vertical distance of the pan gesture.</param>
     public PanUpdatedEventArgs(PanGestureStatus statusType, double totalX, double totalY)
     {
         StatusType = statusType;
@@ -14,7 +20,18 @@ public class PanUpdatedEventArgs : EventArgs
         TotalY = totalY;
     }
 
+    /// <summary>
+    /// Gets or sets the current status of the pan gesture.
+    /// </summary>
     public PanGestureStatus StatusType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total horizontal distance of the pan gesture.
+    /// </summary>
     public double TotalX { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total vertical distance of the pan gesture.
+    /// </summary>
     public double TotalY { get; set; }
 }

--- a/src/Avalonia.Controls.Maui/Controls/SwipeView/SwipeEventArgs.cs
+++ b/src/Avalonia.Controls.Maui/Controls/SwipeView/SwipeEventArgs.cs
@@ -17,11 +17,20 @@ public class OpenRequestedEventArgs : RoutedEventArgs
     /// </summary>
     public bool Cancel { get; set; }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="OpenRequestedEventArgs"/> with the specified swipe direction.
+    /// </summary>
+    /// <param name="openSwipeItem">The direction in which the swipe is being opened.</param>
     public OpenRequestedEventArgs(OpenSwipeItem openSwipeItem)
     {
         OpenSwipeItem = openSwipeItem;
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="OpenRequestedEventArgs"/> with the specified routed event and swipe direction.
+    /// </summary>
+    /// <param name="routedEvent">The routed event associated with this event args.</param>
+    /// <param name="openSwipeItem">The direction in which the swipe is being opened.</param>
     public OpenRequestedEventArgs(RoutedEvent? routedEvent, OpenSwipeItem openSwipeItem) : base(routedEvent)
     {
         OpenSwipeItem = openSwipeItem;
@@ -38,10 +47,17 @@ public class CloseRequestedEventArgs : RoutedEventArgs
     /// </summary>
     public bool Cancel { get; set; }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="CloseRequestedEventArgs"/>.
+    /// </summary>
     public CloseRequestedEventArgs()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="CloseRequestedEventArgs"/> with the specified routed event.
+    /// </summary>
+    /// <param name="routedEvent">The routed event associated with this event args.</param>
     public CloseRequestedEventArgs(RoutedEvent? routedEvent) : base(routedEvent)
     {
     }
@@ -57,11 +73,20 @@ public class SwipeStartedEventArgs : RoutedEventArgs
     /// </summary>
     public SwipeDirection SwipeDirection { get; }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="SwipeStartedEventArgs"/> with the specified swipe direction.
+    /// </summary>
+    /// <param name="swipeDirection">The direction of the swipe gesture.</param>
     public SwipeStartedEventArgs(SwipeDirection swipeDirection)
     {
         SwipeDirection = swipeDirection;
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="SwipeStartedEventArgs"/> with the specified routed event and swipe direction.
+    /// </summary>
+    /// <param name="routedEvent">The routed event associated with this event args.</param>
+    /// <param name="swipeDirection">The direction of the swipe gesture.</param>
     public SwipeStartedEventArgs(RoutedEvent? routedEvent, SwipeDirection swipeDirection) : base(routedEvent)
     {
         SwipeDirection = swipeDirection;
@@ -83,6 +108,11 @@ public class SwipeChangingEventArgs : EventArgs
     /// </summary>
     public double Offset { get; set; }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="SwipeChangingEventArgs"/> with the specified direction and offset.
+    /// </summary>
+    /// <param name="swipeDirection">The direction of the swipe gesture.</param>
+    /// <param name="offset">The current offset of the swipe in pixels.</param>
     public SwipeChangingEventArgs(SwipeDirection swipeDirection, double offset)
     {
         SwipeDirection = swipeDirection;
@@ -105,12 +135,23 @@ public class SwipeEndedEventArgs : RoutedEventArgs
     /// </summary>
     public bool IsOpen { get; }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="SwipeEndedEventArgs"/> with the specified direction and open state.
+    /// </summary>
+    /// <param name="swipeDirection">The direction of the swipe gesture.</param>
+    /// <param name="isOpen">Whether the swipe items remain visible after the gesture completes.</param>
     public SwipeEndedEventArgs(SwipeDirection swipeDirection, bool isOpen)
     {
         SwipeDirection = swipeDirection;
         IsOpen = isOpen;
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="SwipeEndedEventArgs"/> with the specified routed event, direction, and open state.
+    /// </summary>
+    /// <param name="routedEvent">The routed event associated with this event args.</param>
+    /// <param name="swipeDirection">The direction of the swipe gesture.</param>
+    /// <param name="isOpen">Whether the swipe items remain visible after the gesture completes.</param>
     public SwipeEndedEventArgs(RoutedEvent? routedEvent, SwipeDirection swipeDirection, bool isOpen) : base(routedEvent)
     {
         SwipeDirection = swipeDirection;

--- a/src/Avalonia.Controls.Maui/Extensions/ColorExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/ColorExtensions.cs
@@ -2,8 +2,16 @@ using Avalonia.Media;
 
 namespace Avalonia.Controls.Maui.Extensions;
 
+/// <summary>
+/// Provides extension methods for converting .NET MAUI <see cref="Microsoft.Maui.Graphics.Color"/> values to Avalonia color and brush types.
+/// </summary>
 public static class ColorExtensions
 {
+    /// <summary>
+    /// Converts a nullable .NET MAUI <see cref="Microsoft.Maui.Graphics.Color"/> to an Avalonia <see cref="IBrush"/>.
+    /// </summary>
+    /// <param name="color">The .NET MAUI color to convert, or <c>null</c>.</param>
+    /// <returns>A <see cref="SolidColorBrush"/> representing the color, or <c>null</c> if the input is <c>null</c>.</returns>
     public static IBrush? ToAvaloniaBrush(this Microsoft.Maui.Graphics.Color? color)
     {
         if (color == null)
@@ -12,6 +20,11 @@ public static class ColorExtensions
         return new SolidColorBrush(color.ToAvaloniaColor());
     }
 
+    /// <summary>
+    /// Converts a .NET MAUI <see cref="Microsoft.Maui.Graphics.Color"/> to an Avalonia <see cref="Color"/> struct.
+    /// </summary>
+    /// <param name="color">The .NET MAUI color to convert.</param>
+    /// <returns>An Avalonia <see cref="Color"/> with equivalent ARGB values.</returns>
     public static Color ToAvaloniaColor(this Microsoft.Maui.Graphics.Color color)
     {
         return Color.FromArgb(

--- a/src/Avalonia.Controls.Maui/Extensions/ElementExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/ElementExtensions.cs
@@ -41,6 +41,14 @@ public static class ElementExtensions
         return (IElementHandler)ActivatorUtilities.CreateInstance(mauiContext.Services, handlerType);
     }
 
+    /// <summary>
+    /// Creates or retrieves the <see cref="IElementHandler"/> for a .NET MAUI <see cref="IElement"/> using the specified <see cref="IMauiContext"/>.
+    /// </summary>
+    /// <param name="view">The .NET MAUI element to get a handler for.</param>
+    /// <param name="context">The MAUI context used for handler resolution and dependency injection.</param>
+    /// <returns>The <see cref="IElementHandler"/> associated with the element.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="view"/> or <paramref name="context"/> is <c>null</c>.</exception>
+    /// <exception cref="HandlerNotFoundException">Thrown when no handler is registered for the element type.</exception>
     public static IElementHandler ToHandler(this IElement view, IMauiContext context)
     {
         if (view == null)
@@ -96,6 +104,12 @@ public static class ElementExtensions
         return elementHandler;
     }
 
+    /// <summary>
+    /// Gets the platform view for a .NET MAUI <see cref="IElement"/> whose handler has already been set.
+    /// </summary>
+    /// <param name="view">The .NET MAUI element to get the platform view for.</param>
+    /// <returns>The platform view object (typically an Avalonia control).</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the element's handler or platform view is not set.</exception>
     public static object ToPlatform(this IElement view)
     {
         if (view is IReplaceableView replaceableView && replaceableView.ReplacedView != view)
@@ -126,6 +140,13 @@ public static class ElementExtensions
         return view.Handler?.PlatformView ?? throw new InvalidOperationException($"Unable to convert {view} to {typeof(object)}");
     }
 
+    /// <summary>
+    /// Creates a handler for a .NET MAUI <see cref="IElement"/> using the specified <see cref="IMauiContext"/> and returns its platform view.
+    /// </summary>
+    /// <param name="view">The .NET MAUI element to convert to a platform view.</param>
+    /// <param name="context">The MAUI context used for handler resolution.</param>
+    /// <returns>The platform view object (typically an Avalonia control).</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the platform view cannot be obtained.</exception>
     public static object ToPlatform(this IElement view, IMauiContext context)
     {
         IElementHandler elementHandler = view.ToHandler(context);
@@ -179,16 +200,35 @@ public static class ElementExtensions
         }
     }
 
+    /// <summary>
+    /// Connects a .NET MAUI <see cref="IApplication"/> to its handler using the specified platform object and context.
+    /// </summary>
+    /// <param name="platformApplication">The platform application object.</param>
+    /// <param name="application">The .NET MAUI application to associate with its handler.</param>
+    /// <param name="context">The MAUI context for handler resolution.</param>
     public static void SetApplicationHandler(this object platformApplication, IApplication application, IMauiContext context)
     {
         platformApplication.SetHandler(application, context);
     }
 
+    /// <summary>
+    /// Connects a .NET MAUI <see cref="IWindow"/> to its handler using the specified platform object and context.
+    /// </summary>
+    /// <param name="platformWindow">The platform window object.</param>
+    /// <param name="window">The .NET MAUI window to associate with its handler.</param>
+    /// <param name="context">The MAUI context for handler resolution.</param>
     public static void SetWindowHandler(this object platformWindow, IWindow window, IMauiContext context)
     {
         platformWindow.SetHandler(window, context);
     }
 
+    /// <summary>
+    /// Walks the parent chain of a .NET MAUI <see cref="IElement"/> to find the first ancestor of the specified type.
+    /// </summary>
+    /// <typeparam name="T">The type of parent element to search for.</typeparam>
+    /// <param name="element">The element whose parent chain to search.</param>
+    /// <param name="includeThis">If <c>true</c>, includes the element itself in the search.</param>
+    /// <returns>The first ancestor of type <typeparamref name="T"/>, or <c>default</c> if none is found.</returns>
     public static T? FindParentOfType<T>(this IElement element, bool includeThis = false) where T : IElement
     {
         if (includeThis && element is T)

--- a/src/Avalonia.Controls.Maui/Extensions/FontExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/FontExtensions.cs
@@ -1,7 +1,15 @@
 namespace Avalonia.Controls.Maui;
 
+/// <summary>
+/// Provides extension methods for converting .NET MAUI font types to their Avalonia equivalents.
+/// </summary>
 public static class FontExtensions
 {
+    /// <summary>
+    /// Converts a .NET MAUI <see cref="Microsoft.Maui.FontWeight"/> to an Avalonia <see cref="Avalonia.Media.FontWeight"/>.
+    /// </summary>
+    /// <param name="weight">The .NET MAUI font weight to convert.</param>
+    /// <returns>The corresponding Avalonia <see cref="Avalonia.Media.FontWeight"/> value.</returns>
     public static Avalonia.Media.FontWeight ToAvalonia(this Microsoft.Maui.FontWeight weight) => weight switch
     {
         Microsoft.Maui.FontWeight.Thin => Avalonia.Media.FontWeight.Thin,
@@ -12,6 +20,11 @@ public static class FontExtensions
         _ => Avalonia.Media.FontWeight.Normal
     };
 
+    /// <summary>
+    /// Converts .NET MAUI <see cref="Microsoft.Maui.Controls.FontAttributes"/> to an Avalonia <see cref="Avalonia.Media.FontStyle"/>.
+    /// </summary>
+    /// <param name="fontAttributes">The .NET MAUI font attributes to convert.</param>
+    /// <returns><see cref="Avalonia.Media.FontStyle.Italic"/> if the italic flag is set; otherwise, <see cref="Avalonia.Media.FontStyle.Normal"/>.</returns>
     public static global::Avalonia.Media.FontStyle ToPlatformFontStyle(this Microsoft.Maui.Controls.FontAttributes fontAttributes)
     {
         if (fontAttributes.HasFlag(Microsoft.Maui.Controls.FontAttributes.Italic))

--- a/src/Avalonia.Controls.Maui/Extensions/GraphicsExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/GraphicsExtensions.cs
@@ -20,13 +20,26 @@ using MauiControlsLinearGradientBrush = Microsoft.Maui.Controls.LinearGradientBr
 using MauiControlsRadialGradientBrush = Microsoft.Maui.Controls.RadialGradientBrush;
 namespace Avalonia.Controls.Maui;
 
+/// <summary>
+/// Provides extension methods for converting .NET MAUI graphics types to their Avalonia equivalents.
+/// </summary>
 public static class GraphicsExtensions
 {
+    /// <summary>
+    /// Converts a .NET MAUI <see cref="MauiColor"/> to an Avalonia <see cref="AvaloniaSolidColorBrush"/>.
+    /// </summary>
+    /// <param name="color">The .NET MAUI color to convert.</param>
+    /// <returns>A <see cref="AvaloniaSolidColorBrush"/> representing the color.</returns>
     public static AvaloniaSolidColorBrush ToPlatform(this MauiColor color)
     {
         return new AvaloniaSolidColorBrush(color.ToAvaloniaColor());
     }
 
+    /// <summary>
+    /// Converts a .NET MAUI <see cref="MauiColor"/> to an Avalonia <see cref="AvaloniaColor"/> struct.
+    /// </summary>
+    /// <param name="color">The .NET MAUI color to convert.</param>
+    /// <returns>An <see cref="AvaloniaColor"/> with equivalent ARGB channel values.</returns>
     public static AvaloniaColor ToAvaloniaColor(this MauiColor color)
     {
         return AvaloniaColor.FromArgb(
@@ -36,6 +49,11 @@ public static class GraphicsExtensions
             (byte)(color.Blue * 255));
     }
 
+    /// <summary>
+    /// Converts a nullable .NET MAUI <see cref="MauiPaint"/> to an Avalonia <see cref="AvaloniaIBrush"/>, supporting solid, linear gradient, and radial gradient paints.
+    /// </summary>
+    /// <param name="paint">The .NET MAUI paint to convert, or <c>null</c>.</param>
+    /// <returns>An Avalonia brush representing the paint, or <c>null</c> if the paint is <c>null</c> or not a supported type.</returns>
     public static AvaloniaIBrush? ToPlatform(this MauiPaint? paint)
     {
         if (paint is MauiSolidPaint solidPaint && solidPaint.Color != null)
@@ -56,6 +74,11 @@ public static class GraphicsExtensions
         return null;
     }
 
+    /// <summary>
+    /// Converts a .NET MAUI <see cref="MauiLineCap"/> to an Avalonia <see cref="AvaloniaPenLineCap"/>.
+    /// </summary>
+    /// <param name="lineCap">The .NET MAUI line cap to convert.</param>
+    /// <returns>The corresponding Avalonia <see cref="AvaloniaPenLineCap"/> value.</returns>
     public static AvaloniaPenLineCap ToPlatform(this MauiLineCap lineCap)
     {
         return lineCap switch
@@ -67,6 +90,11 @@ public static class GraphicsExtensions
         };
     }
 
+    /// <summary>
+    /// Converts a .NET MAUI <see cref="MauiLineJoin"/> to an Avalonia <see cref="AvaloniaPenLineJoin"/>.
+    /// </summary>
+    /// <param name="lineJoin">The .NET MAUI line join to convert.</param>
+    /// <returns>The corresponding Avalonia <see cref="AvaloniaPenLineJoin"/> value.</returns>
     public static AvaloniaPenLineJoin ToPlatform(this MauiLineJoin lineJoin)
     {
         return lineJoin switch
@@ -78,6 +106,11 @@ public static class GraphicsExtensions
         };
     }
 
+    /// <summary>
+    /// Converts a nullable .NET MAUI Controls <see cref="MauiControlsBrush"/> to an Avalonia <see cref="AvaloniaIBrush"/>, supporting solid color, linear gradient, and radial gradient brushes.
+    /// </summary>
+    /// <param name="brush">The .NET MAUI Controls brush to convert, or <c>null</c>.</param>
+    /// <returns>An Avalonia brush representing the MAUI brush, or <c>null</c> if the brush is <c>null</c>, empty, or not a supported type.</returns>
     public static AvaloniaIBrush? ToPlatform(this MauiControlsBrush? brush)
     {
         if (brush == null || brush.IsEmpty)

--- a/src/Avalonia.Controls.Maui/Extensions/LayoutExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/LayoutExtensions.cs
@@ -5,8 +5,16 @@ using AvaloniaVerticalAlignment = Avalonia.Layout.VerticalAlignment;
 
 namespace Avalonia.Controls.Maui;
 
+/// <summary>
+/// Provides extension methods for converting .NET MAUI layout alignment enums to Avalonia alignment types.
+/// </summary>
 public static class LayoutExtensions
 {
+    /// <summary>
+    /// Converts a .NET MAUI <see cref="LayoutAlignment"/> to an Avalonia <see cref="AvaloniaHorizontalAlignment"/>.
+    /// </summary>
+    /// <param name="alignment">The .NET MAUI layout alignment to convert.</param>
+    /// <returns>The corresponding Avalonia <see cref="AvaloniaHorizontalAlignment"/> value.</returns>
     public static AvaloniaHorizontalAlignment ToAvaloniaHorizontalAlignment(this LayoutAlignment alignment)
     {
         return alignment switch
@@ -19,6 +27,11 @@ public static class LayoutExtensions
         };
     }
 
+    /// <summary>
+    /// Converts a .NET MAUI <see cref="LayoutAlignment"/> to an Avalonia <see cref="AvaloniaVerticalAlignment"/>.
+    /// </summary>
+    /// <param name="alignment">The .NET MAUI layout alignment to convert.</param>
+    /// <returns>The corresponding Avalonia <see cref="AvaloniaVerticalAlignment"/> value.</returns>
     public static AvaloniaVerticalAlignment ToAvaloniaVerticalAlignment(this LayoutAlignment alignment)
     {
         return alignment switch

--- a/src/Avalonia.Controls.Maui/Extensions/MauiAppBuilderExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/MauiAppBuilderExtensions.cs
@@ -8,6 +8,9 @@ using Microsoft.Maui;
 using Microsoft.Maui.Animations;
 using Microsoft.Maui.Hosting;
 
+/// <summary>
+/// Provides extension methods for configuring Avalonia services and handlers in a .NET MAUI application.
+/// </summary>
 public static class MauiAppBuilderExtensions
 {
     /// <summary>
@@ -26,6 +29,11 @@ public static class MauiAppBuilderExtensions
         return builder;
     }
 
+    /// <summary>
+    /// Configures Avalonia-specific services for MAUI image handling using a custom registration delegate.
+    /// </summary>
+    /// <param name="builder">The <see cref="MauiAppBuilder"/> to configure.</param>
+    /// <param name="configureDelegate">An optional delegate to register custom <see cref="IImageSourceService"/> implementations.</param>
     public static MauiAppBuilder ConfigureImageSources(this MauiAppBuilder builder, Action<IImageSourceServiceCollection>? configureDelegate)
     {
         if (configureDelegate != null)

--- a/src/Avalonia.Controls.Maui/Extensions/PaintExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/PaintExtensions.cs
@@ -3,8 +3,17 @@ using Microsoft.Maui.Graphics;
 
 namespace Avalonia.Controls.Maui.Extensions;
 
+/// <summary>
+/// Provides extension methods for converting .NET MAUI <see cref="Paint"/> types to Avalonia brush types.
+/// </summary>
 public static class PaintExtensions
 {
+    /// <summary>
+    /// Converts a .NET MAUI <see cref="Paint"/> to an Avalonia <see cref="global::Avalonia.Media.IBrush"/>, supporting
+    /// <see cref="SolidPaint"/>, <see cref="LinearGradientPaint"/>, and <see cref="RadialGradientPaint"/>.
+    /// </summary>
+    /// <param name="paint">The .NET MAUI paint to convert.</param>
+    /// <returns>An Avalonia brush representing the paint, or <c>null</c> if the paint type is not supported or the input is <c>null</c>.</returns>
     public static global::Avalonia.Media.IBrush ToAvaloniaBrush(this Paint paint)
     {
         if (paint is null)

--- a/src/Avalonia.Controls.Maui/Extensions/ShellItemExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/ShellItemExtensions.cs
@@ -19,6 +19,9 @@ namespace Avalonia.Controls.Maui.Extensions;
 /// </summary>
 public static class ShellItemExtensions
 {
+    /// <summary>
+    /// Updates the tab items for the shell item.
+    /// </summary>
     /// <param name="handler">The <see cref="ShellItemHandler"/> instance.</param>
     /// <param name="item">The <see cref="ShellItem"/> instance to update from.</param>
     public static void UpdateTabs(this ShellItemHandler handler, ShellItem item)
@@ -184,6 +187,9 @@ public static class ShellItemExtensions
         }
     }
 
+    /// <summary>
+    /// Updates the currently displayed shell section content.
+    /// </summary>
     /// <param name="handler">The <see cref="ShellItemHandler"/> instance.</param>
     /// <param name="item">The <see cref="ShellItem"/> instance to update from.</param>
     public static void UpdateCurrentItem(this ShellItemHandler handler, ShellItem item)
@@ -234,6 +240,9 @@ public static class ShellItemExtensions
         }
     }
 
+    /// <summary>
+    /// Updates tab bar visibility based on the current page's TabBarIsVisible property.
+    /// </summary>
     /// <param name="handler">The <see cref="ShellItemHandler"/> instance.</param>
     /// <param name="item">The <see cref="ShellItem"/> instance to update from.</param>
     public static void UpdateTabBarVisibility(this ShellItemHandler handler, ShellItem item)
@@ -254,6 +263,9 @@ public static class ShellItemExtensions
             handler._tabControl.Classes.Add("hide-tabstrip");
     }
 
+    /// <summary>
+    /// Updates tab bar appearance colors from shell properties.
+    /// </summary>
     /// <param name="handler">The <see cref="ShellItemHandler"/> instance.</param>
     /// <param name="item">The <see cref="ShellItem"/> instance to update from.</param>
     public static void UpdateTabAppearance(this ShellItemHandler handler, ShellItem item)
@@ -262,6 +274,9 @@ public static class ShellItemExtensions
         handler.UpdateTabAppearanceInternal(item);
     }
 
+    /// <summary>
+    /// Updates the tab bar background color.
+    /// </summary>
     /// <param name="handler">The <see cref="ShellItemHandler"/> instance.</param>
     /// <param name="item">The <see cref="ShellItem"/> instance to update from.</param>
     public static void UpdateTabBarBackgroundColor(this ShellItemHandler handler, ShellItem item)
@@ -282,21 +297,41 @@ public static class ShellItemExtensions
             handler._tabControl.ClearValue(TabControl.BackgroundProperty);
     }
 
+    /// <summary>
+    /// Updates the tab bar foreground color by re-applying the full tab appearance.
+    /// </summary>
+    /// <param name="handler">The <see cref="ShellItemHandler"/> instance.</param>
+    /// <param name="item">The <see cref="ShellItem"/> instance to update from.</param>
     public static void UpdateTabBarForegroundColor(this ShellItemHandler handler, ShellItem item)
     {
         handler.UpdateTabAppearance(item);
     }
 
+    /// <summary>
+    /// Updates the tab bar title color by re-applying the full tab appearance.
+    /// </summary>
+    /// <param name="handler">The <see cref="ShellItemHandler"/> instance.</param>
+    /// <param name="item">The <see cref="ShellItem"/> instance to update from.</param>
     public static void UpdateTabBarTitleColor(this ShellItemHandler handler, ShellItem item)
     {
         handler.UpdateTabAppearance(item);
     }
 
+    /// <summary>
+    /// Updates the tab bar unselected item color by re-applying the full tab appearance.
+    /// </summary>
+    /// <param name="handler">The <see cref="ShellItemHandler"/> instance.</param>
+    /// <param name="item">The <see cref="ShellItem"/> instance to update from.</param>
     public static void UpdateTabBarUnselectedColor(this ShellItemHandler handler, ShellItem item)
     {
         handler.UpdateTabAppearance(item);
     }
 
+    /// <summary>
+    /// Updates the tab bar disabled item color by re-applying the full tab appearance.
+    /// </summary>
+    /// <param name="handler">The <see cref="ShellItemHandler"/> instance.</param>
+    /// <param name="item">The <see cref="ShellItem"/> instance to update from.</param>
     public static void UpdateTabBarDisabledColor(this ShellItemHandler handler, ShellItem item)
     {
         handler.UpdateTabAppearance(item);

--- a/src/Avalonia.Controls.Maui/Extensions/WindowExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/WindowExtensions.cs
@@ -3,11 +3,24 @@ using Microsoft.Maui;
 
 namespace Avalonia.Controls.Maui;
 
+/// <summary>
+/// Provides extension methods for integrating Avalonia <see cref="Avalonia.Controls.Window"/> with .NET MAUI <see cref="IWindow"/>.
+/// </summary>
 public static class WindowExtensions
 {
+    /// <summary>
+    /// Updates the title of an Avalonia <see cref="Avalonia.Controls.Window"/> from the associated .NET MAUI <see cref="IWindow"/>.
+    /// </summary>
+    /// <param name="platformWindow">The Avalonia window to update.</param>
+    /// <param name="window">The .NET MAUI window providing the title.</param>
     public static void UpdateTitle(this Avalonia.Controls.Window platformWindow, IWindow window) =>
         platformWindow.Title = window.Title;
 
+    /// <summary>
+    /// Finds the .NET MAUI <see cref="IWindow"/> associated with the specified Avalonia <see cref="Avalonia.Controls.Window"/>.
+    /// </summary>
+    /// <param name="platformWindow">The Avalonia window to look up.</param>
+    /// <returns>The associated <see cref="IWindow"/>, or <c>null</c> if no match is found.</returns>
     public static IWindow? GetWindow(this Avalonia.Controls.Window platformWindow)
     {
         foreach (var window in MauiAvaloniaApplication.Current.Application.Windows)

--- a/src/Avalonia.Controls.Maui/Fonts/FontManager.cs
+++ b/src/Avalonia.Controls.Maui/Fonts/FontManager.cs
@@ -4,6 +4,9 @@ using Microsoft.Extensions.Logging;
 
 namespace Avalonia.Controls.Maui;
 
+/// <summary>
+/// Manages font resolution and conversion between MAUI and Avalonia font systems.
+/// </summary>
 public partial class FontManager : IFontManager
 {
     private readonly ConcurrentDictionary<string, global::Avalonia.Media.FontFamily> _fontFamilies = new();

--- a/src/Avalonia.Controls.Maui/Handlers/ActivityIndicatorHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ActivityIndicatorHandler.cs
@@ -4,30 +4,40 @@ using PlatformView = Avalonia.Controls.Maui.ProgressRing;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IActivityIndicator"/>.</summary>
 public partial class ActivityIndicatorHandler : ViewHandler<IActivityIndicator, ProgressRing>
 {
+    /// <summary>Property mapper for <see cref="ActivityIndicatorHandler"/>.</summary>
     public static IPropertyMapper<IActivityIndicator, ActivityIndicatorHandler> Mapper = new PropertyMapper<IActivityIndicator, ActivityIndicatorHandler>(ViewHandler.ViewMapper)
     {
         [nameof(IActivityIndicator.Color)] = MapColor,
         [nameof(IActivityIndicator.IsRunning)] = MapIsRunning,
     };
 
+    /// <summary>Command mapper for <see cref="ActivityIndicatorHandler"/>.</summary>
     public static CommandMapper<IActivityIndicator, ActivityIndicatorHandler> CommandMapper = new(ViewCommandMapper);
 
+    /// <summary>Initializes a new instance of <see cref="ActivityIndicatorHandler"/>.</summary>
     public ActivityIndicatorHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="ActivityIndicatorHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public ActivityIndicatorHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="ActivityIndicatorHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public ActivityIndicatorHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override ProgressRing CreatePlatformView()
     {
         return new ProgressRing
@@ -36,6 +46,9 @@ public partial class ActivityIndicatorHandler : ViewHandler<IActivityIndicator, 
         };
     }
 
+    /// <summary>Maps the IsRunning property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="activityIndicator">The virtual view.</param>
     public static void MapIsRunning(ActivityIndicatorHandler handler, IActivityIndicator activityIndicator)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -44,6 +57,9 @@ public partial class ActivityIndicatorHandler : ViewHandler<IActivityIndicator, 
         }
     }
 
+    /// <summary>Maps the Color property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="activityIndicator">The virtual view.</param>
     public static void MapColor(ActivityIndicatorHandler handler, IActivityIndicator activityIndicator)
     {
         if (handler.PlatformView is PlatformView platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/ApplicationHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ApplicationHandler.cs
@@ -10,15 +10,27 @@ using Microsoft.Maui.Platform;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>
+/// Avalonia handler for <see cref="IApplication"/>.
+/// </summary>
 public partial class ApplicationHandler : ElementHandler<IApplication, Application>
 {
+    /// <summary>
+    /// The command key used to terminate the application.
+    /// </summary>
     public const string TerminateCommandKey = "Terminate";
 
+    /// <summary>
+    /// Property mapper for <see cref="ApplicationHandler"/>.
+    /// </summary>
     public static IPropertyMapper<IApplication, ApplicationHandler> Mapper = new PropertyMapper<IApplication, ApplicationHandler>(ElementMapper)
     {
         [nameof(IApplication.UserAppTheme)] = MapUserAppTheme,
     };
 
+    /// <summary>
+    /// Command mapper for <see cref="ApplicationHandler"/>.
+    /// </summary>
     public static CommandMapper<IApplication, ApplicationHandler> CommandMapper = new(ElementCommandMapper)
     {
         [TerminateCommandKey] = MapTerminate,
@@ -29,24 +41,43 @@ public partial class ApplicationHandler : ElementHandler<IApplication, Applicati
 
     ILogger<ApplicationHandler>? _logger;
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="ApplicationHandler"/>.
+    /// </summary>
     public ApplicationHandler()
         : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="ApplicationHandler"/>.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
     public ApplicationHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="ApplicationHandler"/>.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
+    /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
     public ApplicationHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Gets the logger instance for this handler.
+    /// </summary>
     ILogger? Logger =>
         _logger ??= MauiContext?.Services?.GetService<ILoggerFactory>()?.CreateLogger<ApplicationHandler>();
 
+    /// <summary>
+    /// Creates the Avalonia <see cref="Application"/> platform element for this handler.
+    /// </summary>
+    /// <returns>The Avalonia <see cref="Application"/> instance from the service provider.</returns>
     protected override Application CreatePlatformElement() =>
         MauiContext?.Services?.GetService<Application>() ?? throw new InvalidOperationException($"MauiContext did not have a valid application.");
 

--- a/src/Avalonia.Controls.Maui/Handlers/BorderHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/BorderHandler.cs
@@ -4,8 +4,10 @@ using PlatformView = Avalonia.Controls.Maui.MauiBorder;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IBorderView"/>.</summary>
 public class BorderHandler : ViewHandler<IBorderView, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="BorderHandler"/>.</summary>
     public static IPropertyMapper<IBorderView, BorderHandler> Mapper =
         new PropertyMapper<IBorderView, BorderHandler>(ViewMapper)
         {
@@ -22,28 +24,39 @@ public class BorderHandler : ViewHandler<IBorderView, PlatformView>
             [nameof(IPadding.Padding)] = MapPadding,
         };
 
+    /// <summary>Command mapper for <see cref="BorderHandler"/>.</summary>
     public static CommandMapper<IBorderView, BorderHandler> CommandMapper =
         new(ViewCommandMapper);
 
+    /// <summary>Initializes a new instance of <see cref="BorderHandler"/>.</summary>
     public BorderHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="BorderHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public BorderHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="BorderHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public BorderHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <summary>Maps the Content property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="border">The virtual view.</param>
     public static void MapContent(BorderHandler handler, IBorderView border)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -52,6 +65,9 @@ public class BorderHandler : ViewHandler<IBorderView, PlatformView>
         platformView.UpdateContent(border, handler.MauiContext);
     }
 
+    /// <summary>Maps the Background property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="border">The virtual view.</param>
     public static void MapBackground(BorderHandler handler, IBorderView border)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -60,6 +76,9 @@ public class BorderHandler : ViewHandler<IBorderView, PlatformView>
         platformView.UpdateBackground(border);
     }
 
+    /// <summary>Maps the Stroke property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="border">The virtual view.</param>
     public static void MapStroke(BorderHandler handler, IBorderView border)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -68,6 +87,9 @@ public class BorderHandler : ViewHandler<IBorderView, PlatformView>
         platformView.UpdateStroke(border);
     }
 
+    /// <summary>Maps the StrokeThickness property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="border">The virtual view.</param>
     public static void MapStrokeThickness(BorderHandler handler, IBorderView border)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -76,6 +98,9 @@ public class BorderHandler : ViewHandler<IBorderView, PlatformView>
         platformView.UpdateStrokeThickness(border);
     }
 
+    /// <summary>Maps the StrokeShape property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="border">The virtual view.</param>
     public static void MapStrokeShape(BorderHandler handler, IBorderView border)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -84,6 +109,9 @@ public class BorderHandler : ViewHandler<IBorderView, PlatformView>
         platformView.UpdateStrokeShape(border);
     }
 
+    /// <summary>Maps the StrokeDashPattern property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="border">The virtual view.</param>
     public static void MapStrokeDashPattern(BorderHandler handler, IBorderView border)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -92,6 +120,9 @@ public class BorderHandler : ViewHandler<IBorderView, PlatformView>
         platformView.UpdateStrokeDashPattern(border);
     }
 
+    /// <summary>Maps the StrokeDashOffset property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="border">The virtual view.</param>
     public static void MapStrokeDashOffset(BorderHandler handler, IBorderView border)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -100,6 +131,9 @@ public class BorderHandler : ViewHandler<IBorderView, PlatformView>
         platformView.UpdateStrokeDashOffset(border);
     }
 
+    /// <summary>Maps the StrokeLineCap property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="border">The virtual view.</param>
     public static void MapStrokeLineCap(BorderHandler handler, IBorderView border)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -108,6 +142,9 @@ public class BorderHandler : ViewHandler<IBorderView, PlatformView>
         platformView.UpdateStrokeLineCap(border);
     }
 
+    /// <summary>Maps the StrokeLineJoin property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="border">The virtual view.</param>
     public static void MapStrokeLineJoin(BorderHandler handler, IBorderView border)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -116,6 +153,9 @@ public class BorderHandler : ViewHandler<IBorderView, PlatformView>
         platformView.UpdateStrokeLineJoin(border);
     }
 
+    /// <summary>Maps the StrokeMiterLimit property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="border">The virtual view.</param>
     public static void MapStrokeMiterLimit(BorderHandler handler, IBorderView border)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -124,6 +164,9 @@ public class BorderHandler : ViewHandler<IBorderView, PlatformView>
         platformView.UpdateStrokeMiterLimit(border);
     }
 
+    /// <summary>Maps the Padding property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="border">The virtual view.</param>
     public static void MapPadding(BorderHandler handler, IBorderView border)
     {
         if (handler.PlatformView is not PlatformView platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/BoxViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/BoxViewHandler.cs
@@ -4,35 +4,48 @@ using Microsoft.Maui.Controls;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="BoxView"/>.</summary>
 public class BoxViewHandler : ViewHandler<BoxView, Border>
 {
+    /// <summary>Property mapper for <see cref="BoxViewHandler"/>.</summary>
     public static IPropertyMapper<BoxView, BoxViewHandler> Mapper = new PropertyMapper<BoxView, BoxViewHandler>(ViewHandler.ViewMapper)
     {
         [nameof(BoxView.Color)] = MapColor,
         [nameof(BoxView.CornerRadius)] = MapCornerRadius,
     };
     
+    /// <summary>Command mapper for <see cref="BoxViewHandler"/>.</summary>
     public static CommandMapper<BoxView, BoxViewHandler> CommandMapper = new(ViewCommandMapper);
-    
+
+    /// <summary>Initializes a new instance of <see cref="BoxViewHandler"/>.</summary>
     public BoxViewHandler() : base(Mapper, CommandMapper)
     {
     }
-    
+
+    /// <summary>Initializes a new instance of <see cref="BoxViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public BoxViewHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
-    
+
+    /// <summary>Initializes a new instance of <see cref="BoxViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public BoxViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override Border CreatePlatformView()
     {
         return new Border();
     }
     
+    /// <summary>Maps the Color property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="boxView">The virtual view.</param>
     public static void MapColor(BoxViewHandler handler, BoxView boxView)
     {
         if (handler.PlatformView is Border platformView)
@@ -40,7 +53,10 @@ public class BoxViewHandler : ViewHandler<BoxView, Border>
             platformView.UpdateColor(boxView);
         }
     }
-    
+
+    /// <summary>Maps the CornerRadius property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="boxView">The virtual view.</param>
     public static void MapCornerRadius(BoxViewHandler handler, BoxView boxView)
     {
         if (handler.PlatformView is Border platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/ButtonHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ButtonHandler.cs
@@ -11,11 +11,13 @@ using MButton = Microsoft.Maui.Controls.Button;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IButton"/>.</summary>
 public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
 {
     private CancellationTokenSource? _imageSourceCts;
     private ImageSourcePartLoader? _imageSourcePartLoader;
 
+    /// <summary>Property mapper for <see cref="ButtonHandler"/>.</summary>
     public static IPropertyMapper<IButton, ButtonHandler> Mapper = new PropertyMapper<IButton, ButtonHandler>(ViewHandler.ViewMapper)
     {
         // IText properties
@@ -44,27 +46,37 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
         [nameof(IView.Shadow)] = MapButtonShadow,
     };
 
+    /// <summary>Command mapper for <see cref="ButtonHandler"/>.</summary>
     public static CommandMapper<IButton, ButtonHandler> CommandMapper = new(ViewCommandMapper);
 
+    /// <summary>Initializes a new instance of <see cref="ButtonHandler"/>.</summary>
     public ButtonHandler()
         : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="ButtonHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
     public ButtonHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="ButtonHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
+    /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
     public ButtonHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
-    // Shadow is applied directly to the PlatformView, so the button does not need
-    // a ContainerView wrapper just for shadow. This avoids a rendering issue where
-    // DropShadowEffect on a parent Panel causes the button content to disappear
-    // when the button's visual state changes (hover/pressed).
+    /// <summary>Gets a value indicating whether this handler requires a container view.</summary>
+    /// <remarks>
+    /// Shadow is applied directly to the PlatformView, so the button does not need
+    /// a ContainerView wrapper just for shadow. This avoids a rendering issue where
+    /// DropShadowEffect on a parent Panel causes the button content to disappear
+    /// when the button's visual state changes (hover/pressed).
+    /// </remarks>
     public override bool NeedsContainer
     {
         get
@@ -77,14 +89,19 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
         }
     }
 
+    /// <summary>Gets the image source loader for loading button images.</summary>
     public ImageSourcePartLoader ImageSourceLoader =>
         _imageSourcePartLoader ??= new ImageSourcePartLoader(new ButtonImageSourcePartSetter(this));
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override MauiButton CreatePlatformView()
     {
         return new MauiButton();
     }
 
+    /// <summary>Maps the Shadow property to the platform view.</summary>
+    /// <param name="handler">The handler for the button.</param>
+    /// <param name="button">The virtual view.</param>
     public static void MapButtonShadow(ButtonHandler handler, IButton button)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is not IView view)
@@ -93,6 +110,9 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
         Avalonia.Controls.Maui.Extensions.ViewExtensions.UpdateShadow(platformView, view);
     }
 
+    /// <summary>Maps the Background property to the platform view.</summary>
+    /// <param name="handler">The handler for the button.</param>
+    /// <param name="button">The virtual view.</param>
     public static void MapBackground(ButtonHandler handler, IButton button)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -101,6 +121,9 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
         platformView.UpdateButtonBackground(handler.VirtualView);
     }
 
+    /// <summary>Maps the StrokeColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the button.</param>
+    /// <param name="button">The virtual view.</param>
     public static void MapStrokeColor(ButtonHandler handler, IButton button)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -109,6 +132,9 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
         platformView.UpdateStrokeColor(handler.VirtualView);
     }
 
+    /// <summary>Maps the StrokeThickness property to the platform view.</summary>
+    /// <param name="handler">The handler for the button.</param>
+    /// <param name="button">The virtual view.</param>
     public static void MapStrokeThickness(ButtonHandler handler, IButton button)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -117,6 +143,9 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
         platformView.UpdateStrokeThickness(handler.VirtualView);
     }
 
+    /// <summary>Maps the CornerRadius property to the platform view.</summary>
+    /// <param name="handler">The handler for the button.</param>
+    /// <param name="button">The virtual view.</param>
     public static void MapCornerRadius(ButtonHandler handler, IButton button)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -125,6 +154,9 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
         platformView.UpdateCornerRadius(handler.VirtualView);
     }
 
+    /// <summary>Maps the Text property to the platform view.</summary>
+    /// <param name="handler">The handler for the button.</param>
+    /// <param name="button">The virtual view.</param>
     public static void MapText(ButtonHandler handler, IButton button)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -133,6 +165,9 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
         platformView.UpdateText(handler.VirtualView);
     }
 
+    /// <summary>Maps the TextColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the button.</param>
+    /// <param name="button">The virtual view.</param>
     public static void MapTextColor(ButtonHandler handler, IButton button)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -141,6 +176,9 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
         platformView.UpdateTextColor(handler.VirtualView);
     }
 
+    /// <summary>Maps the CharacterSpacing property to the platform view.</summary>
+    /// <param name="handler">The handler for the button.</param>
+    /// <param name="button">The virtual view.</param>
     public static void MapCharacterSpacing(ButtonHandler handler, IButton button)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -149,6 +187,9 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
         platformView.UpdateCharacterSpacing(handler.VirtualView);
     }
 
+    /// <summary>Maps the Font property to the platform view.</summary>
+    /// <param name="handler">The handler for the button.</param>
+    /// <param name="button">The virtual view.</param>
     public static void MapFont(ButtonHandler handler, IButton button)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -158,6 +199,9 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
         platformView.UpdateFont(handler.VirtualView, fontManager);
     }
 
+    /// <summary>Maps the Padding property to the platform view.</summary>
+    /// <param name="handler">The handler for the button.</param>
+    /// <param name="button">The virtual view.</param>
     public static void MapPadding(ButtonHandler handler, IButton button)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -165,7 +209,10 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
 
         platformView.UpdatePadding(handler.VirtualView);
     }
-    
+
+    /// <summary>Maps the ImageSource property to the platform view.</summary>
+    /// <param name="handler">The handler for the button.</param>
+    /// <param name="button">The virtual view.</param>
     public static void MapImageSource(ButtonHandler handler, IButton button)
     {
         if (handler is not ButtonHandler buttonHandler || handler.VirtualView is null)
@@ -194,6 +241,9 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
         buttonHandler._imageSourceCts = cts;
         _ = buttonHandler.LoadImageSourceAsync(imageSource, cts.Token);
     }
+    /// <summary>Maps the ContentLayout property to the platform view.</summary>
+    /// <param name="handler">The handler for the button.</param>
+    /// <param name="button">The virtual view.</param>
     public static void MapContentLayout(ButtonHandler handler, IButton button)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -211,6 +261,9 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
         }
     }
 
+    /// <summary>Maps the LineBreakMode property to the platform view.</summary>
+    /// <param name="handler">The handler for the button.</param>
+    /// <param name="button">The virtual view.</param>
     public static void MapLineBreakMode(ButtonHandler handler, IButton button)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -219,15 +272,17 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
         platformView.UpdateLineBreakMode(handler.VirtualView);
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         base.ConnectHandler(platformView);
-        
+
         platformView.AddHandler(InputElement.PointerPressedEvent, OnPointerPressed, RoutingStrategies.Tunnel);
         platformView.AddHandler(InputElement.PointerReleasedEvent, OnPointerReleased, RoutingStrategies.Tunnel);
         platformView.Click += OnClick;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         platformView.RemoveHandler(InputElement.PointerPressedEvent, OnPointerPressed);
@@ -235,7 +290,7 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
         platformView.Click -= OnClick;
         _imageSourceCts?.Cancel();
         _imageSourceCts = null;
-        
+
         base.DisconnectHandler(platformView);
     }
 
@@ -293,14 +348,18 @@ public partial class ButtonHandler : ViewHandler<IButton, PlatformView>
         }
     }
 
+    /// <summary>Image source part setter for <see cref="ButtonHandler"/>.</summary>
     partial class ButtonImageSourcePartSetter : ImageSourcePartSetter<ButtonHandler>
     {
+        /// <summary>Initializes a new instance of <see cref="ButtonImageSourcePartSetter"/>.</summary>
+        /// <param name="handler">The button handler.</param>
         public ButtonImageSourcePartSetter(ButtonHandler handler)
             : base(handler)
         {
         }
 
 #if !IOS && !MACCATALYST && !ANDROID && !WINDOWS
+        /// <inheritdoc/>
         public override void SetImageSource(object? platformImage)
         {
             if (Handler?.PlatformView is PlatformView button)

--- a/src/Avalonia.Controls.Maui/Handlers/CarouselViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/CarouselViewHandler.cs
@@ -11,11 +11,10 @@ using PlatformView = Avalonia.Controls.Maui.Platform.MauiCarouselView;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-/// <summary>
-/// Handler for MAUI CarouselView to Avalonia Carousel mapping
-/// </summary>
+/// <summary>Avalonia handler for <see cref="Microsoft.Maui.Controls.CarouselView"/>.</summary>
 public partial class CarouselViewHandler : ViewHandler<Microsoft.Maui.Controls.CarouselView, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="CarouselViewHandler"/>.</summary>
     public static IPropertyMapper<Microsoft.Maui.Controls.CarouselView, CarouselViewHandler> Mapper =
         new PropertyMapper<Microsoft.Maui.Controls.CarouselView, CarouselViewHandler>(ViewHandler.ViewMapper)
         {
@@ -26,36 +25,46 @@ public partial class CarouselViewHandler : ViewHandler<Microsoft.Maui.Controls.C
             [nameof(Microsoft.Maui.Controls.CarouselView.Loop)] = MapLoop,
         };
 
+    /// <summary>Command mapper for <see cref="CarouselViewHandler"/>.</summary>
     public static CommandMapper<Microsoft.Maui.Controls.CarouselView, CarouselViewHandler> CommandMapper =
         new(ViewCommandMapper)
         {
         };
 
+    /// <summary>Initializes a new instance of <see cref="CarouselViewHandler"/>.</summary>
     public CarouselViewHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="CarouselViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public CarouselViewHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="CarouselViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public CarouselViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         base.ConnectHandler(platformView);
         platformView.PropertyChanged += OnPlatformPropertyChanged;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         platformView.PropertyChanged -= OnPlatformPropertyChanged;
@@ -79,6 +88,9 @@ public partial class CarouselViewHandler : ViewHandler<Microsoft.Maui.Controls.C
         }
     }
 
+    /// <summary>Maps the ItemsSource property to the platform view.</summary>
+    /// <param name="handler">The handler for the carousel view.</param>
+    /// <param name="carouselView">The virtual carousel view.</param>
     public static void MapItemsSource(CarouselViewHandler handler, Microsoft.Maui.Controls.CarouselView carouselView)
     {
         if (handler.PlatformView == null || handler.VirtualView == null)
@@ -87,6 +99,9 @@ public partial class CarouselViewHandler : ViewHandler<Microsoft.Maui.Controls.C
         handler.PlatformView.ItemsSource = carouselView.ItemsSource;
     }
 
+    /// <summary>Maps the ItemTemplate property to the platform view.</summary>
+    /// <param name="handler">The handler for the carousel view.</param>
+    /// <param name="carouselView">The virtual carousel view.</param>
     public static void MapItemTemplate(CarouselViewHandler handler, Microsoft.Maui.Controls.CarouselView carouselView)
     {
         if (handler.PlatformView == null || handler.VirtualView == null)
@@ -122,6 +137,9 @@ public partial class CarouselViewHandler : ViewHandler<Microsoft.Maui.Controls.C
         }
     }
 
+    /// <summary>Maps the CurrentItem property to the platform view.</summary>
+    /// <param name="handler">The handler for the carousel view.</param>
+    /// <param name="carouselView">The virtual carousel view.</param>
     public static void MapCurrentItem(CarouselViewHandler handler, Microsoft.Maui.Controls.CarouselView carouselView)
     {
         if (handler.PlatformView == null || carouselView.ItemsSource == null)
@@ -139,6 +157,9 @@ public partial class CarouselViewHandler : ViewHandler<Microsoft.Maui.Controls.C
         }
     }
 
+    /// <summary>Maps the Position property to the platform view.</summary>
+    /// <param name="handler">The handler for the carousel view.</param>
+    /// <param name="carouselView">The virtual carousel view.</param>
     public static void MapPosition(CarouselViewHandler handler, Microsoft.Maui.Controls.CarouselView carouselView)
     {
         if (handler.PlatformView == null)
@@ -147,6 +168,9 @@ public partial class CarouselViewHandler : ViewHandler<Microsoft.Maui.Controls.C
         handler.PlatformView.SelectedIndex = carouselView.Position;
     }
 
+    /// <summary>Maps the Loop property to the platform view.</summary>
+    /// <param name="handler">The handler for the carousel view.</param>
+    /// <param name="carouselView">The virtual carousel view.</param>
     public static void MapLoop(CarouselViewHandler handler, Microsoft.Maui.Controls.CarouselView carouselView)
     {
         if (handler.PlatformView == null)
@@ -155,5 +179,6 @@ public partial class CarouselViewHandler : ViewHandler<Microsoft.Maui.Controls.C
         handler.PlatformView.Loop = carouselView.Loop;
     }
 
+    /// <inheritdoc/>
     public override bool NeedsContainer => false;
 }

--- a/src/Avalonia.Controls.Maui/Handlers/CheckBoxHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/CheckBoxHandler.cs
@@ -4,8 +4,10 @@ using PlatformView = Avalonia.Controls.CheckBox;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="ICheckBox"/>.</summary>
 public class CheckBoxHandler : ViewHandler<ICheckBox, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="CheckBoxHandler"/>.</summary>
     public static IPropertyMapper<ICheckBox, CheckBoxHandler> Mapper =
         new PropertyMapper<ICheckBox, CheckBoxHandler>(ViewHandler.ViewMapper)
         {
@@ -15,35 +17,45 @@ public class CheckBoxHandler : ViewHandler<ICheckBox, PlatformView>
             ["Color"] = MapColor, // Color is on CheckBox class, not ICheckBox interface
         };
 
+    /// <summary>Command mapper for <see cref="CheckBoxHandler"/>.</summary>
     public static CommandMapper<ICheckBox, CheckBoxHandler> CommandMapper = new(ViewCommandMapper)
     {
     };
 
+    /// <summary>Initializes a new instance of <see cref="CheckBoxHandler"/>.</summary>
     public CheckBoxHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="CheckBoxHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
     public CheckBoxHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="CheckBoxHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
+    /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
     public CheckBoxHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         base.ConnectHandler(platformView);
         platformView.IsCheckedChanged += OnIsCheckedChanged;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         base.DisconnectHandler(platformView);
@@ -58,20 +70,33 @@ public class CheckBoxHandler : ViewHandler<ICheckBox, PlatformView>
         }
     }
 
+    /// <summary>Gets a value indicating whether this handler requires a container view.</summary>
     public override bool NeedsContainer => false;
 
+    /// <summary>Maps the Background property to the platform view.</summary>
+    /// <param name="handler">The handler for the check box.</param>
+    /// <param name="checkBox">The virtual view.</param>
     public static void MapBackground(CheckBoxHandler handler, ICheckBox checkBox)
     {
         handler.UpdateValue(nameof(IViewHandler.ContainerView));
         ((PlatformView)handler.PlatformView)?.UpdateBackground(checkBox);
     }
 
+    /// <summary>Maps the IsChecked property to the platform view.</summary>
+    /// <param name="handler">The handler for the check box.</param>
+    /// <param name="checkBox">The virtual view.</param>
     public static void MapIsChecked(CheckBoxHandler handler, ICheckBox checkBox) =>
         ((PlatformView)handler.PlatformView)?.UpdateIsChecked(checkBox);
 
+    /// <summary>Maps the Foreground property to the platform view.</summary>
+    /// <param name="handler">The handler for the check box.</param>
+    /// <param name="checkBox">The virtual view.</param>
     public static void MapForeground(CheckBoxHandler handler, ICheckBox checkBox) =>
         ((PlatformView)handler.PlatformView)?.UpdateForeground(checkBox);
 
+    /// <summary>Maps the Color property to the platform view.</summary>
+    /// <param name="handler">The handler for the check box.</param>
+    /// <param name="checkBox">The virtual view.</param>
     public static void MapColor(CheckBoxHandler handler, ICheckBox checkBox) =>
         handler.UpdateValue(nameof(ICheckBox.Foreground));
 }

--- a/src/Avalonia.Controls.Maui/Handlers/CollectionViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/CollectionViewHandler.cs
@@ -5,8 +5,10 @@ using Avalonia.Controls.Maui.Extensions;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="CollectionView"/>.</summary>
 public class CollectionViewHandler : ViewHandler<CollectionView, MauiCollectionView>
 {
+    /// <summary>Property mapper for <see cref="CollectionViewHandler"/>.</summary>
     public static IPropertyMapper<ItemsView, CollectionViewHandler> Mapper =
         new PropertyMapper<ItemsView, CollectionViewHandler>(ViewHandler.ViewMapper)
         {
@@ -31,6 +33,7 @@ public class CollectionViewHandler : ViewHandler<CollectionView, MauiCollectionV
             [nameof(ItemsView.RemainingItemsThreshold)] = MapRemainingItemsThreshold,
         };
 
+    /// <summary>Command mapper for <see cref="CollectionViewHandler"/>.</summary>
     public static CommandMapper<CollectionView, CollectionViewHandler> CommandMapper =
         new(ViewCommandMapper)
         {
@@ -39,25 +42,33 @@ public class CollectionViewHandler : ViewHandler<CollectionView, MauiCollectionV
 
     private bool _isUpdatingSelection;
 
+    /// <summary>Initializes a new instance of <see cref="CollectionViewHandler"/>.</summary>
     public CollectionViewHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="CollectionViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public CollectionViewHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="CollectionViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public CollectionViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override MauiCollectionView CreatePlatformView()
     {
         return new MauiCollectionView();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(MauiCollectionView platformView)
     {
         base.ConnectHandler(platformView);
@@ -71,6 +82,7 @@ public class CollectionViewHandler : ViewHandler<CollectionView, MauiCollectionV
         }
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(MauiCollectionView platformView)
     {
         platformView.SelectionChanged -= OnSelectionChanged;
@@ -178,98 +190,156 @@ public class CollectionViewHandler : ViewHandler<CollectionView, MauiCollectionV
         });
     }
 
+    /// <inheritdoc/>
     public override bool NeedsContainer => false;
 
+    /// <summary>Maps the ItemsSource property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapItemsSource(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateItemsSource(itemsView);
     }
 
+    /// <summary>Maps the ItemTemplate property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapItemTemplate(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateItemTemplate(itemsView, handler);
     }
 
+    /// <summary>Maps the EmptyView property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapEmptyView(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateEmptyView(itemsView, handler);
     }
 
+    /// <summary>Maps the EmptyViewTemplate property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapEmptyViewTemplate(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateEmptyViewTemplate(itemsView, handler);
     }
 
+    /// <summary>Maps the HorizontalScrollBarVisibility property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapHorizontalScrollBarVisibility(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateHorizontalScrollBarVisibility(itemsView);
     }
 
+    /// <summary>Maps the VerticalScrollBarVisibility property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapVerticalScrollBarVisibility(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateVerticalScrollBarVisibility(itemsView);
     }
 
+    /// <summary>Maps the ItemsLayout property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapItemsLayout(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateItemsLayout(itemsView);
     }
 
+    /// <summary>Maps the IsGrouped property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapIsGrouped(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateIsGrouped(itemsView);
     }
 
+    /// <summary>Maps the GroupHeaderTemplate property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapGroupHeaderTemplate(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateGroupHeaderTemplate(itemsView, handler);
     }
 
+    /// <summary>Maps the GroupFooterTemplate property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapGroupFooterTemplate(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateGroupFooterTemplate(itemsView, handler);
     }
 
+    /// <summary>Maps the SelectedItem property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapSelectedItem(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateSelectedItem(itemsView);
     }
 
+    /// <summary>Maps the SelectionMode property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapSelectionMode(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateSelectionMode(itemsView);
     }
 
+    /// <summary>Maps the Header property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapHeader(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateHeader(itemsView, handler);
     }
 
+    /// <summary>Maps the HeaderTemplate property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapHeaderTemplate(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateHeaderTemplate(itemsView, handler);
     }
 
+    /// <summary>Maps the Footer property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapFooter(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateFooter(itemsView, handler);
     }
 
+    /// <summary>Maps the FooterTemplate property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapFooterTemplate(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateFooterTemplate(itemsView, handler);
     }
 
+    /// <summary>Maps the SelectedItems property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapSelectedItems(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateSelectedItems(itemsView);
     }
 
+    /// <summary>Maps the ItemsUpdatingScrollMode property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapItemsUpdatingScrollMode(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateItemsUpdatingScrollMode(itemsView);
     }
 
+    /// <summary>Maps the RemainingItemsThreshold property to the platform view.</summary>
+    /// <param name="handler">The handler for the collection view.</param>
+    /// <param name="itemsView">The virtual items view.</param>
     public static void MapRemainingItemsThreshold(CollectionViewHandler handler, ItemsView itemsView)
     {
         handler.PlatformView.UpdateRemainingItemsThreshold(itemsView);
@@ -277,7 +347,7 @@ public class CollectionViewHandler : ViewHandler<CollectionView, MauiCollectionV
 
     private void OnScrollToRequested(object? sender, ScrollToRequestEventArgs request)
     {
-        if (PlatformView == null) 
+        if (PlatformView == null)
             return;
 
         if (request.Mode == ScrollToMode.Position)

--- a/src/Avalonia.Controls.Maui/Handlers/ContentPresenterHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ContentPresenterHandler.cs
@@ -9,32 +9,44 @@ using PlatformView = System.Object;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IContentView"/>.</summary>
 public partial class ContentPresenterHandler : ViewHandler<IContentView, Avalonia.Controls.Maui.Platform.MauiContentPresenter>
 {
+    /// <summary>Property mapper for <see cref="ContentPresenterHandler"/>.</summary>
     public static IPropertyMapper<IContentView, ContentPresenterHandler> Mapper =
         new PropertyMapper<IContentView, ContentPresenterHandler>(ViewMapper)
         {
             [nameof(IContentView.Content)] = MapContent,
         };
 
+    /// <summary>Command mapper for <see cref="ContentPresenterHandler"/>.</summary>
     public static CommandMapper<IContentView, ContentPresenterHandler> CommandMapper =
         new(ViewCommandMapper);
 
+    /// <summary>Initializes a new instance of <see cref="ContentPresenterHandler"/>.</summary>
     public ContentPresenterHandler() : base(Mapper, CommandMapper)
     {
 
     }
 
+    /// <summary>Initializes a new instance of <see cref="ContentPresenterHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public ContentPresenterHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="ContentPresenterHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public ContentPresenterHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Maps the Content property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="page">The virtual view.</param>
     public static void MapContent(ContentPresenterHandler handler, IContentView page)
     {
         if (handler.PlatformView is MauiContentPresenter platformView)
@@ -43,6 +55,7 @@ public partial class ContentPresenterHandler : ViewHandler<IContentView, Avaloni
         }
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override Avalonia.Controls.Maui.Platform.MauiContentPresenter CreatePlatformView()
     {
         if (VirtualView == null)
@@ -58,6 +71,7 @@ public partial class ContentPresenterHandler : ViewHandler<IContentView, Avaloni
         return view;
     }
 
+    /// <inheritdoc/>
     public override void SetVirtualView(IView view)
     {
         base.SetVirtualView(view);

--- a/src/Avalonia.Controls.Maui/Handlers/ContentViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ContentViewHandler.cs
@@ -11,32 +11,44 @@ using PlatformView = System.Object;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IContentView"/>.</summary>
 public partial class ContentViewHandler : ViewHandler<IContentView, Avalonia.Controls.Maui.Platform.ContentView>
 {
+    /// <summary>Property mapper for <see cref="ContentViewHandler"/>.</summary>
     public static IPropertyMapper<IContentView, ContentViewHandler> Mapper =
         new PropertyMapper<IContentView, ContentViewHandler>(ViewMapper)
         {
             [nameof(IContentView.Content)] = MapContent,
         };
 
+    /// <summary>Command mapper for <see cref="ContentViewHandler"/>.</summary>
     public static CommandMapper<IContentView, ContentViewHandler> CommandMapper =
         new(ViewCommandMapper);
 
+    /// <summary>Initializes a new instance of <see cref="ContentViewHandler"/>.</summary>
     public ContentViewHandler() : base(Mapper, CommandMapper)
     {
 
     }
 
+    /// <summary>Initializes a new instance of <see cref="ContentViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public ContentViewHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="ContentViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public ContentViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Maps the Content property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="page">The virtual view.</param>
     public static void MapContent(ContentViewHandler handler, IContentView page)
     {
         if (handler.PlatformView is Avalonia.Controls.Maui.Platform.ContentView platformView)
@@ -45,6 +57,7 @@ public partial class ContentViewHandler : ViewHandler<IContentView, Avalonia.Con
         }
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override Avalonia.Controls.Maui.Platform.ContentView CreatePlatformView()
     {
         if (VirtualView == null)
@@ -60,6 +73,7 @@ public partial class ContentViewHandler : ViewHandler<IContentView, Avalonia.Con
         return view;
     }
 
+    /// <inheritdoc/>
     public override void SetVirtualView(IView view)
     {
         base.SetVirtualView(view);

--- a/src/Avalonia.Controls.Maui/Handlers/DatePickerHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/DatePickerHandler.cs
@@ -4,8 +4,10 @@ using PlatformView = Avalonia.Controls.DatePicker;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IDatePicker"/>.</summary>
 public class DatePickerHandler : ViewHandler<IDatePicker, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="DatePickerHandler"/>.</summary>
     public static IPropertyMapper<IDatePicker, DatePickerHandler> Mapper = new PropertyMapper<IDatePicker, DatePickerHandler>(ViewHandler.ViewMapper)
     {
         [nameof(IDatePicker.CharacterSpacing)] = MapCharacterSpacing,
@@ -17,40 +19,54 @@ public class DatePickerHandler : ViewHandler<IDatePicker, PlatformView>
         [nameof(IDatePicker.TextColor)] = MapTextColor,
     };
 
+    /// <summary>Command mapper for <see cref="DatePickerHandler"/>.</summary>
     public static CommandMapper<IPicker, DatePickerHandler> CommandMapper = new(ViewCommandMapper)
     {
     };
 
+    /// <summary>Initializes a new instance of <see cref="DatePickerHandler"/>.</summary>
     public DatePickerHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="DatePickerHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
     public DatePickerHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="DatePickerHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
+    /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
     public DatePickerHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView() => new PlatformView();
 
+    /// <summary>Gets a value indicating whether this handler requires a container view.</summary>
     public override bool NeedsContainer => false;
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         platformView.SelectedDateChanged += OnSelectedDateChanged;
         base.ConnectHandler(platformView);
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         platformView.SelectedDateChanged -= OnSelectedDateChanged;
         base.DisconnectHandler(platformView);
     }
 
+    /// <summary>Maps the Date property to the platform view.</summary>
+    /// <param name="handler">The handler for the date picker.</param>
+    /// <param name="datePicker">The virtual view.</param>
     public static void MapDate(DatePickerHandler handler, IDatePicker datePicker)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -59,6 +75,9 @@ public class DatePickerHandler : ViewHandler<IDatePicker, PlatformView>
         platformView.UpdateDate(datePicker);
     }
 
+    /// <summary>Maps the MinimumDate property to the platform view.</summary>
+    /// <param name="handler">The handler for the date picker.</param>
+    /// <param name="datePicker">The virtual view.</param>
     public static void MapMinimumDate(DatePickerHandler handler, IDatePicker datePicker)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -67,6 +86,9 @@ public class DatePickerHandler : ViewHandler<IDatePicker, PlatformView>
         platformView.UpdateMinimumDate(datePicker);
     }
 
+    /// <summary>Maps the MaximumDate property to the platform view.</summary>
+    /// <param name="handler">The handler for the date picker.</param>
+    /// <param name="datePicker">The virtual view.</param>
     public static void MapMaximumDate(DatePickerHandler handler, IDatePicker datePicker)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -75,6 +97,9 @@ public class DatePickerHandler : ViewHandler<IDatePicker, PlatformView>
         platformView.UpdateMaximumDate(datePicker);
     }
 
+    /// <summary>Maps the Format property to the platform view.</summary>
+    /// <param name="handler">The handler for the date picker.</param>
+    /// <param name="datePicker">The virtual view.</param>
     public static void MapFormat(DatePickerHandler handler, IDatePicker datePicker)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -83,6 +108,9 @@ public class DatePickerHandler : ViewHandler<IDatePicker, PlatformView>
         platformView.UpdateFormat(datePicker);
     }
 
+    /// <summary>Maps the CharacterSpacing property to the platform view.</summary>
+    /// <param name="handler">The handler for the date picker.</param>
+    /// <param name="datePicker">The virtual view.</param>
     public static void MapCharacterSpacing(DatePickerHandler handler, IDatePicker datePicker)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -91,6 +119,9 @@ public class DatePickerHandler : ViewHandler<IDatePicker, PlatformView>
         platformView.UpdateCharacterSpacing(datePicker);
     }
 
+    /// <summary>Maps the Font property to the platform view.</summary>
+    /// <param name="handler">The handler for the date picker.</param>
+    /// <param name="datePicker">The virtual view.</param>
     public static void MapFont(DatePickerHandler handler, IDatePicker datePicker)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -100,6 +131,9 @@ public class DatePickerHandler : ViewHandler<IDatePicker, PlatformView>
         platformView.UpdateFont(datePicker, fontManager);
     }
 
+    /// <summary>Maps the TextColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the date picker.</param>
+    /// <param name="datePicker">The virtual view.</param>
     public static void MapTextColor(DatePickerHandler handler, IDatePicker datePicker)
     {
         if (handler.PlatformView is not PlatformView platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/EditorHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/EditorHandler.cs
@@ -5,8 +5,10 @@ using Microsoft.Maui;
 
 namespace Avalonia.Controls.Maui.Handlers
 {
+    /// <summary>Avalonia handler for <see cref="IEditor"/>.</summary>
     public class EditorHandler : ViewHandler<IEditor, MauiEditor>
     {
+        /// <summary>Property mapper for <see cref="EditorHandler"/>.</summary>
         public static IPropertyMapper<IEditor, EditorHandler> Mapper = new PropertyMapper<IEditor, EditorHandler>(ViewHandler.ViewMapper)
         {
             [nameof(IEditor.Background)] = MapBackground,
@@ -29,29 +31,40 @@ namespace Avalonia.Controls.Maui.Handlers
             [nameof(Microsoft.Maui.Controls.Editor.AutoSize)] = MapAutoSize,
         };
 
+        /// <summary>Command mapper for <see cref="EditorHandler"/>.</summary>
         public static CommandMapper<IEditor, EditorHandler> CommandMapper = new(ViewCommandMapper)
         {
         };
 
+        /// <summary>Initializes a new instance of <see cref="EditorHandler"/>.</summary>
         public EditorHandler() : base(Mapper, CommandMapper)
         {
         }
 
+        /// <summary>Initializes a new instance of <see cref="EditorHandler"/>.</summary>
+        /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
         public EditorHandler(IPropertyMapper? mapper)
             : base(mapper ?? Mapper, CommandMapper)
         {
         }
 
+        /// <summary>Initializes a new instance of <see cref="EditorHandler"/>.</summary>
+        /// <param name="mapper">The property mapper to use.</param>
+        /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
         public EditorHandler(IPropertyMapper mapper, CommandMapper? commandMapper = null)
             : base(mapper, commandMapper)
         {
         }
         
+        /// <summary>Creates the Avalonia platform view for this handler.</summary>
         protected override MauiEditor CreatePlatformView()
         {
             return new MauiEditor();
         }
 
+        /// <summary>Maps the Background property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapBackground(EditorHandler handler, IEditor editor)
         {
             handler.UpdateValue(nameof(IViewHandler.ContainerView));
@@ -62,6 +75,7 @@ namespace Avalonia.Controls.Maui.Handlers
             }
         }
         
+        /// <inheritdoc/>
         protected override void ConnectHandler(MauiEditor platformView)
         {
             base.ConnectHandler(platformView);
@@ -70,6 +84,7 @@ namespace Avalonia.Controls.Maui.Handlers
             platformView.LostFocus += OnLostFocus;
         }
 
+        /// <inheritdoc/>
         protected override void DisconnectHandler(MauiEditor platformView)
         {
             platformView.TextChanged -= OnTextChanged;
@@ -78,60 +93,112 @@ namespace Avalonia.Controls.Maui.Handlers
             base.DisconnectHandler(platformView);
         }
 
+        /// <summary>Gets a value indicating whether this handler requires a container view.</summary>
         public override bool NeedsContainer => false;
 
+        /// <summary>Maps the Text property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapText(EditorHandler handler, IEditor editor) =>
             handler.PlatformView?.UpdateEditorText(editor);
 
+        /// <summary>Maps the TextColor property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapTextColor(EditorHandler handler, IEditor editor) =>
             handler.PlatformView?.UpdateEditorTextColor(editor);
 
+        /// <summary>Maps the CharacterSpacing property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapCharacterSpacing(EditorHandler handler, IEditor editor) =>
             handler.PlatformView?.UpdateEditorCharacterSpacing(editor);
 
+        /// <summary>Maps the Font property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapFont(EditorHandler handler, IEditor editor)
         {
             var fontManager = handler.GetRequiredService<IFontManager>();
             handler.PlatformView?.UpdateEditorFont(editor, fontManager);
         }
 
+        /// <summary>Maps the HorizontalTextAlignment property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapHorizontalTextAlignment(EditorHandler handler, IEditor editor) =>
             handler.PlatformView?.UpdateEditorHorizontalTextAlignment(editor);
 
+        /// <summary>Maps the VerticalTextAlignment property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapVerticalTextAlignment(EditorHandler handler, IEditor editor) =>
             handler.PlatformView?.UpdateEditorVerticalTextAlignment(editor);
 
+        /// <summary>Maps the IsReadOnly property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapIsReadOnly(EditorHandler handler, IEditor editor) =>
             handler.PlatformView?.UpdateEditorIsReadOnly(editor);
 
+        /// <summary>Maps the IsTextPredictionEnabled property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapIsTextPredictionEnabled(EditorHandler handler, IEditor editor) =>
             handler.PlatformView?.UpdateEditorIsTextPredictionEnabled(editor);
 
+        /// <summary>Maps the IsSpellCheckEnabled property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         [Avalonia.Controls.Maui.Platform.NotImplementedAttribute("Avalonia TextBox does not currently support disabling spell check.")]
         public static void MapIsSpellCheckEnabled(EditorHandler handler, IEditor editor) =>
             handler.PlatformView?.UpdateEditorIsSpellCheckEnabled(editor);
 
+        /// <summary>Maps the Keyboard property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapKeyboard(EditorHandler handler, IEditor editor) =>
             handler.PlatformView?.UpdateEditorKeyboard(editor);
 
+        /// <summary>Maps the MaxLength property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapMaxLength(EditorHandler handler, IEditor editor) =>
             handler.PlatformView?.UpdateEditorMaxLength(editor);
 
+        /// <summary>Maps the Placeholder property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapPlaceholder(EditorHandler handler, IEditor editor) =>
             handler.PlatformView?.UpdateEditorPlaceholder(editor);
 
+        /// <summary>Maps the PlaceholderColor property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapPlaceholderColor(EditorHandler handler, IEditor editor) =>
             handler.PlatformView?.UpdateEditorPlaceholderColor(editor);
 
+        /// <summary>Maps the CursorPosition property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapCursorPosition(EditorHandler handler, IEditor editor) =>
             handler.PlatformView?.UpdateEditorCursorPosition(editor);
 
+        /// <summary>Maps the SelectionLength property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapSelectionLength(EditorHandler handler, IEditor editor) =>
             handler.PlatformView?.UpdateEditorSelectionLength(editor);
 
+        /// <summary>Maps the TextTransform property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapTextTransform(EditorHandler handler, IEditor editor) =>
             handler.PlatformView?.UpdateEditorTextTransform(editor);
 
+        /// <summary>Maps the AutoSize property to the platform view.</summary>
+        /// <param name="handler">The handler for the editor.</param>
+        /// <param name="editor">The virtual view.</param>
         public static void MapAutoSize(EditorHandler handler, IEditor editor) =>
             handler.PlatformView?.UpdateEditorAutoSize(editor);
         

--- a/src/Avalonia.Controls.Maui/Handlers/EntryHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/EntryHandler.cs
@@ -7,8 +7,10 @@ using Avalonia.Controls.Maui.Controls;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IEntry"/>.</summary>
 public class EntryHandler : ViewHandler<IEntry, MauiEntry>
 {
+    /// <summary>Property mapper for <see cref="EntryHandler"/>.</summary>
     public static IPropertyMapper<IEntry, EntryHandler> Mapper = new PropertyMapper<IEntry, EntryHandler>(ViewHandler.ViewMapper)
     {
         [nameof(IEntry.Background)] = MapBackground,
@@ -33,27 +35,36 @@ public class EntryHandler : ViewHandler<IEntry, MauiEntry>
         [nameof(Microsoft.Maui.Controls.Entry.TextTransform)] = MapTextTransform
     };
     
+    /// <summary>Command mapper for <see cref="EntryHandler"/>.</summary>
     public static CommandMapper<IEntry, EntryHandler> CommandMapper = new(ViewCommandMapper);
-    
+
+    /// <summary>Initializes a new instance of <see cref="EntryHandler"/>.</summary>
     public EntryHandler() : base(Mapper, CommandMapper)
     {
     }
-    
+
+    /// <summary>Initializes a new instance of <see cref="EntryHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
     public EntryHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
-    
+
+    /// <summary>Initializes a new instance of <see cref="EntryHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use.</param>
+    /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
     public EntryHandler(IPropertyMapper mapper, CommandMapper? commandMapper = null)
         : base(mapper, commandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override MauiEntry CreatePlatformView()
     {
         return new MauiEntry();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(MauiEntry platformView)
     {
         base.ConnectHandler(platformView);
@@ -61,48 +72,80 @@ public class EntryHandler : ViewHandler<IEntry, MauiEntry>
         platformView.KeyDown += OnKeyDown;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(MauiEntry platformView)
     {
         platformView.TextChanged -= OnTextChanged;
         platformView.KeyDown -= OnKeyDown;
         base.DisconnectHandler(platformView);
     }
-    
+
+    /// <summary>Gets a value indicating whether this handler requires a container view.</summary>
     public override bool NeedsContainer => false;
-    
+
+    /// <summary>Maps the Background property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapBackground(EntryHandler handler, IEntry entry)
     {
         handler.UpdateValue(nameof(IViewHandler.ContainerView));
         handler.PlatformView?.UpdateBackground(entry);
     }
     
+    /// <summary>Maps the Text property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapText(EntryHandler handler, IEntry entry) =>
         handler.PlatformView?.UpdateText(entry);
-    
+
+    /// <summary>Maps the TextColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapTextColor(EntryHandler handler, IEntry entry) =>
         handler.PlatformView?.UpdateTextColor(entry);
-    
+
+    /// <summary>Maps the CharacterSpacing property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapCharacterSpacing(EntryHandler handler, IEntry entry) =>
         handler.PlatformView?.UpdateCharacterSpacing(entry);
-    
+
+    /// <summary>Maps the Font property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapFont(EntryHandler handler, IEntry entry)
     {
         var fontManager = handler.GetRequiredService<IFontManager>();
         handler.PlatformView?.UpdateFont(entry, fontManager);
     }
-    
+
+    /// <summary>Maps the HorizontalTextAlignment property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapHorizontalTextAlignment(EntryHandler handler, IEntry entry) =>
         handler.PlatformView?.UpdateHorizontalTextAlignment(entry);
-    
+
+    /// <summary>Maps the VerticalTextAlignment property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapVerticalTextAlignment(EntryHandler handler, IEntry entry) =>
         handler.PlatformView?.UpdateVerticalTextAlignment(entry);
-    
+
+    /// <summary>Maps the IsPassword property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapIsPassword(EntryHandler handler, IEntry entry) =>
         handler.PlatformView?.UpdateIsPassword(entry);
-    
+
+    /// <summary>Maps the IsReadOnly property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapIsReadOnly(EntryHandler handler, IEntry entry) =>
         handler.PlatformView?.UpdateIsReadOnly(entry);
-    
+
+    /// <summary>Maps the IsTextPredictionEnabled property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapIsTextPredictionEnabled(EntryHandler handler, IEntry entry)
     {
         if (handler.PlatformView is MauiEntry textBox)
@@ -110,36 +153,66 @@ public class EntryHandler : ViewHandler<IEntry, MauiEntry>
             TextInputOptions.SetShowSuggestions(textBox, entry.IsTextPredictionEnabled);
         }
     }
-    
+
+    /// <summary>Maps the IsSpellCheckEnabled property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapIsSpellCheckEnabled(EntryHandler handler, IEntry entry) =>
         handler.PlatformView?.UpdateIsSpellCheckEnabled(entry);
-    
+
+    /// <summary>Maps the Keyboard property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapKeyboard(EntryHandler handler, IEntry entry)
     {
         handler.PlatformView?.UpdateKeyboard(entry.Keyboard);
     }
-    
+
+    /// <summary>Maps the MaxLength property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapMaxLength(EntryHandler handler, IEntry entry) =>
         handler.PlatformView?.UpdateMaxLength(entry);
-    
+
+    /// <summary>Maps the Placeholder property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapPlaceholder(EntryHandler handler, IEntry entry) =>
         handler.PlatformView?.UpdatePlaceholder(entry);
-    
+
+    /// <summary>Maps the PlaceholderColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapPlaceholderColor(EntryHandler handler, IEntry entry) =>
         handler.PlatformView?.UpdatePlaceholderColor(entry);
-    
+
+    /// <summary>Maps the ReturnType property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapReturnType(EntryHandler handler, IEntry entry) =>
         handler.PlatformView?.UpdateReturnType(entry);
-    
+
+    /// <summary>Maps the ClearButtonVisibility property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapClearButtonVisibility(EntryHandler handler, IEntry entry) =>
         handler.PlatformView?.UpdateClearButtonVisibility(entry);
-    
+
+    /// <summary>Maps the CursorPosition property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapCursorPosition(EntryHandler handler, IEntry entry) =>
         handler.PlatformView?.UpdateCursorPosition(entry);
-    
+
+    /// <summary>Maps the SelectionLength property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapSelectionLength(EntryHandler handler, IEntry entry) =>
         handler.PlatformView?.UpdateSelectionLength(entry);
-    
+
+    /// <summary>Maps the TextTransform property to the platform view.</summary>
+    /// <param name="handler">The handler for the entry.</param>
+    /// <param name="entry">The virtual view.</param>
     public static void MapTextTransform(EntryHandler handler, IEntry entry) =>
         handler.PlatformView?.UpdateTextTransform(entry);
     

--- a/src/Avalonia.Controls.Maui/Handlers/FlyoutViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/FlyoutViewHandler.cs
@@ -6,9 +6,7 @@ using PlatformView = Avalonia.Controls.Maui.Controls.Shell.FlyoutContainer;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-/// <summary>
-/// Handler for MAUI FlyoutView to Avalonia SplitView mapping
-/// </summary>
+/// <summary>Avalonia handler for <see cref="IFlyoutView"/>.</summary>
 public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, PlatformView>
 {
     // Properties are set with priority because other mappers depend on them.
@@ -18,6 +16,7 @@ public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, PlatformView>
         [nameof(IFlyoutView.Detail)] = MapDetail,
     };
 
+    /// <summary>Property mapper for <see cref="FlyoutViewHandler"/>.</summary>
     public static IPropertyMapper<IFlyoutView, FlyoutViewHandler> Mapper =
         new PropertyMapper<IFlyoutView, FlyoutViewHandler>(ViewHandler.ViewMapper, FlyoutLayoutMapper)
         {
@@ -27,30 +26,39 @@ public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, PlatformView>
             [nameof(IFlyoutView.IsGestureEnabled)] = MapIsGestureEnabled,
         };
 
+    /// <summary>Command mapper for <see cref="FlyoutViewHandler"/>.</summary>
     public static CommandMapper<IFlyoutView, FlyoutViewHandler> CommandMapper =
         new(ViewCommandMapper)
         {
         };
 
+    /// <summary>Initializes a new instance of <see cref="FlyoutViewHandler"/>.</summary>
     public FlyoutViewHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="FlyoutViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public FlyoutViewHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="FlyoutViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public FlyoutViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         base.ConnectHandler(platformView);
@@ -59,6 +67,7 @@ public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, PlatformView>
         platformView.FlyoutClosed += OnFlyoutClosed;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         platformView.FlyoutOpened -= OnFlyoutOpened;
@@ -83,6 +92,9 @@ public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, PlatformView>
         }
     }
 
+    /// <summary>Maps the Flyout property to the platform view.</summary>
+    /// <param name="handler">The handler for the flyout view.</param>
+    /// <param name="flyoutView">The virtual flyout view.</param>
     public static void MapFlyout(FlyoutViewHandler handler, IFlyoutView flyoutView)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -102,6 +114,9 @@ public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, PlatformView>
         }
     }
 
+    /// <summary>Maps the Detail property to the platform view.</summary>
+    /// <param name="handler">The handler for the flyout view.</param>
+    /// <param name="flyoutView">The virtual flyout view.</param>
     public static void MapDetail(FlyoutViewHandler handler, IFlyoutView flyoutView)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -121,6 +136,9 @@ public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, PlatformView>
         }
     }
 
+    /// <summary>Maps the IsPresented property to the platform view.</summary>
+    /// <param name="handler">The handler for the flyout view.</param>
+    /// <param name="flyoutView">The virtual flyout view.</param>
     public static void MapIsPresented(FlyoutViewHandler handler, IFlyoutView flyoutView)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -129,6 +147,9 @@ public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, PlatformView>
         platformView.IsFlyoutOpen = flyoutView.IsPresented;
     }
 
+    /// <summary>Maps the FlyoutBehavior property to the platform view.</summary>
+    /// <param name="handler">The handler for the flyout view.</param>
+    /// <param name="flyoutView">The virtual flyout view.</param>
     public static void MapFlyoutBehavior(FlyoutViewHandler handler, IFlyoutView flyoutView)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -150,6 +171,9 @@ public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, PlatformView>
         }
     }
 
+    /// <summary>Maps the FlyoutWidth property to the platform view.</summary>
+    /// <param name="handler">The handler for the flyout view.</param>
+    /// <param name="flyoutView">The virtual flyout view.</param>
     public static void MapFlyoutWidth(FlyoutViewHandler handler, IFlyoutView flyoutView)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -166,6 +190,9 @@ public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, PlatformView>
         }
     }
 
+    /// <summary>Maps the IsGestureEnabled property to the platform view.</summary>
+    /// <param name="handler">The handler for the flyout view.</param>
+    /// <param name="flyoutView">The virtual flyout view.</param>
     public static void MapIsGestureEnabled(FlyoutViewHandler handler, IFlyoutView flyoutView)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -174,6 +201,9 @@ public partial class FlyoutViewHandler : ViewHandler<IFlyoutView, PlatformView>
         platformView.IsGestureEnabled = flyoutView.IsGestureEnabled;
     }
 
+    /// <summary>Maps the Toolbar property to the platform view.</summary>
+    /// <param name="handler">The handler for the flyout view.</param>
+    /// <param name="flyoutView">The virtual flyout view.</param>
     public static void MapToolbar(FlyoutViewHandler handler, IFlyoutView flyoutView)
     {
         // Toolbar is handled by NavigationPage's StackNavigationManager

--- a/src/Avalonia.Controls.Maui/Handlers/ImageButtonHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ImageButtonHandler.cs
@@ -10,11 +10,13 @@ using PlatformView = Avalonia.Controls.Maui.MauiImageButton;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IImageButton"/>.</summary>
 public partial class ImageButtonHandler : ViewHandler<IImageButton, PlatformView>
 {
     private CancellationTokenSource? _imageSourceCts;
     private ImageSourcePartLoader? _imageSourcePartLoader;
 
+    /// <summary>Property mapper for <see cref="ImageButtonHandler"/>.</summary>
     public static IPropertyMapper<IImageButton, ImageButtonHandler> Mapper = new PropertyMapper<IImageButton, ImageButtonHandler>(ViewHandler.ViewMapper)
     {
         // IImage properties
@@ -31,32 +33,44 @@ public partial class ImageButtonHandler : ViewHandler<IImageButton, PlatformView
         [nameof(IButtonStroke.CornerRadius)] = MapCornerRadius,
     };
 
+    /// <summary>Command mapper for <see cref="ImageButtonHandler"/>.</summary>
     public static CommandMapper<IImageButton, ImageButtonHandler> CommandMapper = new(ViewCommandMapper);
 
+    /// <summary>Initializes a new instance of <see cref="ImageButtonHandler"/>.</summary>
     public ImageButtonHandler()
         : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="ImageButtonHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public ImageButtonHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="ImageButtonHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public ImageButtonHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Gets the image source part loader for this handler.</summary>
     public virtual ImageSourcePartLoader SourceLoader =>
         _imageSourcePartLoader ??= new ImageSourcePartLoader(new ImageButtonImageSourcePartSetter(this));
-        
 
+
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override MauiImageButton CreatePlatformView()
     {
         return new MauiImageButton();
     }
 
+    /// <summary>Maps the Background property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="imageButton">The virtual view.</param>
     public static void MapBackground(ImageButtonHandler handler, IImageButton imageButton)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -65,6 +79,9 @@ public partial class ImageButtonHandler : ViewHandler<IImageButton, PlatformView
         platformView.UpdateImageButtonBackground(handler.VirtualView);
     }
 
+    /// <summary>Maps the StrokeColor property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="imageButton">The virtual view.</param>
     public static void MapStrokeColor(ImageButtonHandler handler, IImageButton imageButton)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -73,6 +90,9 @@ public partial class ImageButtonHandler : ViewHandler<IImageButton, PlatformView
         platformView.UpdateStrokeColor(handler.VirtualView);
     }
 
+    /// <summary>Maps the StrokeThickness property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="imageButton">The virtual view.</param>
     public static void MapStrokeThickness(ImageButtonHandler handler, IImageButton imageButton)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -81,6 +101,9 @@ public partial class ImageButtonHandler : ViewHandler<IImageButton, PlatformView
         platformView.UpdateStrokeThickness(handler.VirtualView);
     }
 
+    /// <summary>Maps the CornerRadius property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="imageButton">The virtual view.</param>
     public static void MapCornerRadius(ImageButtonHandler handler, IImageButton imageButton)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -89,6 +112,9 @@ public partial class ImageButtonHandler : ViewHandler<IImageButton, PlatformView
         platformView.UpdateCornerRadius(handler.VirtualView);
     }
 
+    /// <summary>Maps the Padding property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="imageButton">The virtual view.</param>
     public static void MapPadding(ImageButtonHandler handler, IImageButton imageButton)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -97,6 +123,9 @@ public partial class ImageButtonHandler : ViewHandler<IImageButton, PlatformView
         platformView.UpdatePadding(handler.VirtualView);
     }
 
+    /// <summary>Maps the Aspect property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="imageButton">The virtual view.</param>
     public static void MapAspect(ImageButtonHandler handler, IImageButton imageButton)
     {
         if (handler.PlatformView is not PlatformView platformView || handler.VirtualView is null)
@@ -105,6 +134,9 @@ public partial class ImageButtonHandler : ViewHandler<IImageButton, PlatformView
         platformView.UpdateAspect(handler.VirtualView);
     }
 
+    /// <summary>Maps the ImageSource property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="imageButton">The virtual view.</param>
     public static void MapImageSource(ImageButtonHandler handler, IImageButton imageButton)
     {
         if (handler is not ImageButtonHandler imageButtonHandler || handler.VirtualView is null)
@@ -129,6 +161,7 @@ public partial class ImageButtonHandler : ViewHandler<IImageButton, PlatformView
         _ = imageButtonHandler.LoadImageSourceAsync(imageSource, cts.Token);
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         base.ConnectHandler(platformView);
@@ -138,6 +171,7 @@ public partial class ImageButtonHandler : ViewHandler<IImageButton, PlatformView
         platformView.Click += OnClick;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         platformView.RemoveHandler(InputElement.PointerPressedEvent, OnPointerPressed);

--- a/src/Avalonia.Controls.Maui/Handlers/ImageHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ImageHandler.cs
@@ -16,6 +16,7 @@ using Microsoft.Maui.Controls;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IImage"/>.</summary>
 public partial class ImageHandler : ViewHandler<IImage, AGrid>
 {
     private readonly AImage _staticImage;
@@ -24,6 +25,7 @@ public partial class ImageHandler : ViewHandler<IImage, AGrid>
 
     private static readonly ConcurrentDictionary<string, Uri?> AssetCache = new();
 
+    /// <summary>Property mapper for <see cref="ImageHandler"/>.</summary>
     public static IPropertyMapper<IImage, ImageHandler> Mapper = new PropertyMapper<IImage, ImageHandler>(ViewHandler.ViewMapper)
     {
         [nameof(IImage.Aspect)] = MapAspect,
@@ -33,23 +35,31 @@ public partial class ImageHandler : ViewHandler<IImage, AGrid>
         // IsLoading is read-only and updated automatically by the handler
     };
 
+    /// <summary>Command mapper for <see cref="ImageHandler"/>.</summary>
     public static CommandMapper<IImage, ImageHandler> CommandMapper = new(ViewHandler.ViewCommandMapper);
 
+    /// <summary>Initializes a new instance of <see cref="ImageHandler"/>.</summary>
     public ImageHandler() : base(Mapper, CommandMapper)
     {
         _staticImage = new AImage { IsVisible = true };
     }
 
+    /// <summary>Initializes a new instance of <see cref="ImageHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public ImageHandler(IPropertyMapper? mapper) : base(mapper ?? Mapper, CommandMapper)
     {
         _staticImage = new AImage { IsVisible = true };
     }
 
+    /// <summary>Initializes a new instance of <see cref="ImageHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public ImageHandler(IPropertyMapper? mapper, CommandMapper? commandMapper) : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
         _staticImage = new AImage { IsVisible = true };
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override AGrid CreatePlatformView()
     {
         var grid = new AGrid();
@@ -58,6 +68,9 @@ public partial class ImageHandler : ViewHandler<IImage, AGrid>
         return grid;
     }
 
+    /// <summary>Maps the Source property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="image">The virtual view.</param>
     public static void MapSource(ImageHandler handler, IImage image)
     {
         if (handler is ImageHandler h)
@@ -69,16 +82,25 @@ public partial class ImageHandler : ViewHandler<IImage, AGrid>
         }
     }
     
+    /// <summary>Maps the IsAnimationPlaying property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="image">The virtual view.</param>
     public static void MapIsAnimationPlaying(ImageHandler handler, IImage image)
     {
         (handler.PlatformView as AGrid)?.UpdateIsAnimationPlaying(image.IsAnimationPlaying);
     }
 
+    /// <summary>Maps the Aspect property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="image">The virtual view.</param>
     public static void MapAspect(ImageHandler handler, IImage image)
     {
         (handler.PlatformView as AGrid)?.UpdateAspect(image.Aspect);
     }
 
+    /// <summary>Maps the Clip property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The virtual view.</param>
     public static void MapClip(ImageHandler handler, IView view)
     {
         if (handler is ImageHandler imageHandler)
@@ -344,7 +366,8 @@ public partial class ImageHandler : ViewHandler<IImage, AGrid>
         }
     }
 
-    public virtual ImageSourcePartLoader SourceLoader => 
+    /// <summary>Gets the image source part loader for this handler.</summary>
+    public virtual ImageSourcePartLoader SourceLoader =>
         new ImageSourcePartLoader(new ImageImageSourcePartSetter(this));
         
     partial class ImageImageSourcePartSetter : ImageSourcePartSetter<ImageHandler>

--- a/src/Avalonia.Controls.Maui/Handlers/IndicatorViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/IndicatorViewHandler.cs
@@ -5,11 +5,10 @@ using PlatformView = Avalonia.Controls.Maui.Controls.MauiIndicatorView;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-/// <summary>
-/// Handler for MAUI IndicatorView to Avalonia MauiIndicatorView mapping
-/// </summary>
+/// <summary>Avalonia handler for <see cref="IIndicatorView"/>.</summary>
 public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="IndicatorViewHandler"/>.</summary>
     public static IPropertyMapper<IIndicatorView, IndicatorViewHandler> Mapper =
         new PropertyMapper<IIndicatorView, IndicatorViewHandler>(ViewHandler.ViewMapper)
         {
@@ -23,30 +22,41 @@ public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, Platform
             [nameof(IIndicatorView.IndicatorsShape)] = MapIndicatorShape,
         };
 
+    /// <summary>Command mapper for <see cref="IndicatorViewHandler"/>.</summary>
     public static CommandMapper<IIndicatorView, IndicatorViewHandler> CommandMapper =
         new(ViewCommandMapper)
         {
         };
 
+    /// <summary>Initializes a new instance of <see cref="IndicatorViewHandler"/>.</summary>
     public IndicatorViewHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="IndicatorViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public IndicatorViewHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="IndicatorViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public IndicatorViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <summary>Maps the Count property to the platform view.</summary>
+    /// <param name="handler">The handler for the indicator view.</param>
+    /// <param name="indicator">The virtual indicator view.</param>
     public static void MapCount(IndicatorViewHandler handler, IIndicatorView indicator)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -55,6 +65,9 @@ public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, Platform
         platformView.Count = indicator.Count;
     }
 
+    /// <summary>Maps the Position property to the platform view.</summary>
+    /// <param name="handler">The handler for the indicator view.</param>
+    /// <param name="indicator">The virtual indicator view.</param>
     public static void MapPosition(IndicatorViewHandler handler, IIndicatorView indicator)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -63,6 +76,9 @@ public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, Platform
         platformView.Position = indicator.Position;
     }
 
+    /// <summary>Maps the HideSingle property to the platform view.</summary>
+    /// <param name="handler">The handler for the indicator view.</param>
+    /// <param name="indicator">The virtual indicator view.</param>
     public static void MapHideSingle(IndicatorViewHandler handler, IIndicatorView indicator)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -71,6 +87,9 @@ public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, Platform
         platformView.HideSingle = indicator.HideSingle;
     }
 
+    /// <summary>Maps the MaximumVisible property to the platform view.</summary>
+    /// <param name="handler">The handler for the indicator view.</param>
+    /// <param name="indicator">The virtual indicator view.</param>
     public static void MapMaximumVisible(IndicatorViewHandler handler, IIndicatorView indicator)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -79,6 +98,9 @@ public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, Platform
         platformView.MaximumVisible = indicator.MaximumVisible;
     }
 
+    /// <summary>Maps the IndicatorSize property to the platform view.</summary>
+    /// <param name="handler">The handler for the indicator view.</param>
+    /// <param name="indicator">The virtual indicator view.</param>
     public static void MapIndicatorSize(IndicatorViewHandler handler, IIndicatorView indicator)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -87,6 +109,9 @@ public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, Platform
         platformView.IndicatorSize = indicator.IndicatorSize;
     }
 
+    /// <summary>Maps the IndicatorColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the indicator view.</param>
+    /// <param name="indicator">The virtual indicator view.</param>
     public static void MapIndicatorColor(IndicatorViewHandler handler, IIndicatorView indicator)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -108,6 +133,9 @@ public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, Platform
         }
     }
 
+    /// <summary>Maps the SelectedIndicatorColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the indicator view.</param>
+    /// <param name="indicator">The virtual indicator view.</param>
     public static void MapSelectedIndicatorColor(IndicatorViewHandler handler, IIndicatorView indicator)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -129,6 +157,9 @@ public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, Platform
         }
     }
 
+    /// <summary>Maps the IndicatorsShape property to the platform view.</summary>
+    /// <param name="handler">The handler for the indicator view.</param>
+    /// <param name="indicator">The virtual indicator view.</param>
     public static void MapIndicatorShape(IndicatorViewHandler handler, IIndicatorView indicator)
     {
         if (handler.PlatformView is not PlatformView platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/LabelHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/LabelHandler.cs
@@ -17,8 +17,10 @@ using PlatformView = Avalonia.Controls.Control;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="ILabel"/>.</summary>
 public class LabelHandler : ViewHandler<ILabel, AvaloniaTextBlock>
 {
+    /// <summary>Property mapper for <see cref="LabelHandler"/>.</summary>
     public static IPropertyMapper<ILabel, LabelHandler> Mapper = new PropertyMapper<ILabel, LabelHandler>(ViewHandler.ViewMapper)
     {
         [nameof(ITextStyle.CharacterSpacing)] = MapCharacterSpacing,
@@ -37,46 +39,70 @@ public class LabelHandler : ViewHandler<ILabel, AvaloniaTextBlock>
         [nameof(MauiLabel.FormattedText)] = MapFormattedText,
     };
 
+    /// <summary>Command mapper for <see cref="LabelHandler"/>.</summary>
     public static CommandMapper<ILabel, LabelHandler> CommandMapper = new(ViewCommandMapper)
     {
     };
 
+    /// <summary>Initializes a new instance of <see cref="LabelHandler"/>.</summary>
     public LabelHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="LabelHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public LabelHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="LabelHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use.</param>
+    /// <param name="commandMapper">The command mapper to use.</param>
     public LabelHandler(IPropertyMapper mapper, CommandMapper? commandMapper = null)
         : base(mapper, commandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override AvaloniaTextBlock CreatePlatformView()
     {
         return new AvaloniaTextBlock();
     }
 
+    /// <summary>Gets a value indicating whether this handler requires a container view.</summary>
     public override bool NeedsContainer => VirtualView?.Background != null;
 
+    /// <summary>Maps the Background property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="label">The virtual view.</param>
     public static void MapBackground(LabelHandler handler, ILabel label)
     {
         handler.UpdateValue(nameof(IViewHandler.ContainerView));
         ((AvaloniaTextBlock)handler.PlatformView)?.UpdateBackground(label);
     }
 
+    /// <summary>Maps the Text property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="label">The virtual view.</param>
     public static void MapText(LabelHandler handler, ILabel label) =>
         ((AvaloniaTextBlock)handler.PlatformView)?.UpdateText(label);
 
+    /// <summary>Maps the TextColor property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="label">The virtual view.</param>
     public static void MapTextColor(LabelHandler handler, ILabel label) =>
         ((AvaloniaTextBlock)handler.PlatformView)?.UpdateTextColor(label);
 
+    /// <summary>Maps the CharacterSpacing property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="label">The virtual view.</param>
     public static void MapCharacterSpacing(LabelHandler handler, ILabel label) =>
         ((AvaloniaTextBlock)handler.PlatformView)?.UpdateCharacterSpacing(label);
 
+    /// <summary>Maps the Font property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="label">The virtual view.</param>
     public static void MapFont(LabelHandler handler, ILabel label)
     {
         var fontManager = handler.GetRequiredService<IFontManager>();
@@ -84,41 +110,75 @@ public class LabelHandler : ViewHandler<ILabel, AvaloniaTextBlock>
         ((AvaloniaTextBlock)handler.PlatformView)?.UpdateFont(label, fontManager);
     }
 
+    /// <summary>Maps the HorizontalTextAlignment property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="label">The virtual view.</param>
     public static void MapHorizontalTextAlignment(LabelHandler handler, ILabel label) =>
         ((AvaloniaTextBlock)handler.PlatformView)?.UpdateHorizontalTextAlignment(label);
 
+    /// <summary>Maps the VerticalTextAlignment property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="label">The virtual view.</param>
     public static void MapVerticalTextAlignment(LabelHandler handler, ILabel label) =>
         ((AvaloniaTextBlock)handler.PlatformView)?.UpdateVerticalTextAlignment(label);
 
+    /// <summary>Maps the LineBreakMode property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="label">The virtual view.</param>
     public static void MapLineBreakMode(LabelHandler handler, ILabel label) =>
         ((AvaloniaTextBlock)handler.PlatformView)?.UpdateLineBreakMode(label);
 
+    /// <summary>Maps the TextDecorations property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="label">The virtual view.</param>
     public static void MapTextDecorations(LabelHandler handler, ILabel label) =>
         ((AvaloniaTextBlock)handler.PlatformView)?.UpdateTextDecorations(label);
 
+    /// <summary>Maps the MaxLines property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="label">The virtual view.</param>
     public static void MapMaxLines(LabelHandler handler, ILabel label) =>
         ((AvaloniaTextBlock)handler.PlatformView)?.UpdateMaxLines(label);
 
+    /// <summary>Maps the Padding property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="label">The virtual view.</param>
     public static void MapPadding(LabelHandler handler, ILabel label) =>
         ((AvaloniaTextBlock)handler.PlatformView)?.UpdatePadding(label);
 
+    /// <summary>Maps the LineHeight property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="label">The virtual view.</param>
     public static void MapLineHeight(LabelHandler handler, ILabel label) =>
         ((AvaloniaTextBlock)handler.PlatformView)?.UpdateLineHeight(label);
 
+    /// <summary>Maps the TextTransform property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="label">The virtual view.</param>
     public static void MapTextTransform(LabelHandler handler, ILabel label) =>
         ((AvaloniaTextBlock)handler.PlatformView)?.UpdateTextTransform(label);
 
+    /// <summary>Maps the FormattedText property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="label">The virtual view.</param>
     public static void MapFormattedText(LabelHandler handler, ILabel label) =>
         ((AvaloniaTextBlock)handler.PlatformView)?.UpdateFormattedText(label, handler);
 }
 
+/// <summary>Extension methods for mapping MAUI Label properties to Avalonia controls.</summary>
 public static class LabelTextBlockExtensions
 {
+    /// <summary>Updates the Text property on the platform view.</summary>
+    /// <param name="textBlock">The Avalonia text block.</param>
+    /// <param name="label">The MAUI label providing the text.</param>
     public static void UpdateText(this AvaloniaTextBlock textBlock, ILabel label)
     {
         textBlock.UpdateTextPlainText(label);
     }
 
+    /// <summary>Updates the TextColor property on the platform view.</summary>
+    /// <param name="textBlock">The Avalonia text block.</param>
+    /// <param name="text">The MAUI text style providing the color.</param>
     public static void UpdateTextColor(this AvaloniaTextBlock textBlock, IText text)
     {
         if (text.TextColor != null)
@@ -131,6 +191,9 @@ public static class LabelTextBlockExtensions
         }
     }
 
+    /// <summary>Updates the Padding property on the platform view.</summary>
+    /// <param name="textBlock">The Avalonia text block.</param>
+    /// <param name="label">The MAUI label providing the padding.</param>
     public static void UpdatePadding(this AvaloniaTextBlock textBlock, ILabel label)
     {
         if (!label.Padding.IsEmpty)
@@ -143,6 +206,9 @@ public static class LabelTextBlockExtensions
         }
     }
 
+    /// <summary>Updates the CharacterSpacing property on the platform view.</summary>
+    /// <param name="textBlock">The Avalonia text block.</param>
+    /// <param name="label">The MAUI label providing the character spacing.</param>
     public static void UpdateCharacterSpacing(this AvaloniaTextBlock textBlock, ILabel label)
     {
         if (label.CharacterSpacing != 0)
@@ -155,6 +221,9 @@ public static class LabelTextBlockExtensions
         }
     }
 
+    /// <summary>Updates the MaxLines property on the platform view.</summary>
+    /// <param name="textBlock">The Avalonia text block.</param>
+    /// <param name="label">The MAUI label providing the max lines value.</param>
     public static void UpdateMaxLines(this AvaloniaTextBlock textBlock, ILabel label)
     {
         if (label is not MauiLabel mauiLabel)
@@ -172,6 +241,9 @@ public static class LabelTextBlockExtensions
         }
     }
 
+    /// <summary>Updates the TextDecorations property on the platform view.</summary>
+    /// <param name="textBlock">The Avalonia text block.</param>
+    /// <param name="label">The MAUI label providing the text decorations.</param>
     public static void UpdateTextDecorations(this AvaloniaTextBlock textBlock, ILabel label)
     {
         var decorations = label.TextDecorations;
@@ -203,6 +275,9 @@ public static class LabelTextBlockExtensions
         }
     }
 
+    /// <summary>Updates the LineHeight property on the platform view.</summary>
+    /// <param name="textBlock">The Avalonia text block.</param>
+    /// <param name="label">The MAUI label providing the line height.</param>
     public static void UpdateLineHeight(this AvaloniaTextBlock textBlock, ILabel label)
     {
         if (label.LineHeight >= 0)
@@ -211,6 +286,9 @@ public static class LabelTextBlockExtensions
         }
     }
 
+    /// <summary>Updates the HorizontalTextAlignment property on the platform view.</summary>
+    /// <param name="textBlock">The Avalonia text block.</param>
+    /// <param name="label">The MAUI label providing the horizontal text alignment.</param>
     public static void UpdateHorizontalTextAlignment(this AvaloniaTextBlock textBlock, ILabel label)
     {
         switch (label.HorizontalTextAlignment)
@@ -229,11 +307,17 @@ public static class LabelTextBlockExtensions
         }
     }
 
+    /// <summary>Updates the VerticalTextAlignment property on the platform view.</summary>
+    /// <param name="textBlock">The Avalonia text block.</param>
+    /// <param name="label">The MAUI label providing the vertical text alignment.</param>
     public static void UpdateVerticalTextAlignment(this TextBlock textBlock, ILabel label)
     {
         // TODO: Vertical Text Alignment is not directly supported in Avalonia TextBox yet.
     }
 
+    /// <summary>Updates the LineBreakMode property on the platform view.</summary>
+    /// <param name="textBlock">The Avalonia text block.</param>
+    /// <param name="label">The MAUI label providing the line break mode.</param>
     public static void UpdateLineBreakMode(this AvaloniaTextBlock textBlock, ILabel label)
     {
         if (label is not MauiLabel mauiLabel)
@@ -303,6 +387,9 @@ public static class LabelTextBlockExtensions
         }
     }
 
+    /// <summary>Updates the TextTransform property on the platform view.</summary>
+    /// <param name="textBlock">The Avalonia text block.</param>
+    /// <param name="label">The MAUI label providing the text transform.</param>
     public static void UpdateTextTransform(this AvaloniaTextBlock textBlock, ILabel label)
     {
         if (label is not MauiLabel mauiLabel)
@@ -316,6 +403,10 @@ public static class LabelTextBlockExtensions
 
     
 
+    /// <summary>Updates the FormattedText property on the platform view.</summary>
+    /// <param name="textBlock">The Avalonia text block.</param>
+    /// <param name="label">The MAUI label providing the formatted text.</param>
+    /// <param name="handler">The label handler for accessing services.</param>
     public static void UpdateFormattedText(this AvaloniaTextBlock textBlock, ILabel label, LabelHandler handler)
     {
         if (label is not MauiLabel mauiLabel)

--- a/src/Avalonia.Controls.Maui/Handlers/LayoutHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/LayoutHandler.cs
@@ -9,8 +9,14 @@ using System.Text;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>
+/// Avalonia handler for <see cref="ILayout"/>.
+/// </summary>
 public partial class LayoutHandler : ViewHandler<ILayout, Panel>
 {
+    /// <summary>
+    /// Property mapper for <see cref="LayoutHandler"/>.
+    /// </summary>
     public static IPropertyMapper<ILayout, LayoutHandler> Mapper = new PropertyMapper<ILayout, LayoutHandler>(ViewMapper)
     {
         [nameof(ILayout.Background)] = MapBackground,
@@ -18,6 +24,9 @@ public partial class LayoutHandler : ViewHandler<ILayout, Panel>
         [nameof(IView.InputTransparent)] = MapInputTransparent,
     };
 
+    /// <summary>
+    /// Command mapper for <see cref="LayoutHandler"/>.
+    /// </summary>
     public static CommandMapper<ILayout, LayoutHandler> CommandMapper = new(ViewCommandMapper)
     {
         [nameof(LayoutHandler.Add)] = MapAdd,
@@ -28,15 +37,27 @@ public partial class LayoutHandler : ViewHandler<ILayout, Panel>
         [nameof(LayoutHandler.UpdateZIndex)] = MapUpdateZIndex,
     };
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="LayoutHandler"/>.
+    /// </summary>
     public LayoutHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="LayoutHandler"/>.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
+    /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
     public LayoutHandler(IPropertyMapper? mapper = null, CommandMapper? commandMapper = null)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Creates the Avalonia platform view for this handler.
+    /// </summary>
+    /// <returns>A new <see cref="Platform.LayoutPanel"/> instance configured with cross-platform layout delegates.</returns>
     protected override Panel CreatePlatformView()
     {
         return new Avalonia.Controls.Maui.Platform.LayoutPanel()
@@ -46,21 +67,42 @@ public partial class LayoutHandler : ViewHandler<ILayout, Panel>
         };
     }
 
+    /// <summary>
+    /// Maps the Background property to the platform view.
+    /// </summary>
+    /// <param name="handler">The associated handler.</param>
+    /// <param name="layout">The associated <see cref="ILayout"/> instance.</param>
     public static void MapBackground(LayoutHandler handler, ILayout layout)
     {
         ((LayoutHandler)handler).PlatformView?.UpdateBackground(layout);
     }
 
+    /// <summary>
+    /// Maps the <see cref="IView.InputTransparent"/> property to the platform view.
+    /// </summary>
+    /// <param name="handler">The associated handler.</param>
+    /// <param name="layout">The associated <see cref="ILayout"/> instance.</param>
     public static void MapInputTransparent(LayoutHandler handler, ILayout layout)
     {
         // TODO: Implement InputTransparent
     }
 
+    /// <summary>
+    /// Maps the <see cref="ILayout.ClipsToBounds"/> property to the platform view.
+    /// </summary>
+    /// <param name="handler">The associated handler.</param>
+    /// <param name="layout">The associated <see cref="ILayout"/> instance.</param>
     public static void MapClipsToBounds(LayoutHandler handler, ILayout layout)
     {
         ((LayoutHandler)handler).PlatformView?.UpdateClipsToBounds(layout);
     }
 
+    /// <summary>
+    /// Maps the Add command to add a child view to the layout.
+    /// </summary>
+    /// <param name="handler">The associated handler.</param>
+    /// <param name="layout">The associated <see cref="ILayout"/> instance.</param>
+    /// <param name="arg">The <see cref="LayoutHandlerUpdate"/> containing the view to add.</param>
     public static void MapAdd(LayoutHandler handler, ILayout layout, object? arg)
     {
         if (arg is LayoutHandlerUpdate args)
@@ -69,6 +111,12 @@ public partial class LayoutHandler : ViewHandler<ILayout, Panel>
         }
     }
 
+    /// <summary>
+    /// Maps the Remove command to remove a child view from the layout.
+    /// </summary>
+    /// <param name="handler">The associated handler.</param>
+    /// <param name="layout">The associated <see cref="ILayout"/> instance.</param>
+    /// <param name="arg">The <see cref="LayoutHandlerUpdate"/> containing the view to remove.</param>
     public static void MapRemove(LayoutHandler handler, ILayout layout, object? arg)
     {
         if (arg is LayoutHandlerUpdate args)
@@ -77,6 +125,12 @@ public partial class LayoutHandler : ViewHandler<ILayout, Panel>
         }
     }
 
+    /// <summary>
+    /// Maps the Insert command to insert a child view at a specific index in the layout.
+    /// </summary>
+    /// <param name="handler">The associated handler.</param>
+    /// <param name="layout">The associated <see cref="ILayout"/> instance.</param>
+    /// <param name="arg">The <see cref="LayoutHandlerUpdate"/> containing the view and index.</param>
     public static void MapInsert(LayoutHandler handler, ILayout layout, object? arg)
     {
         if (arg is LayoutHandlerUpdate args)
@@ -85,11 +139,20 @@ public partial class LayoutHandler : ViewHandler<ILayout, Panel>
         }
     }
 
+    /// <summary>
+    /// Maps the Clear command to remove all child views from the layout.
+    /// </summary>
+    /// <param name="handler">The associated handler.</param>
+    /// <param name="layout">The associated <see cref="ILayout"/> instance.</param>
+    /// <param name="arg">The associated command arguments.</param>
     public static void MapClear(LayoutHandler handler, ILayout layout, object? arg)
     {
         handler.Clear();
     }
 
+    /// <summary>
+    /// Maps the Update command to replace a child view at a specific index in the layout.
+    /// </summary>
     static void MapUpdate(LayoutHandler handler, ILayout layout, object? arg)
     {
         if (arg is LayoutHandlerUpdate args)
@@ -98,6 +161,9 @@ public partial class LayoutHandler : ViewHandler<ILayout, Panel>
         }
     }
 
+    /// <summary>
+    /// Maps the UpdateZIndex command to update the Z-index of a child view.
+    /// </summary>
     static void MapUpdateZIndex(LayoutHandler handler, ILayout layout, object? arg)
     {
         if (arg is IView view)
@@ -106,6 +172,10 @@ public partial class LayoutHandler : ViewHandler<ILayout, Panel>
         }
     }
 
+    /// <summary>
+    /// Adds a child view to the layout's platform panel.
+    /// </summary>
+    /// <param name="child">The child view to add.</param>
     public void Add(IView child)
     {
         _ = PlatformView ?? throw new InvalidOperationException($"{nameof(PlatformView)} should have been set by base class.");
@@ -119,6 +189,11 @@ public partial class LayoutHandler : ViewHandler<ILayout, Panel>
         }
     }
 
+    /// <summary>
+    /// Removes a child view from the layout's platform panel.
+    /// </summary>
+    /// <param name="index">The index of the child to remove.</param>
+    /// <param name="child">The child view to remove.</param>
     public void Remove(int index, IView child)
     {
         _ = PlatformView ?? throw new InvalidOperationException($"{nameof(PlatformView)} should have been set by base class.");
@@ -139,11 +214,19 @@ public partial class LayoutHandler : ViewHandler<ILayout, Panel>
         }
     }
 
+    /// <summary>
+    /// Removes all child views from the layout's platform panel.
+    /// </summary>
     public void Clear()
     {
         PlatformView?.Children.Clear();
     }
 
+    /// <summary>
+    /// Inserts a child view at the specified index in the layout's platform panel.
+    /// </summary>
+    /// <param name="index">The index at which to insert the child.</param>
+    /// <param name="child">The child view to insert.</param>
     public void Insert(int index, IView child)
     {
         _ = PlatformView ?? throw new InvalidOperationException($"{nameof(PlatformView)} should have been set by base class.");
@@ -157,6 +240,11 @@ public partial class LayoutHandler : ViewHandler<ILayout, Panel>
         }
     }
 
+    /// <summary>
+    /// Replaces the child view at the specified index in the layout's platform panel.
+    /// </summary>
+    /// <param name="index">The index of the child to replace.</param>
+    /// <param name="child">The new child view.</param>
     public void Update(int index, IView child)
     {
         _ = PlatformView ?? throw new InvalidOperationException($"{nameof(PlatformView)} should have been set by base class.");
@@ -171,6 +259,10 @@ public partial class LayoutHandler : ViewHandler<ILayout, Panel>
         }
     }
 
+    /// <summary>
+    /// Updates the Z-index of a child view's platform control.
+    /// </summary>
+    /// <param name="child">The child view whose Z-index should be updated.</param>
     public void UpdateZIndex(IView child)
     {
         if (child?.Handler is IViewHandler viewHandler)
@@ -183,6 +275,7 @@ public partial class LayoutHandler : ViewHandler<ILayout, Panel>
         }
     }
 
+    /// <inheritdoc/>
     public override void SetVirtualView(IView view)
     {
         base.SetVirtualView(view);
@@ -201,6 +294,7 @@ public partial class LayoutHandler : ViewHandler<ILayout, Panel>
         }
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(Panel platformView)
     {
         base.ConnectHandler(platformView);
@@ -211,6 +305,7 @@ public partial class LayoutHandler : ViewHandler<ILayout, Panel>
         }
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(Panel platformView)
     {
         base.DisconnectHandler(platformView);
@@ -221,6 +316,9 @@ public partial class LayoutHandler : ViewHandler<ILayout, Panel>
         }
     }
 
+    /// <summary>
+    /// Gets the flow direction for the layout. Currently returns the input value unchanged.
+    /// </summary>
     internal static FlowDirection GetLayoutFlowDirection(FlowDirection flowDirection)
     {
         return flowDirection;

--- a/src/Avalonia.Controls.Maui/Handlers/MenuBarHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/MenuBarHandler.cs
@@ -5,12 +5,15 @@ using PlatformView = Avalonia.Controls.Menu;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IMenuBar"/>.</summary>
 public partial class MenuBarHandler : ElementHandler<IMenuBar, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="MenuBarHandler"/>.</summary>
     public static IPropertyMapper<IMenuBar, MenuBarHandler> Mapper = new PropertyMapper<IMenuBar, MenuBarHandler>(ElementMapper)
     {
     };
 
+    /// <summary>Command mapper for <see cref="MenuBarHandler"/>.</summary>
     public static CommandMapper<IMenuBar, MenuBarHandler> CommandMapper = new(ElementCommandMapper)
     {
         [nameof(MenuBarHandler.Add)] = MapAdd,
@@ -19,19 +22,25 @@ public partial class MenuBarHandler : ElementHandler<IMenuBar, PlatformView>
         [nameof(MenuBarHandler.Insert)] = MapInsert,
     };
 
+    /// <summary>Initializes a new instance of <see cref="MenuBarHandler"/>.</summary>
     public MenuBarHandler() : this(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="MenuBarHandler"/>.</summary>
+    /// <param name="mapper">The property mapper.</param>
+    /// <param name="commandMapper">The command mapper.</param>
     public MenuBarHandler(IPropertyMapper mapper, CommandMapper? commandMapper = null) : base(mapper, commandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformElement()
     {
         return new PlatformView();
     }
 
+    /// <inheritdoc/>
     public override void SetVirtualView(IElement view)
     {
         base.SetVirtualView(view);
@@ -43,6 +52,10 @@ public partial class MenuBarHandler : ElementHandler<IMenuBar, PlatformView>
         }
     }
 
+    /// <summary>Maps the Add command to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="layout">The menu bar.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapAdd(MenuBarHandler handler, IMenuBar layout, object? arg)
     {
         if (arg is MenuBarHandlerUpdate args)
@@ -51,6 +64,10 @@ public partial class MenuBarHandler : ElementHandler<IMenuBar, PlatformView>
         }
     }
 
+    /// <summary>Maps the Remove command to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="layout">The menu bar.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapRemove(MenuBarHandler handler, IMenuBar layout, object? arg)
     {
         if (arg is MenuBarHandlerUpdate args)
@@ -59,6 +76,10 @@ public partial class MenuBarHandler : ElementHandler<IMenuBar, PlatformView>
         }
     }
 
+    /// <summary>Maps the Insert command to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="layout">The menu bar.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapInsert(MenuBarHandler handler, IMenuBar layout, object? arg)
     {
         if (arg is MenuBarHandlerUpdate args)
@@ -67,11 +88,17 @@ public partial class MenuBarHandler : ElementHandler<IMenuBar, PlatformView>
         }
     }
 
+    /// <summary>Maps the Clear command to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="layout">The menu bar.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapClear(MenuBarHandler handler, IMenuBar layout, object? arg)
     {
         handler.Clear();
     }
 
+    /// <summary>Adds a child element.</summary>
+    /// <param name="view">The menu bar item to add.</param>
     public void Add(IMenuBarItem view)
     {
         var platformView = view.ToPlatform(MauiContext!);
@@ -81,6 +108,8 @@ public partial class MenuBarHandler : ElementHandler<IMenuBar, PlatformView>
         }
     }
 
+    /// <summary>Removes a child element.</summary>
+    /// <param name="view">The menu bar item to remove.</param>
     public void Remove(IMenuBarItem view)
     {
         if (view.Handler?.PlatformView is object platformView)
@@ -89,11 +118,15 @@ public partial class MenuBarHandler : ElementHandler<IMenuBar, PlatformView>
         }
     }
 
+    /// <summary>Clears all child elements.</summary>
     public void Clear()
     {
         PlatformView.Items.Clear();
     }
 
+    /// <summary>Inserts a child element at the specified index.</summary>
+    /// <param name="index">The index at which to insert.</param>
+    /// <param name="view">The menu bar item to insert.</param>
     public void Insert(int index, IMenuBarItem view)
     {
         var platformView = view.ToPlatform(MauiContext!);
@@ -103,6 +136,7 @@ public partial class MenuBarHandler : ElementHandler<IMenuBar, PlatformView>
         }
     }
 
+    /// <inheritdoc/>
     public override void OnDisconnectHandler(object platformView)
     {
         base.OnDisconnectHandler(platformView);

--- a/src/Avalonia.Controls.Maui/Handlers/MenuBarItemHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/MenuBarItemHandler.cs
@@ -5,14 +5,17 @@ using PlatformView = Avalonia.Controls.MenuItem;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IMenuBarItem"/>.</summary>
 public partial class MenuBarItemHandler : ElementHandler<IMenuBarItem, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="MenuBarItemHandler"/>.</summary>
     public static IPropertyMapper<IMenuBarItem, MenuBarItemHandler> Mapper = new PropertyMapper<IMenuBarItem, MenuBarItemHandler>(ElementMapper)
     {
         [nameof(IMenuBarItem.Text)] = MapText,
         [nameof(IMenuBarItem.IsEnabled)] = MapIsEnabled,
     };
 
+    /// <summary>Command mapper for <see cref="MenuBarItemHandler"/>.</summary>
     public static CommandMapper<IMenuBarItem, MenuBarItemHandler> CommandMapper = new(ElementCommandMapper)
     {
         [nameof(MenuBarItemHandler.Add)] = MapAdd,
@@ -21,31 +24,43 @@ public partial class MenuBarItemHandler : ElementHandler<IMenuBarItem, PlatformV
         [nameof(MenuBarItemHandler.Insert)] = MapInsert,
     };
 
+    /// <summary>Initializes a new instance of <see cref="MenuBarItemHandler"/>.</summary>
     public MenuBarItemHandler() : this(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="MenuBarItemHandler"/>.</summary>
+    /// <param name="mapper">The property mapper.</param>
+    /// <param name="commandMapper">The command mapper.</param>
     public MenuBarItemHandler(IPropertyMapper mapper, CommandMapper? commandMapper = null) : base(mapper, commandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformElement()
     {
         return new PlatformView();
     }
 
+    /// <summary>Maps the Text property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The menu bar item.</param>
     public static void MapText(MenuBarItemHandler handler, IMenuBarItem view)
     {
         if (handler is MenuBarItemHandler platformHandler)
             platformHandler.PlatformView.Header = view.Text;
     }
 
+    /// <summary>Maps the IsEnabled property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The menu bar item.</param>
     public static void MapIsEnabled(MenuBarItemHandler handler, IMenuBarItem view)
     {
         if (handler is MenuBarItemHandler platformHandler)
             platformHandler.PlatformView.IsEnabled = view.IsEnabled;
     }
 
+    /// <inheritdoc/>
     public override void SetVirtualView(IElement view)
     {
         base.SetVirtualView(view);
@@ -57,6 +72,10 @@ public partial class MenuBarItemHandler : ElementHandler<IMenuBarItem, PlatformV
         }
     }
 
+    /// <summary>Maps the Add command to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="layout">The menu bar item.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapAdd(MenuBarItemHandler handler, IMenuBarItem layout, object? arg)
     {
         if (arg is MenuBarItemHandlerUpdate args)
@@ -65,6 +84,10 @@ public partial class MenuBarItemHandler : ElementHandler<IMenuBarItem, PlatformV
         }
     }
 
+    /// <summary>Maps the Remove command to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="layout">The menu bar item.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapRemove(MenuBarItemHandler handler, IMenuBarItem layout, object? arg)
     {
         if (arg is MenuBarItemHandlerUpdate args)
@@ -73,6 +96,10 @@ public partial class MenuBarItemHandler : ElementHandler<IMenuBarItem, PlatformV
         }
     }
 
+    /// <summary>Maps the Insert command to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="layout">The menu bar item.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapInsert(MenuBarItemHandler handler, IMenuBarItem layout, object? arg)
     {
         if (arg is MenuBarItemHandlerUpdate args)
@@ -81,11 +108,17 @@ public partial class MenuBarItemHandler : ElementHandler<IMenuBarItem, PlatformV
         }
     }
 
+    /// <summary>Maps the Clear command to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="layout">The menu bar item.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapClear(MenuBarItemHandler handler, IMenuBarItem layout, object? arg)
     {
         handler.Clear();
     }
 
+    /// <summary>Adds a child element.</summary>
+    /// <param name="view">The menu element to add.</param>
     public void Add(IMenuElement view)
     {
         var platformView = view.ToPlatform(MauiContext!);
@@ -95,6 +128,8 @@ public partial class MenuBarItemHandler : ElementHandler<IMenuBarItem, PlatformV
         }
     }
 
+    /// <summary>Removes a child element.</summary>
+    /// <param name="view">The menu element to remove.</param>
     public void Remove(IMenuElement view)
     {
         if (view.Handler?.PlatformView is object platformView)
@@ -103,11 +138,15 @@ public partial class MenuBarItemHandler : ElementHandler<IMenuBarItem, PlatformV
         }
     }
 
+    /// <summary>Clears all child elements.</summary>
     public void Clear()
     {
         PlatformView.Items.Clear();
     }
 
+    /// <summary>Inserts a child element at the specified index.</summary>
+    /// <param name="index">The index at which to insert.</param>
+    /// <param name="view">The menu element to insert.</param>
     public void Insert(int index, IMenuElement view)
     {
         var platformView = view.ToPlatform(MauiContext!);
@@ -117,6 +156,7 @@ public partial class MenuBarItemHandler : ElementHandler<IMenuBarItem, PlatformV
         }
     }
 
+    /// <inheritdoc/>
     public override void OnDisconnectHandler(object platformView)
     {
         base.OnDisconnectHandler(platformView);

--- a/src/Avalonia.Controls.Maui/Handlers/MenuFlyoutHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/MenuFlyoutHandler.cs
@@ -5,12 +5,15 @@ using PlatformView = Avalonia.Controls.ContextMenu;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IMenuFlyout"/>.</summary>
 public partial class MenuFlyoutHandler : ElementHandler<IMenuFlyout, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="MenuFlyoutHandler"/>.</summary>
     public static IPropertyMapper<IMenuFlyout, MenuFlyoutHandler> Mapper = new PropertyMapper<IMenuFlyout, MenuFlyoutHandler>(ElementMapper)
     {
     };
 
+    /// <summary>Command mapper for <see cref="MenuFlyoutHandler"/>.</summary>
     public static CommandMapper<IMenuFlyout, MenuFlyoutHandler> CommandMapper = new(ElementCommandMapper)
     {
         [nameof(MenuFlyoutHandler.Add)] = MapAdd,
@@ -19,19 +22,25 @@ public partial class MenuFlyoutHandler : ElementHandler<IMenuFlyout, PlatformVie
         [nameof(MenuFlyoutHandler.Insert)] = MapInsert,
     };
 
+    /// <summary>Initializes a new instance of <see cref="MenuFlyoutHandler"/>.</summary>
     public MenuFlyoutHandler() : this(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="MenuFlyoutHandler"/>.</summary>
+    /// <param name="mapper">The property mapper.</param>
+    /// <param name="commandMapper">The command mapper.</param>
     public MenuFlyoutHandler(IPropertyMapper mapper, CommandMapper? commandMapper = null) : base(mapper, commandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformElement()
     {
         return new PlatformView();
     }
 
+    /// <inheritdoc/>
     public override void SetVirtualView(IElement view)
     {
         base.SetVirtualView(view);
@@ -43,6 +52,10 @@ public partial class MenuFlyoutHandler : ElementHandler<IMenuFlyout, PlatformVie
         }
     }
 
+    /// <summary>Maps the Add command to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="menuElement">The menu flyout.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapAdd(MenuFlyoutHandler handler, IMenuFlyout menuElement, object? arg)
     {
         if (arg is ContextFlyoutItemHandlerUpdate args)
@@ -51,6 +64,10 @@ public partial class MenuFlyoutHandler : ElementHandler<IMenuFlyout, PlatformVie
         }
     }
 
+    /// <summary>Maps the Remove command to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="menuElement">The menu flyout.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapRemove(MenuFlyoutHandler handler, IMenuFlyout menuElement, object? arg)
     {
         if (arg is ContextFlyoutItemHandlerUpdate args)
@@ -59,6 +76,10 @@ public partial class MenuFlyoutHandler : ElementHandler<IMenuFlyout, PlatformVie
         }
     }
 
+    /// <summary>Maps the Insert command to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="menuElement">The menu flyout.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapInsert(MenuFlyoutHandler handler, IMenuFlyout menuElement, object? arg)
     {
         if (arg is ContextFlyoutItemHandlerUpdate args)
@@ -67,11 +88,17 @@ public partial class MenuFlyoutHandler : ElementHandler<IMenuFlyout, PlatformVie
         }
     }
 
+    /// <summary>Maps the Clear command to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="menuElement">The menu flyout.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapClear(MenuFlyoutHandler handler, IMenuFlyout menuElement, object? arg)
     {
         handler.Clear();
     }
 
+    /// <summary>Adds a child element.</summary>
+    /// <param name="view">The menu element to add.</param>
     public void Add(IMenuElement view)
     {
         var platformView = view.ToPlatform(MauiContext!);
@@ -81,6 +108,8 @@ public partial class MenuFlyoutHandler : ElementHandler<IMenuFlyout, PlatformVie
         }
     }
 
+    /// <summary>Removes a child element.</summary>
+    /// <param name="view">The menu element to remove.</param>
     public void Remove(IMenuElement view)
     {
         if (view.Handler?.PlatformView is object platformView)
@@ -89,11 +118,15 @@ public partial class MenuFlyoutHandler : ElementHandler<IMenuFlyout, PlatformVie
         }
     }
 
+    /// <summary>Clears all child elements.</summary>
     public void Clear()
     {
         PlatformView.Items.Clear();
     }
 
+    /// <summary>Inserts a child element at the specified index.</summary>
+    /// <param name="index">The index at which to insert.</param>
+    /// <param name="view">The menu element to insert.</param>
     public void Insert(int index, IMenuElement view)
     {
         var platformView = view.ToPlatform(MauiContext!);
@@ -103,6 +136,7 @@ public partial class MenuFlyoutHandler : ElementHandler<IMenuFlyout, PlatformVie
         }
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         if (VirtualView is not null)

--- a/src/Avalonia.Controls.Maui/Handlers/MenuFlyoutItemHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/MenuFlyoutItemHandler.cs
@@ -10,8 +10,10 @@ using PlatformView = Avalonia.Controls.MenuItem;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IMenuFlyoutItem"/>.</summary>
 public partial class MenuFlyoutItemHandler : ElementHandler<IMenuFlyoutItem, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="MenuFlyoutItemHandler"/>.</summary>
     public static IPropertyMapper<IMenuFlyoutItem, MenuFlyoutItemHandler> Mapper = new PropertyMapper<IMenuFlyoutItem, MenuFlyoutItemHandler>(ElementMapper)
     {
         [nameof(IMenuFlyoutSubItem.Text)] = MapText,
@@ -20,25 +22,30 @@ public partial class MenuFlyoutItemHandler : ElementHandler<IMenuFlyoutItem, Pla
         [nameof(IMenuElement.IsEnabled)] = MapIsEnabled
     };
 
+    /// <summary>Command mapper for <see cref="MenuFlyoutItemHandler"/>.</summary>
     public static CommandMapper<IMenuFlyoutItem, MenuFlyoutItemHandler> CommandMapper = new(ElementCommandMapper)
     {
     };
 
+    /// <summary>Initializes a new instance of <see cref="MenuFlyoutItemHandler"/>.</summary>
     public MenuFlyoutItemHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformElement()
     {
         return new PlatformView();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         base.ConnectHandler(platformView);
         platformView.Click += OnClicked;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         base.DisconnectHandler(platformView);
@@ -50,15 +57,25 @@ public partial class MenuFlyoutItemHandler : ElementHandler<IMenuFlyoutItem, Pla
         VirtualView.Clicked();
     }
 
+    /// <summary>Maps the Text property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The menu flyout item.</param>
     public static void MapText(MenuFlyoutItemHandler handler, IMenuFlyoutItem view)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.Header = view.Text;
     }
 
+    /// <summary>Maps the Source property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The menu flyout item.</param>
     public static void MapSource(MenuFlyoutItemHandler handler, IMenuFlyoutItem view) =>
         MapSourceAsync(handler, view).FireAndForget(handler);
 
+    /// <summary>Asynchronously maps the Source property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The menu flyout item.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     public static async Task MapSourceAsync(MenuFlyoutItemHandler handler, IMenuFlyoutItem view)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -108,6 +125,9 @@ public partial class MenuFlyoutItemHandler : ElementHandler<IMenuFlyoutItem, Pla
         }
     }
 
+    /// <summary>Maps the KeyboardAccelerators property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The menu flyout item.</param>
     public static void MapKeyboardAccelerators(MenuFlyoutItemHandler handler, IMenuFlyoutItem view)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -178,6 +198,9 @@ public partial class MenuFlyoutItemHandler : ElementHandler<IMenuFlyoutItem, Pla
         return Avalonia.Input.Key.None;
     }
 
+    /// <summary>Maps the IsEnabled property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The menu flyout item.</param>
     public static void MapIsEnabled(MenuFlyoutItemHandler handler, IMenuFlyoutItem view)
     {
         if (handler.PlatformView is PlatformView platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/MenuFlyoutSeparatorHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/MenuFlyoutSeparatorHandler.cs
@@ -4,24 +4,32 @@ using PlatformView = Avalonia.Controls.Separator;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IMenuFlyoutSeparator"/>.</summary>
 public partial class MenuFlyoutSeparatorHandler : ElementHandler<IMenuFlyoutSeparator, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="MenuFlyoutSeparatorHandler"/>.</summary>
     public static IPropertyMapper<IMenuFlyoutSeparator, MenuFlyoutSeparatorHandler> Mapper = new PropertyMapper<IMenuFlyoutSeparator, MenuFlyoutSeparatorHandler>(ElementMapper)
     {
     };
 
+    /// <summary>Command mapper for <see cref="MenuFlyoutSeparatorHandler"/>.</summary>
     public static CommandMapper<IMenuFlyoutSeparator, MenuFlyoutSeparatorHandler> CommandMapper = new(ElementCommandMapper)
     {
     };
 
+    /// <summary>Initializes a new instance of <see cref="MenuFlyoutSeparatorHandler"/>.</summary>
     public MenuFlyoutSeparatorHandler() : this(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="MenuFlyoutSeparatorHandler"/>.</summary>
+    /// <param name="mapper">The property mapper.</param>
+    /// <param name="commandMapper">The command mapper.</param>
     public MenuFlyoutSeparatorHandler(IPropertyMapper mapper, CommandMapper? commandMapper = null) : base(mapper, commandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformElement()
     {
         return new PlatformView();

--- a/src/Avalonia.Controls.Maui/Handlers/MenuFlyoutSubItemHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/MenuFlyoutSubItemHandler.cs
@@ -10,8 +10,10 @@ using PlatformView = Avalonia.Controls.MenuItem;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IMenuFlyoutSubItem"/>.</summary>
 public partial class MenuFlyoutSubItemHandler : ElementHandler<IMenuFlyoutSubItem, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="MenuFlyoutSubItemHandler"/>.</summary>
     public static IPropertyMapper<IMenuFlyoutSubItem, MenuFlyoutSubItemHandler> Mapper = new PropertyMapper<IMenuFlyoutSubItem, MenuFlyoutSubItemHandler>(ElementMapper)
     {
         [nameof(IMenuFlyoutSubItem.Text)] = MapText,
@@ -20,6 +22,7 @@ public partial class MenuFlyoutSubItemHandler : ElementHandler<IMenuFlyoutSubIte
         [nameof(IMenuFlyoutSubItem.IsEnabled)] = MapIsEnabled,
     };
 
+    /// <summary>Command mapper for <see cref="MenuFlyoutSubItemHandler"/>.</summary>
     public static CommandMapper<IMenuFlyoutSubItem, MenuFlyoutSubItemHandler> CommandMapper = new(ElementCommandMapper)
     {
         [nameof(MenuFlyoutSubItemHandler.Add)] = MapAdd,
@@ -28,25 +31,32 @@ public partial class MenuFlyoutSubItemHandler : ElementHandler<IMenuFlyoutSubIte
         [nameof(MenuFlyoutSubItemHandler.Insert)] = MapInsert,
     };
 
+    /// <summary>Initializes a new instance of <see cref="MenuFlyoutSubItemHandler"/>.</summary>
     public MenuFlyoutSubItemHandler() : this(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="MenuFlyoutSubItemHandler"/>.</summary>
+    /// <param name="mapper">The property mapper.</param>
+    /// <param name="commandMapper">The command mapper.</param>
     public MenuFlyoutSubItemHandler(IPropertyMapper mapper, CommandMapper? commandMapper = null) : base(mapper, commandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformElement()
     {
         return new PlatformView();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         base.ConnectHandler(platformView);
         platformView.Click += OnClicked;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         if (VirtualView is not null)
@@ -66,15 +76,25 @@ public partial class MenuFlyoutSubItemHandler : ElementHandler<IMenuFlyoutSubIte
         VirtualView.Clicked();
     }
 
+    /// <summary>Maps the Text property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The menu flyout sub-item.</param>
     public static void MapText(MenuFlyoutSubItemHandler handler, IMenuFlyoutSubItem view)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.Header = view.Text;
     }
 
+    /// <summary>Maps the Source property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The menu flyout sub-item.</param>
     public static void MapSource(MenuFlyoutSubItemHandler handler, IMenuFlyoutSubItem view) =>
         MapSourceAsync(handler, view).FireAndForget(handler);
 
+    /// <summary>Asynchronously maps the Source property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The menu flyout sub-item.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     public static async Task MapSourceAsync(MenuFlyoutSubItemHandler handler, IMenuFlyoutSubItem view)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -124,6 +144,9 @@ public partial class MenuFlyoutSubItemHandler : ElementHandler<IMenuFlyoutSubIte
         }
     }
 
+    /// <summary>Maps the KeyboardAccelerators property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The menu flyout sub-item.</param>
     public static void MapKeyboardAccelerators(MenuFlyoutSubItemHandler handler, IMenuFlyoutSubItem view)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -194,12 +217,16 @@ public partial class MenuFlyoutSubItemHandler : ElementHandler<IMenuFlyoutSubIte
         return Avalonia.Input.Key.None;
     }
 
+    /// <summary>Maps the IsEnabled property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The menu flyout sub-item.</param>
     public static void MapIsEnabled(MenuFlyoutSubItemHandler handler, IMenuFlyoutSubItem view)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.IsEnabled = view.IsEnabled;
     }
 
+    /// <inheritdoc/>
     public override void SetVirtualView(IElement view)
     {
         base.SetVirtualView(view);
@@ -211,6 +238,10 @@ public partial class MenuFlyoutSubItemHandler : ElementHandler<IMenuFlyoutSubIte
         }
     }
 
+    /// <summary>Maps the Add command to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="layout">The menu element.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapAdd(MenuFlyoutSubItemHandler handler, IMenuElement layout, object? arg)
     {
         if (arg is MenuFlyoutSubItemHandlerUpdate args)
@@ -219,6 +250,10 @@ public partial class MenuFlyoutSubItemHandler : ElementHandler<IMenuFlyoutSubIte
         }
     }
 
+    /// <summary>Maps the Remove command to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="layout">The menu element.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapRemove(MenuFlyoutSubItemHandler handler, IMenuElement layout, object? arg)
     {
         if (arg is MenuFlyoutSubItemHandlerUpdate args)
@@ -227,6 +262,10 @@ public partial class MenuFlyoutSubItemHandler : ElementHandler<IMenuFlyoutSubIte
         }
     }
 
+    /// <summary>Maps the Insert command to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="layout">The menu element.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapInsert(MenuFlyoutSubItemHandler handler, IMenuElement layout, object? arg)
     {
         if (arg is MenuFlyoutSubItemHandlerUpdate args)
@@ -235,11 +274,17 @@ public partial class MenuFlyoutSubItemHandler : ElementHandler<IMenuFlyoutSubIte
         }
     }
 
+    /// <summary>Maps the Clear command to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="layout">The menu element.</param>
+    /// <param name="arg">The command argument.</param>
     public static void MapClear(MenuFlyoutSubItemHandler handler, IMenuElement layout, object? arg)
     {
         handler.Clear();
     }
 
+    /// <summary>Adds a child element.</summary>
+    /// <param name="view">The menu element to add.</param>
     public void Add(IMenuElement view)
     {
         var platformView = view.ToPlatform(MauiContext!);
@@ -249,6 +294,8 @@ public partial class MenuFlyoutSubItemHandler : ElementHandler<IMenuFlyoutSubIte
         }
     }
 
+    /// <summary>Removes a child element.</summary>
+    /// <param name="view">The menu element to remove.</param>
     public void Remove(IMenuElement view)
     {
         if (view.Handler?.PlatformView is object platformView)
@@ -257,11 +304,15 @@ public partial class MenuFlyoutSubItemHandler : ElementHandler<IMenuFlyoutSubIte
         }
     }
 
+    /// <summary>Clears all child elements.</summary>
     public void Clear()
     {
         PlatformView.Items.Clear();
     }
 
+    /// <summary>Inserts a child element at the specified index.</summary>
+    /// <param name="index">The index at which to insert.</param>
+    /// <param name="view">The menu element to insert.</param>
     public void Insert(int index, IMenuElement view)
     {
         var platformView = view.ToPlatform(MauiContext!);

--- a/src/Avalonia.Controls.Maui/Handlers/NavigationViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/NavigationViewHandler.cs
@@ -6,35 +6,40 @@ using Microsoft.Maui;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-/// <summary>
-/// Handler for MAUI NavigationPage that uses Avalonia's TransitioningContentControl
-/// to provide animated page navigation.
-/// </summary>
+/// <summary>Avalonia handler for <see cref="IStackNavigationView"/>.</summary>
 public partial class NavigationViewHandler : ViewHandler<IStackNavigationView, NavigationView>
 {
     private StackNavigationManager? _navigationManager;
     private ILogger<NavigationViewHandler>? _logger;
 
+    /// <summary>Property mapper for <see cref="NavigationViewHandler"/>.</summary>
     public static IPropertyMapper<IStackNavigationView, NavigationViewHandler> Mapper =
         new PropertyMapper<IStackNavigationView, NavigationViewHandler>(ViewMapper)
         {
         };
 
+    /// <summary>Command mapper for <see cref="NavigationViewHandler"/>.</summary>
     public static CommandMapper<IStackNavigationView, NavigationViewHandler> CommandMapper =
         new(ViewCommandMapper)
         {
             [nameof(IStackNavigation.RequestNavigation)] = RequestNavigation
         };
 
+    /// <summary>Initializes a new instance of <see cref="NavigationViewHandler"/>.</summary>
     public NavigationViewHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="NavigationViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public NavigationViewHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="NavigationViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public NavigationViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
@@ -43,6 +48,7 @@ public partial class NavigationViewHandler : ViewHandler<IStackNavigationView, N
     ILogger? Logger =>
         _logger ??= MauiContext?.Services?.GetService<ILoggerFactory>()?.CreateLogger<NavigationViewHandler>();
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override NavigationView CreatePlatformView()
     {
         _navigationManager = CreateNavigationManager();
@@ -62,6 +68,7 @@ public partial class NavigationViewHandler : ViewHandler<IStackNavigationView, N
         return view;
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(NavigationView platformView)
     {
         base.ConnectHandler(platformView);
@@ -80,6 +87,7 @@ public partial class NavigationViewHandler : ViewHandler<IStackNavigationView, N
         Logger?.LogDebug("Connected NavigationViewHandler");
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(NavigationView platformView)
     {
         _navigationManager?.Disconnect(VirtualView, platformView);
@@ -87,6 +95,7 @@ public partial class NavigationViewHandler : ViewHandler<IStackNavigationView, N
         Logger?.LogDebug("Disconnected NavigationViewHandler");
     }
 
+    /// <inheritdoc/>
     public override void SetVirtualView(IView view)
     {
         base.SetVirtualView(view);
@@ -97,9 +106,10 @@ public partial class NavigationViewHandler : ViewHandler<IStackNavigationView, N
         PlatformView.CrossPlatformLayout = VirtualView;
     }
 
-    /// <summary>
-    /// Handles navigation requests from the virtual view.
-    /// </summary>
+    /// <summary>Maps the RequestNavigation command to the platform view.</summary>
+    /// <param name="handler">The handler for the navigation view.</param>
+    /// <param name="stackNavigation">The stack navigation interface.</param>
+    /// <param name="args">The navigation request arguments.</param>
     public static void RequestNavigation(NavigationViewHandler handler, IStackNavigation stackNavigation, object? args)
     {
         if (handler is NavigationViewHandler platformHandler && args is NavigationRequest navigationRequest)

--- a/src/Avalonia.Controls.Maui/Handlers/PageHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/PageHandler.cs
@@ -4,8 +4,14 @@ using AvaloniaPanel = Avalonia.Controls.Panel;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>
+/// Avalonia handler for <see cref="Microsoft.Maui.Controls.Page"/>.
+/// </summary>
 public partial class PageHandler : ViewHandler<Microsoft.Maui.Controls.Page, Avalonia.Controls.Maui.Platform.ContentView>
 {
+    /// <summary>
+    /// Property mapper for <see cref="PageHandler"/>.
+    /// </summary>
     public static IPropertyMapper<Microsoft.Maui.Controls.Page, PageHandler> Mapper =
         new PropertyMapper<Microsoft.Maui.Controls.Page, PageHandler>(ViewMapper)
         {
@@ -15,23 +21,42 @@ public partial class PageHandler : ViewHandler<Microsoft.Maui.Controls.Page, Ava
             [nameof(Microsoft.Maui.Controls.ContentPage.Content)] = MapContent,
         };
 
+    /// <summary>
+    /// Command mapper for <see cref="PageHandler"/>.
+    /// </summary>
     public static CommandMapper<Microsoft.Maui.Controls.Page, PageHandler> CommandMapper =
         new(ViewCommandMapper);
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="PageHandler"/>.
+    /// </summary>
     public PageHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="PageHandler"/>.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
     public PageHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="PageHandler"/>.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
+    /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
     public PageHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Creates the Avalonia platform view for this handler.
+    /// </summary>
+    /// <returns>A new <see cref="Platform.ContentView"/> instance configured with cross-platform layout.</returns>
     protected override Platform.ContentView CreatePlatformView()
     {
         return new Platform.ContentView
@@ -40,6 +65,7 @@ public partial class PageHandler : ViewHandler<Microsoft.Maui.Controls.Page, Ava
         };
     }
 
+    /// <inheritdoc/>
     public override void SetVirtualView(IView view)
     {
         base.SetVirtualView(view);
@@ -50,6 +76,11 @@ public partial class PageHandler : ViewHandler<Microsoft.Maui.Controls.Page, Ava
         }
     }
 
+    /// <summary>
+    /// Maps the <see cref="Microsoft.Maui.Controls.ContentPage.Content"/> property to the platform view.
+    /// </summary>
+    /// <param name="handler">The associated handler.</param>
+    /// <param name="page">The associated <see cref="Microsoft.Maui.Controls.Page"/> instance.</param>
     public static void MapContent(PageHandler handler, Microsoft.Maui.Controls.Page page)
     {
         if (handler.PlatformView is Platform.ContentView platformView &&
@@ -59,12 +90,22 @@ public partial class PageHandler : ViewHandler<Microsoft.Maui.Controls.Page, Ava
         }
     }
 
+    /// <summary>
+    /// Maps the Background property to the platform view.
+    /// </summary>
+    /// <param name="handler">The associated handler.</param>
+    /// <param name="page">The associated <see cref="Microsoft.Maui.Controls.Page"/> instance.</param>
     public static void MapBackground(PageHandler handler, Microsoft.Maui.Controls.Page page)
     {
         var platformView = (AvaloniaPanel)handler.PlatformView;
         platformView?.UpdateBackground(page);
     }
 
+    /// <summary>
+    /// Maps the <see cref="Microsoft.Maui.Controls.Page.BackgroundImageSource"/> property to the platform view.
+    /// </summary>
+    /// <param name="handler">The associated handler.</param>
+    /// <param name="page">The associated <see cref="Microsoft.Maui.Controls.Page"/> instance.</param>
     public static void MapBackgroundImageSource(PageHandler handler, Microsoft.Maui.Controls.Page page)
     {
         var platformView = (AvaloniaPanel)handler.PlatformView;

--- a/src/Avalonia.Controls.Maui/Handlers/PickerHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/PickerHandler.cs
@@ -4,10 +4,12 @@ using PlatformView = System.Object;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IPicker"/>.</summary>
 public partial class PickerHandler : ViewHandler<IPicker, MauiComboBox>
 {
     bool _isUpdatingSelection;
 
+    /// <summary>Property mapper for <see cref="PickerHandler"/>.</summary>
     public static IPropertyMapper<IPicker, PickerHandler> Mapper = new PropertyMapper<IPicker, PickerHandler>(ViewMapper)
     {
         [nameof(IPicker.CharacterSpacing)] = MapCharacterSpacing,
@@ -21,6 +23,9 @@ public partial class PickerHandler : ViewHandler<IPicker, MauiComboBox>
         [nameof(ITextAlignment.VerticalTextAlignment)] = MapVerticalTextAlignment,
     };
 
+    /// <summary>Maps the Items property to the platform view.</summary>
+    /// <param name="handler">The handler for the picker.</param>
+    /// <param name="picker">The virtual view.</param>
     public static void MapItems(PickerHandler handler, IPicker picker)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -38,6 +43,9 @@ public partial class PickerHandler : ViewHandler<IPicker, MauiComboBox>
         }
     }
 
+    /// <summary>Maps the VerticalTextAlignment property to the platform view.</summary>
+    /// <param name="handler">The handler for the picker.</param>
+    /// <param name="picker">The virtual view.</param>
     public static void MapVerticalTextAlignment(PickerHandler handler, IPicker picker)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -45,6 +53,9 @@ public partial class PickerHandler : ViewHandler<IPicker, MauiComboBox>
         handler.PlatformView.UpdateVerticalTextAlignment(handler.VirtualView);
     }
 
+    /// <summary>Maps the HorizontalTextAlignment property to the platform view.</summary>
+    /// <param name="handler">The handler for the picker.</param>
+    /// <param name="picker">The virtual view.</param>
     public static void MapHorizontalTextAlignment(PickerHandler handler, IPicker picker)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -52,6 +63,9 @@ public partial class PickerHandler : ViewHandler<IPicker, MauiComboBox>
         handler.PlatformView.UpdateHorizontalTextAlignment(handler.VirtualView);
     }
 
+    /// <summary>Maps the TitleColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the picker.</param>
+    /// <param name="picker">The virtual view.</param>
     public static void MapTitleColor(PickerHandler handler, IPicker picker)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -59,6 +73,9 @@ public partial class PickerHandler : ViewHandler<IPicker, MauiComboBox>
         handler.PlatformView.UpdateTitleColor(handler.VirtualView);
     }
 
+    /// <summary>Maps the Title property to the platform view.</summary>
+    /// <param name="handler">The handler for the picker.</param>
+    /// <param name="picker">The virtual view.</param>
     public static void MapTitle(PickerHandler handler, IPicker picker)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -66,6 +83,9 @@ public partial class PickerHandler : ViewHandler<IPicker, MauiComboBox>
         handler.PlatformView.UpdateTitle(handler.VirtualView);
     }
 
+    /// <summary>Maps the TextColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the picker.</param>
+    /// <param name="picker">The virtual view.</param>
     public static void MapTextColor(PickerHandler handler, IPicker picker)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -73,6 +93,9 @@ public partial class PickerHandler : ViewHandler<IPicker, MauiComboBox>
         handler.PlatformView.UpdateTextColor(handler.VirtualView);
     }
 
+    /// <summary>Maps the SelectedIndex property to the platform view.</summary>
+    /// <param name="handler">The handler for the picker.</param>
+    /// <param name="picker">The virtual view.</param>
     public static void MapSelectedIndex(PickerHandler handler, IPicker picker)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -88,6 +111,9 @@ public partial class PickerHandler : ViewHandler<IPicker, MauiComboBox>
         }
     }
 
+    /// <summary>Maps the Font property to the platform view.</summary>
+    /// <param name="handler">The handler for the picker.</param>
+    /// <param name="picker">The virtual view.</param>
     public static void MapFont(PickerHandler handler, IPicker picker)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -97,6 +123,9 @@ public partial class PickerHandler : ViewHandler<IPicker, MauiComboBox>
         handler.PlatformView.UpdateCharacterSpacing(handler.VirtualView);
     }
 
+    /// <summary>Maps the CharacterSpacing property to the platform view.</summary>
+    /// <param name="handler">The handler for the picker.</param>
+    /// <param name="picker">The virtual view.</param>
     public static void MapCharacterSpacing(PickerHandler handler, IPicker picker)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -104,29 +133,38 @@ public partial class PickerHandler : ViewHandler<IPicker, MauiComboBox>
         handler.PlatformView.UpdateCharacterSpacing(handler.VirtualView);
     }
 
+    /// <summary>Command mapper for <see cref="PickerHandler"/>.</summary>
     public static CommandMapper<IPicker, PickerHandler> CommandMapper = new(ViewCommandMapper)
     {
     };
 
+    /// <summary>Initializes a new instance of <see cref="PickerHandler"/>.</summary>
     public PickerHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="PickerHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
     public PickerHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="PickerHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
+    /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
     public PickerHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override MauiComboBox CreatePlatformView()
     {
         return new MauiComboBox();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(MauiComboBox platformView)
     {
         base.ConnectHandler(platformView);
@@ -149,6 +187,7 @@ public partial class PickerHandler : ViewHandler<IPicker, MauiComboBox>
         }
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(MauiComboBox platformView)
     {
         platformView.DropDownOpened -= OnDropDownOpened;

--- a/src/Avalonia.Controls.Maui/Handlers/ProgressBarHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ProgressBarHandler.cs
@@ -5,35 +5,42 @@ using AvaloniaProgressBar = global::Avalonia.Controls.ProgressBar;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-/// <summary>
-/// Handler for MAUI IProgress to Avalonia ProgressBar mapping
-/// </summary>
+/// <summary>Avalonia handler for <see cref="Microsoft.Maui.IProgress"/>.</summary>
 public class ProgressBarHandler : ViewHandler<Microsoft.Maui.IProgress, AvaloniaProgressBar>
 {
+    /// <summary>Property mapper for <see cref="ProgressBarHandler"/>.</summary>
     public static IPropertyMapper<Microsoft.Maui.IProgress, ProgressBarHandler> Mapper = new PropertyMapper<Microsoft.Maui.IProgress, ProgressBarHandler>(ViewHandler.ViewMapper)
     {
         [nameof(Microsoft.Maui.IProgress.Progress)] = MapProgress,
         [nameof(Microsoft.Maui.IProgress.ProgressColor)] = MapProgressColor
     };
 
+    /// <summary>Command mapper for <see cref="ProgressBarHandler"/>.</summary>
     public static CommandMapper<Microsoft.Maui.IProgress, ProgressBarHandler> CommandMapper = new(ViewCommandMapper)
     {
     };
 
+    /// <summary>Initializes a new instance of <see cref="ProgressBarHandler"/>.</summary>
     public ProgressBarHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="ProgressBarHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public ProgressBarHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="ProgressBarHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public ProgressBarHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override AvaloniaProgressBar CreatePlatformView()
     {
         return new AvaloniaProgressBar
@@ -43,8 +50,12 @@ public class ProgressBarHandler : ViewHandler<Microsoft.Maui.IProgress, Avalonia
         };
     }
 
+    /// <summary>Gets a value indicating whether this handler requires a container view.</summary>
     public override bool NeedsContainer => false;
 
+    /// <summary>Maps the Progress property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="progress">The virtual view.</param>
     public static void MapProgress(ProgressBarHandler handler, Microsoft.Maui.IProgress progress)
     {
         if (handler.PlatformView is AvaloniaProgressBar platformView)
@@ -53,6 +64,9 @@ public class ProgressBarHandler : ViewHandler<Microsoft.Maui.IProgress, Avalonia
         }
     }
 
+    /// <summary>Maps the ProgressColor property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="progress">The virtual view.</param>
     public static void MapProgressColor(ProgressBarHandler handler, Microsoft.Maui.IProgress progress)
     {
         if (handler.PlatformView is AvaloniaProgressBar platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/RadioButtonHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/RadioButtonHandler.cs
@@ -4,8 +4,10 @@ using PlatformView = Avalonia.Controls.Maui.MauiRadioButton;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IRadioButton"/>.</summary>
 public class RadioButtonHandler : ViewHandler<IRadioButton, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="RadioButtonHandler"/>.</summary>
     public static IPropertyMapper<IRadioButton, RadioButtonHandler> Mapper = new PropertyMapper<IRadioButton, RadioButtonHandler>(ViewHandler.ViewMapper)
     {
         [nameof(IRadioButton.IsChecked)] = MapIsChecked,
@@ -23,43 +25,57 @@ public class RadioButtonHandler : ViewHandler<IRadioButton, PlatformView>
         ["Value"] = MapValue,
     };
 
+    /// <summary>Command mapper for <see cref="RadioButtonHandler"/>.</summary>
     public static CommandMapper<IRadioButton, RadioButtonHandler> CommandMapper = new(ViewCommandMapper)
     {
     };
 
+    /// <summary>Initializes a new instance of <see cref="RadioButtonHandler"/>.</summary>
     public RadioButtonHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="RadioButtonHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
     public RadioButtonHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="RadioButtonHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
+    /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
     public RadioButtonHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <summary>Gets a value indicating whether this handler requires a container view.</summary>
     public override bool NeedsContainer => false;
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         platformView.IsCheckedChanged += OnIsCheckedChanged;
         base.ConnectHandler(platformView);
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         platformView.IsCheckedChanged -= OnIsCheckedChanged;
         base.DisconnectHandler(platformView);
     }
 
+    /// <summary>Maps the IsChecked property to the platform view.</summary>
+    /// <param name="handler">The handler for the radio button.</param>
+    /// <param name="radioButton">The virtual view.</param>
     public static void MapIsChecked(RadioButtonHandler handler, IRadioButton radioButton)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -68,6 +84,9 @@ public class RadioButtonHandler : ViewHandler<IRadioButton, PlatformView>
         ((PlatformView)handler.PlatformView).UpdateIsChecked(radioButton);
     }
 
+    /// <summary>Maps the Content property to the platform view.</summary>
+    /// <param name="handler">The handler for the radio button.</param>
+    /// <param name="radioButton">The virtual view.</param>
     public static void MapContent(RadioButtonHandler handler, IRadioButton radioButton)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -76,6 +95,9 @@ public class RadioButtonHandler : ViewHandler<IRadioButton, PlatformView>
         RadioButtonExtensions.UpdateContent((PlatformView)handler.PlatformView, handler, radioButton);
     }
 
+    /// <summary>Maps the StrokeColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the radio button.</param>
+    /// <param name="radioButton">The virtual view.</param>
     public static void MapStrokeColor(RadioButtonHandler handler, IRadioButton radioButton)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -84,6 +106,9 @@ public class RadioButtonHandler : ViewHandler<IRadioButton, PlatformView>
         ((PlatformView)handler.PlatformView).UpdateStrokeColor(radioButton);
     }
 
+    /// <summary>Maps the StrokeThickness property to the platform view.</summary>
+    /// <param name="handler">The handler for the radio button.</param>
+    /// <param name="radioButton">The virtual view.</param>
     public static void MapStrokeThickness(RadioButtonHandler handler, IRadioButton radioButton)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -92,6 +117,9 @@ public class RadioButtonHandler : ViewHandler<IRadioButton, PlatformView>
         ((PlatformView)handler.PlatformView).UpdateStrokeThickness(radioButton);
     }
 
+    /// <summary>Maps the CornerRadius property to the platform view.</summary>
+    /// <param name="handler">The handler for the radio button.</param>
+    /// <param name="radioButton">The virtual view.</param>
     public static void MapCornerRadius(RadioButtonHandler handler, IRadioButton radioButton)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -100,6 +128,9 @@ public class RadioButtonHandler : ViewHandler<IRadioButton, PlatformView>
         ((PlatformView)handler.PlatformView).UpdateCornerRadius(radioButton);
     }
 
+    /// <summary>Maps the CharacterSpacing property to the platform view.</summary>
+    /// <param name="handler">The handler for the radio button.</param>
+    /// <param name="radioButton">The virtual view.</param>
     public static void MapCharacterSpacing(RadioButtonHandler handler, IRadioButton radioButton)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -108,6 +139,9 @@ public class RadioButtonHandler : ViewHandler<IRadioButton, PlatformView>
         ((PlatformView)handler.PlatformView).UpdateCharacterSpacing(radioButton);
     }
 
+    /// <summary>Maps the Font property to the platform view.</summary>
+    /// <param name="handler">The handler for the radio button.</param>
+    /// <param name="radioButton">The virtual view.</param>
     public static void MapFont(RadioButtonHandler handler, IRadioButton radioButton)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -117,6 +151,9 @@ public class RadioButtonHandler : ViewHandler<IRadioButton, PlatformView>
         ((PlatformView)handler.PlatformView).UpdateFont(radioButton, fontManager);
     }
 
+    /// <summary>Maps the TextColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the radio button.</param>
+    /// <param name="radioButton">The virtual view.</param>
     public static void MapTextColor(RadioButtonHandler handler, IRadioButton radioButton)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -125,6 +162,9 @@ public class RadioButtonHandler : ViewHandler<IRadioButton, PlatformView>
         ((PlatformView)handler.PlatformView).UpdateTextColor(radioButton);
     }
 
+    /// <summary>Maps the GroupName property to the platform view.</summary>
+    /// <param name="handler">The handler for the radio button.</param>
+    /// <param name="radioButton">The virtual view.</param>
     public static void MapGroupName(RadioButtonHandler handler, IRadioButton radioButton)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)
@@ -133,6 +173,9 @@ public class RadioButtonHandler : ViewHandler<IRadioButton, PlatformView>
         ((PlatformView)handler.PlatformView).UpdateGroupName(radioButton);
     }
 
+    /// <summary>Maps the Value property to the platform view.</summary>
+    /// <param name="handler">The handler for the radio button.</param>
+    /// <param name="radioButton">The virtual view.</param>
     public static void MapValue(RadioButtonHandler handler, IRadioButton radioButton)
     {
         if (handler.PlatformView is null || handler.VirtualView is null)

--- a/src/Avalonia.Controls.Maui/Handlers/RefreshViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/RefreshViewHandler.cs
@@ -6,11 +6,13 @@ using PlatformView = Avalonia.Controls.RefreshContainer;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IRefreshView"/>.</summary>
 public partial class RefreshViewHandler : ViewHandler<IRefreshView, PlatformView>
 {
     private RefreshCompletionDeferral? _currentRefreshDeferral;
     private bool _isSettingRefreshingFromCode;
 
+    /// <summary>Property mapper for <see cref="RefreshViewHandler"/>.</summary>
     public static IPropertyMapper<IRefreshView, RefreshViewHandler> Mapper = new PropertyMapper<IRefreshView, RefreshViewHandler>(ViewHandler.ViewMapper)
     {
         [nameof(IRefreshView.IsRefreshing)] = MapIsRefreshing,
@@ -20,29 +22,38 @@ public partial class RefreshViewHandler : ViewHandler<IRefreshView, PlatformView
         [nameof(IView.IsEnabled)] = MapIsEnabled,
     };
 
+    /// <summary>Command mapper for <see cref="RefreshViewHandler"/>.</summary>
     public static CommandMapper<IRefreshView, RefreshViewHandler> CommandMapper = new(ViewHandler.ViewCommandMapper)
     {
     };
 
+    /// <summary>Initializes a new instance of <see cref="RefreshViewHandler"/>.</summary>
     public RefreshViewHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="RefreshViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public RefreshViewHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
-    
+
+    /// <summary>Initializes a new instance of <see cref="RefreshViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public RefreshViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         base.ConnectHandler(platformView);
@@ -54,7 +65,8 @@ public partial class RefreshViewHandler : ViewHandler<IRefreshView, PlatformView
             platformView.Visualizer.TemplateApplied += OnVisualizerTemplateApplied;
         }
     }
-    
+
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         platformView.RefreshRequested -= OnRefreshRequested;
@@ -108,7 +120,7 @@ public partial class RefreshViewHandler : ViewHandler<IRefreshView, PlatformView
 
         VirtualView.IsRefreshing = true;
     }
-    
+
     internal void UpdateIsRefreshingState()
     {
         if (PlatformView == null || VirtualView == null)
@@ -135,11 +147,17 @@ public partial class RefreshViewHandler : ViewHandler<IRefreshView, PlatformView
         }
     }
 
+    /// <summary>Maps the IsRefreshing property to the platform view.</summary>
+    /// <param name="handler">The handler for the refresh view.</param>
+    /// <param name="refreshView">The virtual refresh view.</param>
     public static void MapIsRefreshing(RefreshViewHandler handler, IRefreshView refreshView)
     {
         handler.UpdateIsRefreshingState();
     }
-    
+
+    /// <summary>Maps the Content property to the platform view.</summary>
+    /// <param name="handler">The handler for the refresh view.</param>
+    /// <param name="refreshView">The virtual refresh view.</param>
     public static void MapContent(RefreshViewHandler handler, IRefreshView refreshView)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -147,7 +165,10 @@ public partial class RefreshViewHandler : ViewHandler<IRefreshView, PlatformView
 
         platformView.UpdateContent(refreshView, handler.MauiContext);
     }
-    
+
+    /// <summary>Maps the RefreshColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the refresh view.</param>
+    /// <param name="refreshView">The virtual refresh view.</param>
     public static void MapRefreshColor(RefreshViewHandler handler, IRefreshView refreshView)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -156,6 +177,9 @@ public partial class RefreshViewHandler : ViewHandler<IRefreshView, PlatformView
         platformView.UpdateRefreshColor(refreshView);
     }
 
+    /// <summary>Maps the Background property to the platform view.</summary>
+    /// <param name="handler">The handler for the refresh view.</param>
+    /// <param name="refreshView">The virtual refresh view.</param>
     public static void MapBackground(RefreshViewHandler handler, IRefreshView refreshView)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -164,6 +188,9 @@ public partial class RefreshViewHandler : ViewHandler<IRefreshView, PlatformView
         platformView.UpdateBackground(refreshView);
     }
 
+    /// <summary>Maps the IsEnabled property to the platform view.</summary>
+    /// <param name="handler">The handler for the refresh view.</param>
+    /// <param name="refreshView">The virtual refresh view.</param>
     public static void MapIsEnabled(RefreshViewHandler handler, IRefreshView refreshView)
     {
         if (handler.PlatformView is not PlatformView platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/ScrollViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ScrollViewHandler.cs
@@ -4,10 +4,12 @@ using GraphicsSize = Microsoft.Maui.Graphics.Size;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IScrollView"/>.</summary>
 public partial class ScrollViewHandler : ViewHandler<IScrollView, ScrollViewer>
 {
     private EventHandler<ScrollChangedEventArgs>? _scrollChangedHandler;
 
+    /// <summary>Property mapper for <see cref="ScrollViewHandler"/>.</summary>
     public static IPropertyMapper<IScrollView, ScrollViewHandler> Mapper = new PropertyMapper<IScrollView, ScrollViewHandler>(ViewMapper)
     {
         [nameof(IScrollView.Content)] = MapContent,
@@ -16,31 +18,40 @@ public partial class ScrollViewHandler : ViewHandler<IScrollView, ScrollViewer>
         [nameof(IScrollView.Orientation)] = MapOrientation,
     };
 
+    /// <summary>Command mapper for <see cref="ScrollViewHandler"/>.</summary>
     public static CommandMapper<IScrollView, ScrollViewHandler> CommandMapper = new(ViewCommandMapper)
     {
         [nameof(IScrollView.RequestScrollTo)] = MapRequestScrollTo,
     };
 
+    /// <summary>Initializes a new instance of <see cref="ScrollViewHandler"/>.</summary>
     public ScrollViewHandler() : base(Mapper, CommandMapper)
     {
 
     }
 
+    /// <summary>Initializes a new instance of <see cref="ScrollViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public ScrollViewHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="ScrollViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public ScrollViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override ScrollViewer CreatePlatformView()
     {
         return new ScrollViewer();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(ScrollViewer platformView)
     {
         base.ConnectHandler(platformView);
@@ -48,6 +59,7 @@ public partial class ScrollViewHandler : ViewHandler<IScrollView, ScrollViewer>
         platformView.ScrollChanged += _scrollChangedHandler;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(ScrollViewer platformView)
     {
         base.DisconnectHandler(platformView);
@@ -68,6 +80,9 @@ public partial class ScrollViewHandler : ViewHandler<IScrollView, ScrollViewer>
         }
     }
 
+    /// <summary>Maps the Content property to the platform view.</summary>
+    /// <param name="handler">The handler for the scroll view.</param>
+    /// <param name="scrollView">The virtual scroll view.</param>
     public static void MapContent(ScrollViewHandler handler, IScrollView scrollView)
     {
         if (handler.PlatformView is ScrollViewer platformView)
@@ -77,6 +92,9 @@ public partial class ScrollViewHandler : ViewHandler<IScrollView, ScrollViewer>
         }
     }
 
+    /// <summary>Maps the HorizontalScrollBarVisibility property to the platform view.</summary>
+    /// <param name="handler">The handler for the scroll view.</param>
+    /// <param name="scrollView">The virtual scroll view.</param>
     public static void MapHorizontalScrollBarVisibility(ScrollViewHandler handler, IScrollView scrollView)
     {
         if (handler.PlatformView is ScrollViewer platformView)
@@ -86,6 +104,9 @@ public partial class ScrollViewHandler : ViewHandler<IScrollView, ScrollViewer>
         }
     }
 
+    /// <summary>Maps the VerticalScrollBarVisibility property to the platform view.</summary>
+    /// <param name="handler">The handler for the scroll view.</param>
+    /// <param name="scrollView">The virtual scroll view.</param>
     public static void MapVerticalScrollBarVisibility(ScrollViewHandler handler, IScrollView scrollView)
     {
         if (handler.PlatformView is ScrollViewer platformView)
@@ -95,6 +116,9 @@ public partial class ScrollViewHandler : ViewHandler<IScrollView, ScrollViewer>
         }
     }
 
+    /// <summary>Maps the Orientation property to the platform view.</summary>
+    /// <param name="handler">The handler for the scroll view.</param>
+    /// <param name="scrollView">The virtual scroll view.</param>
     public static void MapOrientation(ScrollViewHandler handler, IScrollView scrollView)
     {
         if (handler.PlatformView is ScrollViewer platformView)
@@ -104,6 +128,10 @@ public partial class ScrollViewHandler : ViewHandler<IScrollView, ScrollViewer>
         }
     }
 
+    /// <summary>Maps the RequestScrollTo command to the platform view.</summary>
+    /// <param name="handler">The handler for the scroll view.</param>
+    /// <param name="scrollView">The virtual scroll view.</param>
+    /// <param name="args">The scroll-to request arguments.</param>
     public static void MapRequestScrollTo(ScrollViewHandler handler, IScrollView scrollView, object? args)
     {
         if (args is not ScrollToRequest request)
@@ -151,7 +179,7 @@ public partial class ScrollViewHandler : ViewHandler<IScrollView, ScrollViewer>
     {
         TrySetScrollPosition(scrollView, request.HorizontalOffset, request.VerticalOffset);
     }
-    
+
     private static void TrySetScrollPosition(IScrollView scrollView, double scrollX, double scrollY)
     {
         // Updates the ScrollX and ScrollY properties on the ScrollView using reflection.

--- a/src/Avalonia.Controls.Maui/Handlers/SearchBarHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/SearchBarHandler.cs
@@ -5,8 +5,10 @@ using PlatformView = Avalonia.Controls.Maui.Controls.MauiSearchBar;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="ISearchBar"/>.</summary>
 public partial class SearchBarHandler : ViewHandler<ISearchBar, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="SearchBarHandler"/>.</summary>
     public static IPropertyMapper<ISearchBar, SearchBarHandler> Mapper =
         new PropertyMapper<ISearchBar, SearchBarHandler>(ViewHandler.ViewMapper)
         {
@@ -26,33 +28,43 @@ public partial class SearchBarHandler : ViewHandler<ISearchBar, PlatformView>
             ["SearchIconColor"] = MapSearchIconColor,
         };
 
+    /// <summary>Command mapper for <see cref="SearchBarHandler"/>.</summary>
     public static CommandMapper<ISearchBar, SearchBarHandler> CommandMapper =
         new(ViewCommandMapper)
         {
             [nameof(ISearchBar.Focus)] = MapFocus,
         };
 
+    /// <summary>Initializes a new instance of <see cref="SearchBarHandler"/>.</summary>
     public SearchBarHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="SearchBarHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
     public SearchBarHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="SearchBarHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
+    /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
     public SearchBarHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Gets the underlying text box editor of the search bar.</summary>
     public object? QueryEditor => PlatformView._textBox;
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         base.ConnectHandler(platformView);
@@ -63,6 +75,7 @@ public partial class SearchBarHandler : ViewHandler<ISearchBar, PlatformView>
             MapSearchIconColor(this, VirtualView);
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         platformView.TextChanged -= OnTextChanged;
@@ -86,42 +99,63 @@ public partial class SearchBarHandler : ViewHandler<ISearchBar, PlatformView>
         VirtualView.SearchButtonPressed();
     }
     
+    /// <summary>Maps the Text property to the platform view.</summary>
+    /// <param name="handler">The handler for the search bar.</param>
+    /// <param name="searchBar">The virtual view.</param>
     public static void MapText(SearchBarHandler handler, ISearchBar searchBar)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateText(searchBar);
     }
 
+    /// <summary>Maps the SearchIconColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the search bar.</param>
+    /// <param name="searchBar">The virtual view.</param>
     public static void MapSearchIconColor(SearchBarHandler handler, ISearchBar searchBar)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateSearchIconColor(searchBar);
     }
 
+    /// <summary>Maps the Placeholder property to the platform view.</summary>
+    /// <param name="handler">The handler for the search bar.</param>
+    /// <param name="searchBar">The virtual view.</param>
     public static void MapPlaceholder(SearchBarHandler handler, ISearchBar searchBar)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdatePlaceholder(searchBar);
     }
 
+    /// <summary>Maps the PlaceholderColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the search bar.</param>
+    /// <param name="searchBar">The virtual view.</param>
     public static void MapPlaceholderColor(SearchBarHandler handler, ISearchBar searchBar)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdatePlaceholderColor(searchBar);
     }
-    
+
+    /// <summary>Maps the TextColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the search bar.</param>
+    /// <param name="searchBar">The virtual view.</param>
     public static void MapTextColor(SearchBarHandler handler, ISearchBar searchBar)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateTextColor(searchBar);
     }
-    
+
+    /// <summary>Maps the CharacterSpacing property to the platform view.</summary>
+    /// <param name="handler">The handler for the search bar.</param>
+    /// <param name="searchBar">The virtual view.</param>
     public static void MapCharacterSpacing(SearchBarHandler handler, ISearchBar searchBar)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateCharacterSpacing(searchBar);
     }
 
+    /// <summary>Maps the Font property to the platform view.</summary>
+    /// <param name="handler">The handler for the search bar.</param>
+    /// <param name="searchBar">The virtual view.</param>
     public static void MapFont(SearchBarHandler handler, ISearchBar searchBar)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -130,49 +164,74 @@ public partial class SearchBarHandler : ViewHandler<ISearchBar, PlatformView>
             platformView.UpdateFont(searchBar, fontManager);
         }
     }
-    
+
+    /// <summary>Maps the HorizontalTextAlignment property to the platform view.</summary>
+    /// <param name="handler">The handler for the search bar.</param>
+    /// <param name="searchBar">The virtual view.</param>
     public static void MapHorizontalTextAlignment(SearchBarHandler handler, ISearchBar searchBar)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateHorizontalTextAlignment(searchBar);
     }
 
+    /// <summary>Maps the VerticalTextAlignment property to the platform view.</summary>
+    /// <param name="handler">The handler for the search bar.</param>
+    /// <param name="searchBar">The virtual view.</param>
     public static void MapVerticalTextAlignment(SearchBarHandler handler, ISearchBar searchBar)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateVerticalTextAlignment(searchBar);
     }
 
+    /// <summary>Maps the IsReadOnly property to the platform view.</summary>
+    /// <param name="handler">The handler for the search bar.</param>
+    /// <param name="searchBar">The virtual view.</param>
     public static void MapIsReadOnly(SearchBarHandler handler, ISearchBar searchBar)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateIsReadOnly(searchBar);
     }
 
+    /// <summary>Maps the MaxLength property to the platform view.</summary>
+    /// <param name="handler">The handler for the search bar.</param>
+    /// <param name="searchBar">The virtual view.</param>
     public static void MapMaxLength(SearchBarHandler handler, ISearchBar searchBar)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateMaxLength(searchBar);
     }
 
+    /// <summary>Maps the CancelButtonColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the search bar.</param>
+    /// <param name="searchBar">The virtual view.</param>
     public static void MapCancelButtonColor(SearchBarHandler handler, ISearchBar searchBar)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateCancelButtonColor(searchBar);
     }
 
+    /// <summary>Maps the CursorPosition property to the platform view.</summary>
+    /// <param name="handler">The handler for the search bar.</param>
+    /// <param name="searchBar">The virtual view.</param>
     public static void MapCursorPosition(SearchBarHandler handler, ISearchBar searchBar)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateCursorPosition(searchBar);
     }
 
+    /// <summary>Maps the SelectionLength property to the platform view.</summary>
+    /// <param name="handler">The handler for the search bar.</param>
+    /// <param name="searchBar">The virtual view.</param>
     public static void MapSelectionLength(SearchBarHandler handler, ISearchBar searchBar)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateSelectionLength(searchBar);
     }
 
+    /// <summary>Maps the Focus command to the platform view.</summary>
+    /// <param name="handler">The handler for the search bar.</param>
+    /// <param name="searchBar">The virtual view.</param>
+    /// <param name="args">The focus request arguments.</param>
     public static void MapFocus(SearchBarHandler handler, ISearchBar searchBar, object? args)
     {
         if (handler.PlatformView is PlatformView platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/Shapes/EllipseHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shapes/EllipseHandler.cs
@@ -6,26 +6,35 @@ using Ellipse = Microsoft.Maui.Controls.Shapes.Ellipse;
 
 namespace Avalonia.Controls.Maui.Handlers.Shapes;
 
+/// <summary>Avalonia handler for IEllipse shapes.</summary>
 public partial class EllipseHandler : ShapeViewHandler<Ellipse, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="EllipseHandler"/>.</summary>
     public static new IPropertyMapper<Ellipse, IShapeViewHandler> Mapper = new PropertyMapper<Ellipse, IShapeViewHandler>(ShapeViewHandler.Mapper)
     {
         [nameof(IShapeView.Shape)] = MapShape,
     };
 
+    /// <summary>Initializes a new instance of <see cref="EllipseHandler"/>.</summary>
     public EllipseHandler() : base(Mapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="EllipseHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use.</param>
     public EllipseHandler(IPropertyMapper mapper) : base(mapper ?? Mapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <summary>Maps the Shape property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="shape">The shape view.</param>
     public static new void MapShape(IShapeViewHandler handler, IShapeView shape)
     {
         // Ellipse shape is automatically handled by the Avalonia.Controls.Shapes.Ellipse control

--- a/src/Avalonia.Controls.Maui/Handlers/Shapes/LineHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shapes/LineHandler.cs
@@ -7,8 +7,10 @@ using PlatformView = global::Avalonia.Controls.Shapes.Line;
 
 namespace Avalonia.Controls.Maui.Handlers.Shapes;
 
+/// <summary>Avalonia handler for ILine shapes.</summary>
 public partial class LineHandler : ShapeViewHandler<Line, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="LineHandler"/>.</summary>
     public static new IPropertyMapper<Line, IShapeViewHandler> Mapper = new PropertyMapper<Line, IShapeViewHandler>(ShapeViewHandler.Mapper)
     {
         [nameof(Line.X1)] = MapX1,
@@ -17,19 +19,26 @@ public partial class LineHandler : ShapeViewHandler<Line, PlatformView>
         [nameof(Line.Y2)] = MapY2,
     };
 
+    /// <summary>Initializes a new instance of <see cref="LineHandler"/>.</summary>
     public LineHandler() : base(Mapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="LineHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use.</param>
     public LineHandler(IPropertyMapper mapper) : base(mapper ?? Mapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <summary>Maps the X1 property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="line">The line.</param>
     public static void MapX1(IShapeViewHandler handler, Line line)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -38,6 +47,9 @@ public partial class LineHandler : ShapeViewHandler<Line, PlatformView>
         }
     }
 
+    /// <summary>Maps the Y1 property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="line">The line.</param>
     public static void MapY1(IShapeViewHandler handler, Line line)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -46,6 +58,9 @@ public partial class LineHandler : ShapeViewHandler<Line, PlatformView>
         }
     }
 
+    /// <summary>Maps the X2 property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="line">The line.</param>
     public static void MapX2(IShapeViewHandler handler, Line line)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -54,6 +69,9 @@ public partial class LineHandler : ShapeViewHandler<Line, PlatformView>
         }
     }
 
+    /// <summary>Maps the Y2 property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="line">The line.</param>
     public static void MapY2(IShapeViewHandler handler, Line line)
     {
         if (handler.PlatformView is PlatformView platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/Shapes/PathHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shapes/PathHandler.cs
@@ -8,8 +8,10 @@ using Path = Microsoft.Maui.Controls.Shapes.Path;
 
 namespace Avalonia.Controls.Maui.Handlers.Shapes;
 
+/// <summary>Avalonia handler for IPath shapes.</summary>
 public partial class PathHandler : ShapeViewHandler<Path, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="PathHandler"/>.</summary>
     public static new IPropertyMapper<Path, IShapeViewHandler> Mapper = new PropertyMapper<Path, IShapeViewHandler>(ShapeViewHandler.Mapper)
     {
         [nameof(IShapeView.Shape)] = MapShape,
@@ -17,19 +19,24 @@ public partial class PathHandler : ShapeViewHandler<Path, PlatformView>
         [nameof(Path.RenderTransform)] = MapRenderTransform,
     };
 
+    /// <summary>Initializes a new instance of <see cref="PathHandler"/>.</summary>
     public PathHandler() : base(Mapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="PathHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use.</param>
     public PathHandler(IPropertyMapper mapper) : base(mapper ?? Mapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         base.ConnectHandler(platformView);
@@ -40,6 +47,7 @@ public partial class PathHandler : ShapeViewHandler<Path, PlatformView>
         }
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         if (VirtualView?.RenderTransform != null)
@@ -55,11 +63,17 @@ public partial class PathHandler : ShapeViewHandler<Path, PlatformView>
         MapRenderTransform(this, VirtualView);
     }
 
+    /// <summary>Maps the Shape property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="shape">The shape view.</param>
     public static new void MapShape(IShapeViewHandler handler, IShapeView shape)
     {
         MapData(handler, shape as Path);
     }
 
+    /// <summary>Maps the Data property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="path">The path.</param>
     public static void MapData(IShapeViewHandler handler, Path path)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -68,6 +82,9 @@ public partial class PathHandler : ShapeViewHandler<Path, PlatformView>
         }
     }
 
+    /// <summary>Maps the RenderTransform property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="path">The path.</param>
     public static void MapRenderTransform(IShapeViewHandler handler, Path path)
     {
         if (handler.PlatformView is PlatformView platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/Shapes/PolygonHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shapes/PolygonHandler.cs
@@ -7,8 +7,10 @@ using Polygon = Microsoft.Maui.Controls.Shapes.Polygon;
 
 namespace Avalonia.Controls.Maui.Handlers.Shapes;
 
+/// <summary>Avalonia handler for IPolygon shapes.</summary>
 public partial class PolygonHandler : ShapeViewHandler<Polygon, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="PolygonHandler"/>.</summary>
     public static new IPropertyMapper<Polygon, IShapeViewHandler> Mapper = new PropertyMapper<Polygon, IShapeViewHandler>(ShapeViewHandler.Mapper)
     {
         [nameof(IShapeView.Shape)] = MapShape,
@@ -16,24 +18,34 @@ public partial class PolygonHandler : ShapeViewHandler<Polygon, PlatformView>
         [nameof(Polygon.FillRule)] = MapFillRule,
     };
 
+    /// <summary>Initializes a new instance of <see cref="PolygonHandler"/>.</summary>
     public PolygonHandler() : base(Mapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="PolygonHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use.</param>
     public PolygonHandler(IPropertyMapper mapper) : base(mapper ?? Mapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <summary>Maps the Shape property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="shape">The shape view.</param>
     public static new void MapShape(IShapeViewHandler handler, IShapeView shape)
     {
         // Shape handled via Points property
     }
 
+    /// <summary>Maps the Points property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="polygon">The polygon.</param>
     public static void MapPoints(IShapeViewHandler handler, Polygon polygon)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -42,6 +54,9 @@ public partial class PolygonHandler : ShapeViewHandler<Polygon, PlatformView>
         }
     }
 
+    /// <summary>Maps the FillRule property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="polygon">The polygon.</param>
     public static void MapFillRule(IShapeViewHandler handler, Microsoft.Maui.Controls.Shapes.Polygon polygon)
     {
         // Avalonia Polygon doesn't have a FillRule property

--- a/src/Avalonia.Controls.Maui/Handlers/Shapes/PolylineHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shapes/PolylineHandler.cs
@@ -7,8 +7,10 @@ using Polyline = Microsoft.Maui.Controls.Shapes.Polyline;
 
 namespace Avalonia.Controls.Maui.Handlers.Shapes;
 
+/// <summary>Avalonia handler for IPolyline shapes.</summary>
 public partial class PolylineHandler : ShapeViewHandler<Polyline, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="PolylineHandler"/>.</summary>
     public static new IPropertyMapper<Polyline, IShapeViewHandler> Mapper = new PropertyMapper<Polyline, IShapeViewHandler>(ShapeViewHandler.Mapper)
     {
         [nameof(IShapeView.Shape)] = MapShape,
@@ -16,24 +18,34 @@ public partial class PolylineHandler : ShapeViewHandler<Polyline, PlatformView>
         [nameof(Polyline.FillRule)] = MapFillRule,
     };
 
+    /// <summary>Initializes a new instance of <see cref="PolylineHandler"/>.</summary>
     public PolylineHandler() : base(Mapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="PolylineHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use.</param>
     public PolylineHandler(IPropertyMapper mapper) : base(mapper ?? Mapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <summary>Maps the Shape property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="shape">The shape view.</param>
     public static new void MapShape(IShapeViewHandler handler, IShapeView shape)
     {
         // Shape handled via Points property
     }
 
+    /// <summary>Maps the Points property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="polyline">The polyline.</param>
     public static void MapPoints(IShapeViewHandler handler, Polyline polyline)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -42,6 +54,9 @@ public partial class PolylineHandler : ShapeViewHandler<Polyline, PlatformView>
         }
     }
 
+    /// <summary>Maps the FillRule property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="polyline">The polyline.</param>
     public static void MapFillRule(IShapeViewHandler handler, Microsoft.Maui.Controls.Shapes.Polyline polyline)
     {
         // Avalonia Polyline doesn't have a FillRule property

--- a/src/Avalonia.Controls.Maui/Handlers/Shapes/RectangleHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shapes/RectangleHandler.cs
@@ -7,27 +7,36 @@ using PlatformView = global::Avalonia.Controls.Shapes.Rectangle;
 
 namespace Avalonia.Controls.Maui.Handlers.Shapes;
 
+/// <summary>Avalonia handler for IRectangle shapes.</summary>
 public partial class RectangleHandler : ShapeViewHandler<Rectangle, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="RectangleHandler"/>.</summary>
     public static new IPropertyMapper<Rectangle, IShapeViewHandler> Mapper = new PropertyMapper<Rectangle, IShapeViewHandler>(ShapeViewHandler.Mapper)
     {
         [nameof(Rectangle.RadiusX)] = MapRadiusX,
         [nameof(Rectangle.RadiusY)] = MapRadiusY,
     };
 
+    /// <summary>Initializes a new instance of <see cref="RectangleHandler"/>.</summary>
     public RectangleHandler() : base(Mapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="RectangleHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use.</param>
     public RectangleHandler(IPropertyMapper mapper) : base(mapper ?? Mapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <summary>Maps the RadiusX property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="rectangle">The rectangle.</param>
     public static void MapRadiusX(IShapeViewHandler handler, Rectangle rectangle)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -36,6 +45,9 @@ public partial class RectangleHandler : ShapeViewHandler<Rectangle, PlatformView
         }
     }
 
+    /// <summary>Maps the RadiusY property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="rectangle">The rectangle.</param>
     public static void MapRadiusY(IShapeViewHandler handler, Rectangle rectangle)
     {
         if (handler.PlatformView is PlatformView platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/Shapes/RoundRectangleHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shapes/RoundRectangleHandler.cs
@@ -7,26 +7,35 @@ using PlatformView = Avalonia.Controls.Maui.Platform.MauiRoundRectangle;
 
 namespace Avalonia.Controls.Maui.Handlers.Shapes;
 
+/// <summary>Avalonia handler for IRoundRectangle shapes.</summary>
 public partial class RoundRectangleHandler : ShapeViewHandler<RoundRectangle, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="RoundRectangleHandler"/>.</summary>
     public static new IPropertyMapper<RoundRectangle, IShapeViewHandler> Mapper = new PropertyMapper<RoundRectangle, IShapeViewHandler>(ShapeViewHandler.Mapper)
     {
         [nameof(RoundRectangle.CornerRadius)] = MapCornerRadius
     };
 
+    /// <summary>Initializes a new instance of <see cref="RoundRectangleHandler"/>.</summary>
     public RoundRectangleHandler() : base(Mapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="RoundRectangleHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use.</param>
     public RoundRectangleHandler(IPropertyMapper mapper) : base(mapper ?? Mapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <summary>Maps the CornerRadius property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="roundRectangle">The round rectangle.</param>
     public static void MapCornerRadius(IShapeViewHandler handler, RoundRectangle roundRectangle)
     {
         if (handler.PlatformView is PlatformView platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/Shapes/ShapeViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shapes/ShapeViewHandler.cs
@@ -6,14 +6,20 @@ using PlatformView = global::Avalonia.Controls.Shapes.Shape;
 
 namespace Avalonia.Controls.Maui.Handlers.Shapes;
 
+/// <summary>Avalonia handler for IShapeView shapes.</summary>
 public interface IShapeViewHandler : IViewHandler
 {
+    /// <summary>Gets the virtual view for this handler.</summary>
     new IShapeView VirtualView { get; }
+
+    /// <summary>Gets the platform view for this handler.</summary>
     new PlatformView PlatformView { get; }
 }
 
+/// <summary>Avalonia handler for IShapeView shapes.</summary>
 public abstract partial class ShapeViewHandler : ViewHandler<IShapeView, PlatformView>, IShapeViewHandler
 {
+    /// <summary>Property mapper for <see cref="ShapeViewHandler"/>.</summary>
     public static IPropertyMapper<IShapeView, IShapeViewHandler> Mapper = new PropertyMapper<IShapeView, IShapeViewHandler>(ViewHandler.ViewMapper)
     {
         [nameof(IShapeView.Background)] = MapBackground,
@@ -29,19 +35,28 @@ public abstract partial class ShapeViewHandler : ViewHandler<IShapeView, Platfor
         [nameof(IShapeView.StrokeMiterLimit)] = MapStrokeMiterLimit
     };
 
+    /// <summary>Command mapper for <see cref="ShapeViewHandler"/>.</summary>
     public static CommandMapper<IShapeView, IShapeViewHandler> CommandMapper = new(ViewCommandMapper)
     {
     };
 
+    /// <summary>Initializes a new instance of <see cref="ShapeViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use.</param>
+    /// <param name="commandMapper">The command mapper to use.</param>
     protected ShapeViewHandler(IPropertyMapper mapper, CommandMapper commandMapper = null)
         : base(mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <inheritdoc/>
     IShapeView IShapeViewHandler.VirtualView => VirtualView;
 
+    /// <inheritdoc/>
     PlatformView IShapeViewHandler.PlatformView => PlatformView;
 
+    /// <summary>Maps the Background property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="shapeView">The shape view.</param>
     public static void MapBackground(IShapeViewHandler handler, IShapeView shapeView)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -50,6 +65,9 @@ public abstract partial class ShapeViewHandler : ViewHandler<IShapeView, Platfor
         }
     }
 
+    /// <summary>Maps the Shape property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="shapeView">The shape view.</param>
     public static void MapShape(IShapeViewHandler handler, IShapeView shapeView)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -58,6 +76,9 @@ public abstract partial class ShapeViewHandler : ViewHandler<IShapeView, Platfor
         }
     }
 
+    /// <summary>Maps the Aspect property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="shapeView">The shape view.</param>
     public static void MapAspect(IShapeViewHandler handler, IShapeView shapeView)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -66,6 +87,9 @@ public abstract partial class ShapeViewHandler : ViewHandler<IShapeView, Platfor
         }
     }
 
+    /// <summary>Maps the Fill property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="shapeView">The shape view.</param>
     public static void MapFill(IShapeViewHandler handler, IShapeView shapeView)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -74,6 +98,9 @@ public abstract partial class ShapeViewHandler : ViewHandler<IShapeView, Platfor
         }
     }
 
+    /// <summary>Maps the Stroke property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="shapeView">The shape view.</param>
     public static void MapStroke(IShapeViewHandler handler, IShapeView shapeView)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -82,6 +109,9 @@ public abstract partial class ShapeViewHandler : ViewHandler<IShapeView, Platfor
         }
     }
 
+    /// <summary>Maps the StrokeThickness property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="shapeView">The shape view.</param>
     public static void MapStrokeThickness(IShapeViewHandler handler, IShapeView shapeView)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -90,6 +120,9 @@ public abstract partial class ShapeViewHandler : ViewHandler<IShapeView, Platfor
         }
     }
 
+    /// <summary>Maps the StrokeDashPattern property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="shapeView">The shape view.</param>
     public static void MapStrokeDashPattern(IShapeViewHandler handler, IShapeView shapeView)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -98,6 +131,9 @@ public abstract partial class ShapeViewHandler : ViewHandler<IShapeView, Platfor
         }
     }
 
+    /// <summary>Maps the StrokeDashOffset property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="shapeView">The shape view.</param>
     public static void MapStrokeDashOffset(IShapeViewHandler handler, IShapeView shapeView)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -106,6 +142,9 @@ public abstract partial class ShapeViewHandler : ViewHandler<IShapeView, Platfor
         }
     }
 
+    /// <summary>Maps the StrokeLineCap property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="shapeView">The shape view.</param>
     public static void MapStrokeLineCap(IShapeViewHandler handler, IShapeView shapeView)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -114,6 +153,9 @@ public abstract partial class ShapeViewHandler : ViewHandler<IShapeView, Platfor
         }
     }
 
+    /// <summary>Maps the StrokeLineJoin property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="shapeView">The shape view.</param>
     public static void MapStrokeLineJoin(IShapeViewHandler handler, IShapeView shapeView)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -122,6 +164,9 @@ public abstract partial class ShapeViewHandler : ViewHandler<IShapeView, Platfor
         }
     }
 
+    /// <summary>Maps the StrokeMiterLimit property to the platform view.</summary>
+    /// <param name="handler">The shape view handler.</param>
+    /// <param name="shapeView">The shape view.</param>
     [Avalonia.Controls.Maui.Platform.NotImplemented("Avalonia Shape doesn't expose StrokeMiterLimit property.")]
     public static void MapStrokeMiterLimit(IShapeViewHandler handler, IShapeView shapeView)
     {
@@ -132,33 +177,47 @@ public abstract partial class ShapeViewHandler : ViewHandler<IShapeView, Platfor
     }
 }
 
+/// <summary>Avalonia handler for IShapeView shapes with strongly-typed virtual view and platform view.</summary>
+/// <typeparam name="TVirtualView">The type of the virtual view.</typeparam>
+/// <typeparam name="TPlatformView">The type of the platform view.</typeparam>
 public abstract class ShapeViewHandler<TVirtualView, TPlatformView> : ShapeViewHandler
     where TVirtualView : class, IShapeView
     where TPlatformView : PlatformView
 {
+    /// <summary>Initializes a new instance of <see cref="ShapeViewHandler{TVirtualView, TPlatformView}"/>.</summary>
+    /// <param name="mapper">The property mapper to use.</param>
+    /// <param name="commandMapper">The command mapper to use.</param>
     protected ShapeViewHandler(IPropertyMapper mapper, CommandMapper commandMapper = null)
         : base(mapper, commandMapper)
     {
     }
 
+    /// <summary>Gets the strongly-typed virtual view.</summary>
     public new TVirtualView VirtualView => (TVirtualView)base.VirtualView;
 
+    /// <summary>Gets the strongly-typed platform view.</summary>
     public new TPlatformView PlatformView => (TPlatformView)base.PlatformView;
 
+    /// <summary>Called when the handler is connected to a platform view.</summary>
+    /// <param name="platformView">The platform view being connected.</param>
     protected virtual void ConnectHandler(TPlatformView platformView)
     {
     }
 
+    /// <summary>Called when the handler is disconnected from a platform view.</summary>
+    /// <param name="platformView">The platform view being disconnected.</param>
     protected virtual void DisconnectHandler(TPlatformView platformView)
     {
     }
 
+    /// <inheritdoc/>
     public sealed override void OnConnectHandler(object platformView)
     {
         base.OnConnectHandler(platformView);
         ConnectHandler((TPlatformView)platformView);
     }
 
+    /// <inheritdoc/>
     public sealed override void OnDisconnectHandler(object platformView)
     {
         DisconnectHandler((TPlatformView)platformView);

--- a/src/Avalonia.Controls.Maui/Handlers/Shell/ShellContentHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shell/ShellContentHandler.cs
@@ -6,28 +6,37 @@ using AvaloniaControl = Avalonia.Controls.Control;
 
 namespace Avalonia.Controls.Maui.Handlers.Shell;
 
+/// <summary>Avalonia handler for <see cref="ShellContent"/>.</summary>
 public partial class ShellContentHandler : ElementHandler<ShellContent, AvaloniaControl>
 {
+    /// <summary>Property mapper for <see cref="ShellContentHandler"/>.</summary>
     public static IPropertyMapper<ShellContent, ShellContentHandler> Mapper =
         new PropertyMapper<ShellContent, ShellContentHandler>(ElementHandler.ElementMapper)
         {
             [nameof(ShellContent.Content)] = MapContent,
         };
-    
+
+    /// <summary>Command mapper for <see cref="ShellContentHandler"/>.</summary>
     public static CommandMapper<ShellContent, ShellContentHandler> CommandMapper =
         new CommandMapper<ShellContent, ShellContentHandler>(ElementHandler.ElementCommandMapper);
 
+    /// <summary>Content control container for the shell content page.</summary>
     internal ContentControl? _contentContainer;
-    
+
+    /// <summary>Initializes a new instance of <see cref="ShellContentHandler"/>.</summary>
     public ShellContentHandler() : base(Mapper, CommandMapper)
     {
     }
-    
+
+    /// <summary>Initializes a new instance of <see cref="ShellContentHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use.</param>
+    /// <param name="commandMapper">The command mapper to use.</param>
     public ShellContentHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
-    
+
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override AvaloniaControl CreatePlatformElement()
     {
         _contentContainer = new ContentControl
@@ -43,12 +52,14 @@ public partial class ShellContentHandler : ElementHandler<ShellContent, Avalonia
         return _contentContainer;
     }
     
+    /// <inheritdoc/>
     protected override void ConnectHandler(AvaloniaControl platformView)
     {
         base.ConnectHandler(platformView);
         this.UpdateContent(VirtualView);
     }
-    
+
+    /// <inheritdoc/>
     protected override void DisconnectHandler(AvaloniaControl platformView)
     {
         if (_contentContainer != null)
@@ -59,6 +70,9 @@ public partial class ShellContentHandler : ElementHandler<ShellContent, Avalonia
         base.DisconnectHandler(platformView);
     }
     
+    /// <summary>Maps the Content property to the platform view.</summary>
+    /// <param name="handler">The shell content handler.</param>
+    /// <param name="content">The MAUI ShellContent virtual view.</param>
     public static void MapContent(ShellContentHandler handler, ShellContent content)
     {
         handler.UpdateContent(content);

--- a/src/Avalonia.Controls.Maui/Handlers/Shell/ShellHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shell/ShellHandler.cs
@@ -13,16 +13,31 @@ using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.Maui.Handlers.Shell;
 
+/// <summary>Avalonia handler for <see cref="MauiShell"/>.</summary>
 public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
 {
+    /// <summary>Default height for the navigation bar.</summary>
     internal const double DefaultBarHeight = 48;
+
+    /// <summary>Default spacing between flyout items.</summary>
     internal const double DefaultFlyoutSpacing = 4.0;
+
+    /// <summary>Default selection highlight color for flyout items.</summary>
     internal static readonly Color DefaultSelectionColor = Color.FromArgb(60, 0, 120, 215);
+
+    /// <summary>Selection color used during pointer interaction states.</summary>
     internal static readonly Color SelectionInteractionColor = Color.FromArgb(90, 0, 120, 215);
+
+    /// <summary>Default flyout background color for dark theme.</summary>
     internal static readonly Color DarkThemeFlyoutBackground = Color.Parse("#1F1F1F");
+
+    /// <summary>Default flyout background color for light theme.</summary>
     internal static readonly Color LightThemeFlyoutBackground = Colors.White;
+
+    /// <summary>Default duration for content transitions.</summary>
     internal static readonly TimeSpan DefaultTransitionDuration = TimeSpan.FromMilliseconds(250);
 
+    /// <summary>Property mapper for <see cref="ShellHandler"/>.</summary>
     public static IPropertyMapper<MauiShell, ShellHandler> Mapper =
         new PropertyMapper<MauiShell, ShellHandler>(ViewHandler.ViewMapper)
         {
@@ -66,44 +81,99 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
             [MauiShell.TabBarUnselectedColorProperty.PropertyName] = MapTabBarUnselectedColor,
         };
 
+    /// <summary>Command mapper for <see cref="ShellHandler"/>.</summary>
     public static CommandMapper<MauiShell, ShellHandler> CommandMapper =
         new CommandMapper<MauiShell, ShellHandler>(ViewHandler.ViewCommandMapper);
 
+    /// <summary>Strongly-typed accessor for the MAUI Shell virtual view.</summary>
     internal new MauiShell? VirtualView => (MauiShell?)base.VirtualView;
+
+    /// <summary>The flyout container that manages flyout open/close behavior.</summary>
     internal FlyoutContainer? _flyoutContainer;
+
+    /// <summary>Content control wrapping the flyout panel content.</summary>
     internal ContentControl? _flyoutContentControl;
+
+    /// <summary>Stack panel containing flyout item buttons.</summary>
     internal StackPanel? _flyoutPanel;
+
+    /// <summary>Scroll viewer wrapping the flyout items panel.</summary>
     internal ScrollViewer? _flyoutScrollViewer;
+
+    /// <summary>Dock panel container for the flyout pane layout.</summary>
     internal DockPanel? _flyoutPaneContainer;
+
+    /// <summary>Grid used as the root layout for the flyout pane.</summary>
     internal Grid? _flyoutGrid;
+
+    /// <summary>Content control for the flyout header.</summary>
     internal ContentControl? _flyoutHeaderControl;
+
+    /// <summary>Content control for the flyout footer.</summary>
     internal ContentControl? _flyoutFooterControl;
+
+    /// <summary>Main container dock panel holding the top bar and content area.</summary>
     internal DockPanel? _mainContainer;
+
+    /// <summary>Dock panel for the top navigation bar.</summary>
     internal DockPanel? _topBar;
+
+    /// <summary>Border used as the shadow below the top navigation bar.</summary>
     internal Border? _topBarShadow;
+
+    /// <summary>Hamburger menu button to toggle the flyout.</summary>
     internal Button? _hamburgerButton;
+
+    /// <summary>Back navigation button.</summary>
     internal Button? _backButton;
+
+    /// <summary>Text block displaying the page title.</summary>
     internal TextBlock? _titleTextBlock;
+
+    /// <summary>Content control for the custom title view.</summary>
     internal ContentControl? _titleViewControl;
+
+    /// <summary>Transitioning content control for the main page content.</summary>
     internal TransitioningContentControl? _mainContentControl;
+
+    /// <summary>Handler for the currently displayed shell item.</summary>
     internal ShellItemHandler? _currentItemHandler;
+
+    /// <summary>Index of the previously selected shell item for transition direction.</summary>
     internal int _previousItemIndex = -1;
+
+    /// <summary>Dictionary mapping shell items to their flyout buttons.</summary>
     internal Dictionary<ShellItem, Button> _flyoutItemButtons = new();
+
+    /// <summary>Search control displayed in the navigation bar.</summary>
     internal ShellSearchControl? _searchControl;
+
+    /// <summary>Currently active search handler.</summary>
     internal SearchHandler? _currentSearchHandler;
+
+    /// <summary>Currently tracked page for property change notifications.</summary>
     internal Page? _trackedPage;
+
+    /// <summary>Transitioning content control for modal page presentation.</summary>
     internal TransitioningContentControl? _modalContainer;
+
+    /// <summary>Currently displayed modal page.</summary>
     internal Page? _currentModalPage;
 
+    /// <summary>Initializes a new instance of <see cref="ShellHandler"/>.</summary>
     public ShellHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="ShellHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use.</param>
+    /// <param name="commandMapper">The command mapper to use.</param>
     public ShellHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override Panel CreatePlatformView()
     {
         _flyoutContainer = new FlyoutContainer
@@ -271,6 +341,7 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
         return _flyoutContainer;
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(AvaloniaControl platformView)
     {
         base.ConnectHandler(platformView);
@@ -322,6 +393,7 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
         }
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(AvaloniaControl platformView)
     {
         if (_flyoutContainer != null)
@@ -482,6 +554,9 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
             this.UpdateBackgroundColor(VirtualView);
     }
 
+    /// <summary>Maps the CurrentItem property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapCurrentItem(ShellHandler handler, MauiShell shell)
     {
         if (handler.MauiContext != null)
@@ -490,179 +565,281 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
         }
     }
 
+    /// <summary>Maps the FlyoutBehavior property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapFlyoutBehavior(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutBehavior(shell);
     }
 
+    /// <summary>Maps the FlyoutIcon property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapFlyoutIcon(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutIcon(shell);
     }
 
+    /// <summary>Maps the FlyoutIsPresented property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapFlyoutIsPresented(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutIsPresented(shell);
     }
 
+    /// <summary>Maps the FlyoutWidth property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapFlyoutWidth(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutWidth(shell);
     }
 
+    /// <summary>Maps the FlyoutBackground property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapFlyoutBackground(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutBackground(shell);
     }
 
+    /// <summary>Maps the FlyoutBackgroundColor property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapFlyoutBackgroundColor(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutBackground(shell);
     }
 
+    /// <summary>Maps the FlyoutContent property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapFlyoutContent(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutContent(shell);
     }
 
+    /// <summary>Maps the FlyoutHeader property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapFlyoutHeader(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutHeader(shell);
     }
 
+    /// <summary>Maps the FlyoutFooter property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapFlyoutFooter(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutFooter(shell);
     }
 
+    /// <summary>Maps the Items property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapItems(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutItems(shell);
     }
 
+    /// <summary>Maps the ItemTemplate property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapItemTemplate(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutItems(shell);
     }
 
+    /// <summary>Maps the FlyoutHeight property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapFlyoutHeight(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutHeight(shell);
     }
 
+    /// <summary>Maps the FlyoutBackgroundImage property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapFlyoutBackgroundImage(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutBackgroundImage(shell);
         handler.UpdateFlyoutBackground(shell);
     }
 
+    /// <summary>Maps the FlyoutBackdrop property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapFlyoutBackdrop(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutBackdrop(shell);
     }
 
+    /// <summary>Maps the FlyoutContentTemplate property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapFlyoutContentTemplate(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutContent(shell);
     }
 
+    /// <summary>Maps the FlyoutHeaderBehavior property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapFlyoutHeaderBehavior(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutHeaderBehavior(shell);
     }
 
+    /// <summary>Maps the FlyoutVerticalScrollMode property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapFlyoutVerticalScrollMode(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutVerticalScrollMode(shell);
     }
 
+    /// <summary>Maps the MenuItemTemplate property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapMenuItemTemplate(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutItems(shell);
     }
 
+    /// <summary>Maps the BackgroundColor property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapBackgroundColor(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateBackgroundColor(shell);
     }
 
+    /// <summary>Maps the ForegroundColor property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapForegroundColor(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateForegroundColor(shell);
     }
 
+    /// <summary>Maps the TitleColor property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapTitleColor(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateTitleColor(shell);
     }
 
+    /// <summary>Maps the DisabledColor property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapDisabledColor(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutItemsAppearance(shell);
     }
 
+    /// <summary>Maps the UnselectedColor property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapUnselectedColor(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateFlyoutItemsAppearance(shell);
     }
 
+    /// <summary>Maps the NavBarIsVisible property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapNavBarIsVisible(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateNavBarIsVisible(shell);
         handler.UpdateNavBarHasShadow(shell);
     }
 
+    /// <summary>Maps the NavBarHasShadow property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapNavBarHasShadow(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateNavBarHasShadow(shell);
     }
 
+    /// <summary>Maps the BackButtonBehavior property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapBackButtonBehavior(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateBackButtonBehavior(shell);
     }
 
+    /// <summary>Maps the TitleView property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapTitleView(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateTitleView(shell);
     }
 
+    /// <summary>Maps the TabBarIsVisible property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapTabBarIsVisible(ShellHandler handler, MauiShell shell)
     {
         if (shell.CurrentItem != null)
             handler._currentItemHandler?.UpdateTabBarVisibility(shell.CurrentItem);
     }
 
+    /// <summary>Maps the TabBarBackgroundColor property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapTabBarBackgroundColor(ShellHandler handler, MauiShell shell)
     {
         if (shell.CurrentItem != null)
             handler._currentItemHandler?.UpdateTabBarBackgroundColor(shell.CurrentItem);
     }
 
+    /// <summary>Maps the TabBarForegroundColor property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapTabBarForegroundColor(ShellHandler handler, MauiShell shell)
     {
         if (shell.CurrentItem != null)
             handler._currentItemHandler?.UpdateTabBarForegroundColor(shell.CurrentItem);
     }
 
+    /// <summary>Maps the TabBarTitleColor property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapTabBarTitleColor(ShellHandler handler, MauiShell shell)
     {
         if (shell.CurrentItem != null)
             handler._currentItemHandler?.UpdateTabBarTitleColor(shell.CurrentItem);
     }
 
+    /// <summary>Maps the TabBarDisabledColor property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapTabBarDisabledColor(ShellHandler handler, MauiShell shell)
     {
         if (shell.CurrentItem != null)
             handler._currentItemHandler?.UpdateTabBarDisabledColor(shell.CurrentItem);
     }
 
+    /// <summary>Maps the TabBarUnselectedColor property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapTabBarUnselectedColor(ShellHandler handler, MauiShell shell)
     {
         if (shell.CurrentItem != null)
             handler._currentItemHandler?.UpdateTabBarUnselectedColor(shell.CurrentItem);
     }
-    
+
+    /// <summary>Maps the SearchHandler property to the platform view.</summary>
+    /// <param name="handler">The shell handler.</param>
+    /// <param name="shell">The MAUI Shell virtual view.</param>
     public static void MapSearchHandler(ShellHandler handler, MauiShell shell)
     {
         handler.UpdateSearchHandler(shell);

--- a/src/Avalonia.Controls.Maui/Handlers/Shell/ShellItemHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shell/ShellItemHandler.cs
@@ -11,8 +11,10 @@ using Avalonia.Controls.Maui.Extensions;
 
 namespace Avalonia.Controls.Maui.Handlers.Shell;
 
+/// <summary>Avalonia handler for <see cref="ShellItem"/>.</summary>
 public partial class ShellItemHandler : ElementHandler<ShellItem, AvaloniaControl>
 {
+    /// <summary>Property mapper for <see cref="ShellItemHandler"/>.</summary>
     public static IPropertyMapper<ShellItem, ShellItemHandler> Mapper =
         new PropertyMapper<ShellItem, ShellItemHandler>(ElementHandler.ElementMapper)
         {
@@ -20,26 +22,43 @@ public partial class ShellItemHandler : ElementHandler<ShellItem, AvaloniaContro
             [nameof(ShellItem.Items)] = MapItems,
             [nameof(ShellItem.Title)] = MapTitle,
         };
-    
+
+    /// <summary>Command mapper for <see cref="ShellItemHandler"/>.</summary>
     public static CommandMapper<ShellItem, ShellItemHandler> CommandMapper =
         new CommandMapper<ShellItem, ShellItemHandler>(ElementHandler.ElementCommandMapper);
 
+    /// <summary>Tab control used when multiple shell sections are displayed as tabs.</summary>
     internal TabControl? _tabControl;
+
+    /// <summary>Content control used when a single section is displayed without tabs.</summary>
     internal TransitioningContentControl? _contentControl;
+
+    /// <summary>Handler for the currently active shell section.</summary>
     internal ShellSectionHandler? _currentSectionHandler;
+
+    /// <summary>Index of the previously selected section for transition direction.</summary>
     internal int _previousSectionIndex = -1;
+
+    /// <summary>Whether tabs should be shown for this shell item.</summary>
     internal bool _showTabs;
+
+    /// <summary>Flag to prevent re-entrant tab update processing.</summary>
     internal bool _isUpdatingTabs;
-    
+
+    /// <summary>Initializes a new instance of <see cref="ShellItemHandler"/>.</summary>
     public ShellItemHandler() : base(Mapper, CommandMapper)
     {
     }
-    
+
+    /// <summary>Initializes a new instance of <see cref="ShellItemHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use.</param>
+    /// <param name="commandMapper">The command mapper to use.</param>
     public ShellItemHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override AvaloniaControl CreatePlatformElement()
     {
         // Determine if we should show tabs
@@ -81,6 +100,7 @@ public partial class ShellItemHandler : ElementHandler<ShellItem, AvaloniaContro
         }
     }
     
+    /// <inheritdoc/>
     protected override void ConnectHandler(AvaloniaControl platformView)
     {
         base.ConnectHandler(platformView);
@@ -93,6 +113,7 @@ public partial class ShellItemHandler : ElementHandler<ShellItem, AvaloniaContro
         this.UpdateTabs(VirtualView);
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(AvaloniaControl platformView)
     {
         if (VirtualView is IShellItemController itemController)
@@ -110,16 +131,25 @@ public partial class ShellItemHandler : ElementHandler<ShellItem, AvaloniaContro
         base.DisconnectHandler(platformView);
     }
     
+    /// <summary>Maps the CurrentItem property to the platform view.</summary>
+    /// <param name="handler">The shell item handler.</param>
+    /// <param name="item">The MAUI ShellItem virtual view.</param>
     public static void MapCurrentItem(ShellItemHandler handler, ShellItem item)
     {
         handler.UpdateCurrentItem(item);
     }
-    
+
+    /// <summary>Maps the Items property to the platform view.</summary>
+    /// <param name="handler">The shell item handler.</param>
+    /// <param name="item">The MAUI ShellItem virtual view.</param>
     public static void MapItems(ShellItemHandler handler, ShellItem item)
     {
         handler.UpdateTabs(item);
     }
 
+    /// <summary>Maps the Title property to the platform view.</summary>
+    /// <param name="handler">The shell item handler.</param>
+    /// <param name="item">The MAUI ShellItem virtual view.</param>
     public static void MapTitle(ShellItemHandler handler, ShellItem item)
     {
         // Title updates handled by parent shell

--- a/src/Avalonia.Controls.Maui/Handlers/Shell/ShellSectionHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shell/ShellSectionHandler.cs
@@ -8,8 +8,10 @@ using Avalonia.Controls.Maui.Extensions;
 
 namespace Avalonia.Controls.Maui.Handlers.Shell;
 
+/// <summary>Avalonia handler for <see cref="ShellSection"/>.</summary>
 public partial class ShellSectionHandler : ElementHandler<ShellSection, AvaloniaControl>, IStackNavigation
 {
+    /// <summary>Property mapper for <see cref="ShellSectionHandler"/>.</summary>
     public static IPropertyMapper<ShellSection, ShellSectionHandler> Mapper =
         new PropertyMapper<ShellSection, ShellSectionHandler>(ElementHandler.ElementMapper)
         {
@@ -17,6 +19,7 @@ public partial class ShellSectionHandler : ElementHandler<ShellSection, Avalonia
             [nameof(ShellSection.Items)] = MapItems,
         };
 
+    /// <summary>Command mapper for <see cref="ShellSectionHandler"/>.</summary>
     public static CommandMapper<ShellSection, ShellSectionHandler> CommandMapper =
         new CommandMapper<ShellSection, ShellSectionHandler>(ElementHandler.ElementCommandMapper)
         {
@@ -28,15 +31,25 @@ public partial class ShellSectionHandler : ElementHandler<ShellSection, Avalonia
     Page? _currentPage;
     bool _isNavigating;
 
+    /// <summary>Default duration for content transitions.</summary>
     internal static readonly TimeSpan DefaultTransitionDuration = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>Duration for page slide push/pop transitions.</summary>
     internal static readonly TimeSpan PageSlideDuration = TimeSpan.FromMilliseconds(300);
+
+    /// <summary>Duration for modal presentation transitions.</summary>
     internal static readonly TimeSpan ModalTransitionDuration = TimeSpan.FromMilliseconds(400);
 
+    /// <summary>Initializes a new instance of <see cref="ShellSectionHandler"/>.</summary>
     public ShellSectionHandler() : base(Mapper, CommandMapper) { }
 
+    /// <summary>Initializes a new instance of <see cref="ShellSectionHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use.</param>
+    /// <param name="commandMapper">The command mapper to use.</param>
     public ShellSectionHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override AvaloniaControl CreatePlatformElement()
     {
         _sectionContainer = new TransitioningContentControl
@@ -51,6 +64,7 @@ public partial class ShellSectionHandler : ElementHandler<ShellSection, Avalonia
         return _sectionContainer;
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(AvaloniaControl platformView)
     {
         base.ConnectHandler(platformView);
@@ -62,6 +76,7 @@ public partial class ShellSectionHandler : ElementHandler<ShellSection, Avalonia
         platformView.AttachedToVisualTree += OnAttachedToVisualTree;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(AvaloniaControl platformView)
     {
         if (VirtualView is IShellSectionController sectionController)
@@ -81,12 +96,22 @@ public partial class ShellSectionHandler : ElementHandler<ShellSection, Avalonia
         SyncNavigationStack();
     }
 
+    /// <summary>Maps the CurrentItem property to the platform view.</summary>
+    /// <param name="handler">The shell section handler.</param>
+    /// <param name="section">The MAUI ShellSection virtual view.</param>
     public static void MapCurrentItem(ShellSectionHandler handler, ShellSection section)
         => handler.UpdateCurrentItem();
 
+    /// <summary>Maps the Items property to the platform view.</summary>
+    /// <param name="handler">The shell section handler.</param>
+    /// <param name="section">The MAUI ShellSection virtual view.</param>
     public static void MapItems(ShellSectionHandler handler, ShellSection section)
         => handler.UpdateCurrentItem();
 
+    /// <summary>Handles a navigation request command.</summary>
+    /// <param name="handler">The shell section handler.</param>
+    /// <param name="view">The stack navigation view.</param>
+    /// <param name="arg">The navigation request argument.</param>
     public static void RequestNavigation(ShellSectionHandler handler, IStackNavigation view, object? arg)
     {
         if (arg is NavigationRequest request)
@@ -148,6 +173,7 @@ public partial class ShellSectionHandler : ElementHandler<ShellSection, Avalonia
         }
     }
     
+    /// <summary>Synchronizes the internal navigation stack with the MAUI navigation stack and displays the top page.</summary>
     public void SyncNavigationStack()
     {
         if (_isNavigating || VirtualView == null || _sectionContainer == null)

--- a/src/Avalonia.Controls.Maui/Handlers/SingleViewWindowHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/SingleViewWindowHandler.cs
@@ -14,6 +14,9 @@ public partial class SingleViewWindowHandler : ElementHandler<IWindow, Avalonia.
 {
     static readonly AlertManager s_alertManager = new();
 
+    /// <summary>
+    /// Property mapper for <see cref="SingleViewWindowHandler"/>.
+    /// </summary>
     static IPropertyMapper<IWindow, SingleViewWindowHandler> mapper = new PropertyMapper<IWindow, SingleViewWindowHandler>(ElementHandler.ElementMapper)
     {
         [nameof(IWindow.Title)] = mapTitle,
@@ -21,11 +24,20 @@ public partial class SingleViewWindowHandler : ElementHandler<IWindow, Avalonia.
         // X, Y, Width, Height, Min/Max dimensions are not relevant for single-view platforms
     };
 
+    /// <summary>
+    /// Command mapper for <see cref="SingleViewWindowHandler"/>.
+    /// </summary>
     static CommandMapper<IWindow, SingleViewWindowHandler> CommandMapper = new(ElementCommandMapper)
     {
         [nameof(IWindow.RequestDisplayDensity)] = MapRequestDisplayDensity,
     };
 
+    /// <summary>
+    /// Maps the <see cref="IWindow.RequestDisplayDensity"/> command to return the current rendering scale.
+    /// </summary>
+    /// <param name="handler">The associated handler.</param>
+    /// <param name="window">The associated <see cref="IWindow"/> instance.</param>
+    /// <param name="arg3">The associated command arguments.</param>
     private static void MapRequestDisplayDensity(SingleViewWindowHandler handler, IWindow window, object? arg3)
     {
         if (arg3 is DisplayDensityRequest request)
@@ -35,16 +47,24 @@ public partial class SingleViewWindowHandler : ElementHandler<IWindow, Avalonia.
         }
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="SingleViewWindowHandler"/>.
+    /// </summary>
     public SingleViewWindowHandler()
         : base(mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Creates the Avalonia platform view for this handler.
+    /// </summary>
+    /// <returns>A new <see cref="MauiAvaloniaContent"/> instance.</returns>
     protected override Avalonia.Controls.ContentControl CreatePlatformElement()
     {
         return new MauiAvaloniaContent();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(Avalonia.Controls.ContentControl platformView)
     {
         base.ConnectHandler(platformView);
@@ -57,6 +77,7 @@ public partial class SingleViewWindowHandler : ElementHandler<IWindow, Avalonia.
         }
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(Avalonia.Controls.ContentControl platformView)
     {
         if (VirtualView is Microsoft.Maui.Controls.Window window)
@@ -79,12 +100,18 @@ public partial class SingleViewWindowHandler : ElementHandler<IWindow, Avalonia.
         // Modal support would need to be implemented differently for single-view platforms
     }
 
+    /// <summary>
+    /// Maps the Title property. Not relevant for single-view platforms.
+    /// </summary>
     static void mapTitle(SingleViewWindowHandler handler, IWindow window)
     {
         // Title mapping is not relevant for single-view platforms
         // In browser, this could potentially update the document title
     }
 
+    /// <summary>
+    /// Maps the <see cref="IWindow.Content"/> property to the platform view.
+    /// </summary>
     static void mapContent(SingleViewWindowHandler handler, IWindow window)
     {
         var avContent = GetMauiContent(handler);
@@ -92,6 +119,9 @@ public partial class SingleViewWindowHandler : ElementHandler<IWindow, Avalonia.
         avContent.SetMainContent(content);
     }
 
+    /// <summary>
+    /// Gets the <see cref="MauiAvaloniaContent"/> from the handler, ensuring <see cref="IMauiContext"/> is set.
+    /// </summary>
     static MauiAvaloniaContent GetMauiContent(SingleViewWindowHandler handler)
     {
         _ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");

--- a/src/Avalonia.Controls.Maui/Handlers/SliderHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/SliderHandler.cs
@@ -8,10 +8,12 @@ using System.Threading.Tasks;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="ISlider"/>.</summary>
 public class SliderHandler : ViewHandler<ISlider, PlatformView>
 {
     private CancellationTokenSource? _thumbImageCts;
 
+    /// <summary>Property mapper for <see cref="SliderHandler"/>.</summary>
     public static IPropertyMapper<ISlider, SliderHandler> Mapper = new PropertyMapper<ISlider, SliderHandler>(ViewHandler.ViewMapper)
     {
         [nameof(ISlider.Maximum)] = MapMaximum,
@@ -23,37 +25,48 @@ public class SliderHandler : ViewHandler<ISlider, PlatformView>
         [nameof(ISlider.Value)] = MapValue,
     };
 
+    /// <summary>Command mapper for <see cref="SliderHandler"/>.</summary>
     public static CommandMapper<ISlider, SliderHandler> CommandMapper = new(ViewCommandMapper)
     {
     };
 
+    /// <summary>Initializes a new instance of <see cref="SliderHandler"/>.</summary>
     public SliderHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="SliderHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
     public SliderHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="SliderHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
+    /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
     public SliderHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <summary>Gets a value indicating whether this handler requires a container view.</summary>
     public override bool NeedsContainer => false;
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         platformView.PropertyChanged += OnSliderPropertyChanged;
         base.ConnectHandler(platformView);
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         platformView.PropertyChanged -= OnSliderPropertyChanged;
@@ -62,6 +75,9 @@ public class SliderHandler : ViewHandler<ISlider, PlatformView>
         base.DisconnectHandler(platformView);
     }
 
+    /// <summary>Maps the Minimum property to the platform view.</summary>
+    /// <param name="handler">The handler for the slider.</param>
+    /// <param name="slider">The virtual view.</param>
     public static void MapMinimum(SliderHandler handler, ISlider slider)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -70,6 +86,9 @@ public class SliderHandler : ViewHandler<ISlider, PlatformView>
         }
     }
 
+    /// <summary>Maps the Maximum property to the platform view.</summary>
+    /// <param name="handler">The handler for the slider.</param>
+    /// <param name="slider">The virtual view.</param>
     public static void MapMaximum(SliderHandler handler, ISlider slider)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -78,6 +97,9 @@ public class SliderHandler : ViewHandler<ISlider, PlatformView>
         }
     }
 
+    /// <summary>Maps the Value property to the platform view.</summary>
+    /// <param name="handler">The handler for the slider.</param>
+    /// <param name="slider">The virtual view.</param>
     public static void MapValue(SliderHandler handler, ISlider slider)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -86,6 +108,9 @@ public class SliderHandler : ViewHandler<ISlider, PlatformView>
         }
     }
 
+    /// <summary>Maps the MinimumTrackColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the slider.</param>
+    /// <param name="slider">The virtual view.</param>
     public static void MapMinimumTrackColor(SliderHandler handler, ISlider slider)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -94,6 +119,9 @@ public class SliderHandler : ViewHandler<ISlider, PlatformView>
         }
     }
 
+    /// <summary>Maps the MaximumTrackColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the slider.</param>
+    /// <param name="slider">The virtual view.</param>
     public static void MapMaximumTrackColor(SliderHandler handler, ISlider slider)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -102,6 +130,9 @@ public class SliderHandler : ViewHandler<ISlider, PlatformView>
         }
     }
 
+    /// <summary>Maps the ThumbColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the slider.</param>
+    /// <param name="slider">The virtual view.</param>
     public static void MapThumbColor(SliderHandler handler, ISlider slider)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -110,6 +141,9 @@ public class SliderHandler : ViewHandler<ISlider, PlatformView>
         }
     }
 
+    /// <summary>Maps the ThumbImageSource property to the platform view.</summary>
+    /// <param name="handler">The handler for the slider.</param>
+    /// <param name="slider">The virtual view.</param>
     public static void MapThumbImageSource(SliderHandler handler, ISlider slider)
     {
         if (handler.PlatformView is PlatformView platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/StepperHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/StepperHandler.cs
@@ -4,8 +4,10 @@ using PlatformView = Avalonia.Controls.Maui.Stepper;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IStepper"/>.</summary>
 public partial class StepperHandler : ViewHandler<IStepper, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="StepperHandler"/>.</summary>
     public static IPropertyMapper<IStepper, StepperHandler> Mapper = new PropertyMapper<IStepper, StepperHandler>(ViewHandler.ViewMapper)
     {
         [nameof(IStepper.Interval)] = MapIncrement,
@@ -15,35 +17,45 @@ public partial class StepperHandler : ViewHandler<IStepper, PlatformView>
         [nameof(IStepper.Background)] = MapBackground,
     };
 
+    /// <summary>Command mapper for <see cref="StepperHandler"/>.</summary>
     public static CommandMapper<IStepper, StepperHandler> CommandMapper = new(ViewHandler.ViewCommandMapper)
     {
     };
 
+    /// <summary>Initializes a new instance of <see cref="StepperHandler"/>.</summary>
     public StepperHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="StepperHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
     public StepperHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="StepperHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
+    /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
     public StepperHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         base.ConnectHandler(platformView);
         platformView.ValueChanged += OnValueChanged;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         platformView.ValueChanged -= OnValueChanged;
@@ -58,6 +70,9 @@ public partial class StepperHandler : ViewHandler<IStepper, PlatformView>
         VirtualView.Value = PlatformView.Value;
     }
 
+    /// <summary>Maps the Minimum property to the platform view.</summary>
+    /// <param name="handler">The handler for the stepper.</param>
+    /// <param name="stepper">The virtual view.</param>
     public static void MapMinimum(StepperHandler handler, IStepper stepper)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -66,6 +81,9 @@ public partial class StepperHandler : ViewHandler<IStepper, PlatformView>
         }
     }
 
+    /// <summary>Maps the Maximum property to the platform view.</summary>
+    /// <param name="handler">The handler for the stepper.</param>
+    /// <param name="stepper">The virtual view.</param>
     public static void MapMaximum(StepperHandler handler, IStepper stepper)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -74,6 +92,9 @@ public partial class StepperHandler : ViewHandler<IStepper, PlatformView>
         }
     }
 
+    /// <summary>Maps the Increment property to the platform view.</summary>
+    /// <param name="handler">The handler for the stepper.</param>
+    /// <param name="stepper">The virtual view.</param>
     public static void MapIncrement(StepperHandler handler, IStepper stepper)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -82,6 +103,9 @@ public partial class StepperHandler : ViewHandler<IStepper, PlatformView>
         }
     }
 
+    /// <summary>Maps the Value property to the platform view.</summary>
+    /// <param name="handler">The handler for the stepper.</param>
+    /// <param name="stepper">The virtual view.</param>
     public static void MapValue(StepperHandler handler, IStepper stepper)
     {
         if (handler.PlatformView is PlatformView platformView)
@@ -90,6 +114,9 @@ public partial class StepperHandler : ViewHandler<IStepper, PlatformView>
         }
     }
 
+    /// <summary>Maps the Background property to the platform view.</summary>
+    /// <param name="handler">The handler for the stepper.</param>
+    /// <param name="stepper">The virtual view.</param>
     public static void MapBackground(StepperHandler handler, IStepper stepper)
     {
         ViewHandler.MapBackground(handler, stepper);

--- a/src/Avalonia.Controls.Maui/Handlers/SwipeItemMenuItemHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/SwipeItemMenuItemHandler.cs
@@ -4,12 +4,10 @@ using PlatformView = Avalonia.Controls.Button;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-/// <summary>
-/// Handler for .NET MAUI SwipeItemMenuItem to Avalonia platform-native menu item mapping.
-/// Maps ISwipeItemMenuItem cross-platform interface to platform-specific menu item implementations.
-/// </summary>
+/// <summary>Avalonia handler for <see cref="ISwipeItemMenuItem"/>.</summary>
 public partial class SwipeItemMenuItemHandler : ElementHandler<ISwipeItemMenuItem, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="SwipeItemMenuItemHandler"/>.</summary>
     public static IPropertyMapper<ISwipeItemMenuItem, SwipeItemMenuItemHandler> Mapper =
         new PropertyMapper<ISwipeItemMenuItem, SwipeItemMenuItemHandler>(ElementHandler.ElementMapper)
         {
@@ -22,25 +20,33 @@ public partial class SwipeItemMenuItemHandler : ElementHandler<ISwipeItemMenuIte
             [nameof(IMenuElement.Source)] = MapSource,
         };
 
+    /// <summary>Command mapper for <see cref="SwipeItemMenuItemHandler"/>.</summary>
     public static CommandMapper<ISwipeItemMenuItem, SwipeItemMenuItemHandler> CommandMapper =
         new(ElementHandler.ElementCommandMapper)
         {
         };
 
+    /// <summary>Initializes a new instance of <see cref="SwipeItemMenuItemHandler"/>.</summary>
     public SwipeItemMenuItemHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="SwipeItemMenuItemHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
     protected SwipeItemMenuItemHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="SwipeItemMenuItemHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
+    /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
     protected SwipeItemMenuItemHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform element for this handler.</summary>
     protected override PlatformView CreatePlatformElement()
     {
         var button = new PlatformView
@@ -55,57 +61,84 @@ public partial class SwipeItemMenuItemHandler : ElementHandler<ISwipeItemMenuIte
         return button;
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         base.ConnectHandler(platformView);
         platformView.Click += OnButtonClick;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         platformView.Click -= OnButtonClick;
         base.DisconnectHandler(platformView);
     }
-    
+
+    /// <summary>Maps the Visibility property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The virtual view.</param>
     public static void MapVisibility(SwipeItemMenuItemHandler handler, ISwipeItemMenuItem view)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateVisibility(view);
     }
 
+    /// <summary>Maps the Background property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The virtual view.</param>
     public static void MapBackground(SwipeItemMenuItemHandler handler, ISwipeItemMenuItem view)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateBackground(view);
     }
 
+    /// <summary>Maps the Text property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The virtual view.</param>
     public static void MapText(SwipeItemMenuItemHandler handler, ISwipeItemMenuItem view)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateText(view);
     }
 
+    /// <summary>Maps the TextColor property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The virtual view.</param>
     public static void MapTextColor(SwipeItemMenuItemHandler handler, ISwipeItemMenuItem view)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateTextColor(view);
     }
 
+    /// <summary>Maps the CharacterSpacing property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The virtual view.</param>
     public static void MapCharacterSpacing(SwipeItemMenuItemHandler handler, ISwipeItemMenuItem view)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateCharacterSpacing(view);
     }
 
+    /// <summary>Maps the Font property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The virtual view.</param>
     public static void MapFont(SwipeItemMenuItemHandler handler, ISwipeItemMenuItem view)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateFont(view, handler);
     }
 
+    /// <summary>Maps the Source property to the platform view.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The virtual view.</param>
     public static void MapSource(SwipeItemMenuItemHandler handler, ISwipeItemMenuItem view) =>
         MapSourceAsync(handler, view).FireAndForget(handler);
 
+    /// <summary>Maps the Source property to the platform view asynchronously.</summary>
+    /// <param name="handler">The handler.</param>
+    /// <param name="view">The virtual view.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     public static async Task MapSourceAsync(SwipeItemMenuItemHandler handler, ISwipeItemMenuItem view)
     {
         if (handler.PlatformView is not PlatformView platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/SwipeItemViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/SwipeItemViewHandler.cs
@@ -5,30 +5,36 @@ using PlatformView = Avalonia.Controls.ContentControl;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-/// <summary>
-/// Handler for .NET MAUI SwipeItemView to Avalonia ContentControl mapping
-/// </summary>
+/// <summary>Avalonia handler for <see cref="ISwipeItemView"/>.</summary>
 public partial class SwipeItemViewHandler : ContentViewHandler
 {
+    /// <summary>Property mapper for <see cref="SwipeItemViewHandler"/>.</summary>
     public static new IPropertyMapper<ISwipeItemView, SwipeItemViewHandler> Mapper =
         new PropertyMapper<ISwipeItemView, SwipeItemViewHandler>(ContentViewHandler.Mapper)
         {
         };
 
+    /// <summary>Command mapper for <see cref="SwipeItemViewHandler"/>.</summary>
     public static new CommandMapper<ISwipeItemView, SwipeItemViewHandler> CommandMapper =
         new(ContentViewHandler.CommandMapper)
         {
         };
 
+    /// <summary>Initializes a new instance of <see cref="SwipeItemViewHandler"/>.</summary>
     public SwipeItemViewHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="SwipeItemViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
     public SwipeItemViewHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="SwipeItemViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
+    /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
     public SwipeItemViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {

--- a/src/Avalonia.Controls.Maui/Handlers/SwipeViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/SwipeViewHandler.cs
@@ -4,11 +4,10 @@ using PlatformView = Avalonia.Controls.Maui.Swipe;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-/// <summary>
-/// Handler for .NET MAUI SwipeView to Avalonia.Labs Swipe mapping
-/// </summary>
+/// <summary>Avalonia handler for <see cref="ISwipeView"/>.</summary>
 public partial class SwipeViewHandler : ViewHandler<ISwipeView, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="SwipeViewHandler"/>.</summary>
     public static IPropertyMapper<ISwipeView, SwipeViewHandler> Mapper =
         new PropertyMapper<ISwipeView, SwipeViewHandler>(ViewHandler.ViewMapper)
         {
@@ -21,6 +20,7 @@ public partial class SwipeViewHandler : ViewHandler<ISwipeView, PlatformView>
             [nameof(ISwipeView.Threshold)] = MapThreshold,
         };
 
+    /// <summary>Command mapper for <see cref="SwipeViewHandler"/>.</summary>
     public static CommandMapper<ISwipeView, SwipeViewHandler> CommandMapper =
         new(ViewCommandMapper)
         {
@@ -28,25 +28,33 @@ public partial class SwipeViewHandler : ViewHandler<ISwipeView, PlatformView>
             [nameof(ISwipeView.RequestClose)] = MapRequestClose,
         };
 
+    /// <summary>Initializes a new instance of <see cref="SwipeViewHandler"/>.</summary>
     public SwipeViewHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="SwipeViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public SwipeViewHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="SwipeViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public SwipeViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         base.ConnectHandler(platformView);
@@ -56,6 +64,7 @@ public partial class SwipeViewHandler : ViewHandler<ISwipeView, PlatformView>
         platformView.ExecuteRequested += OnExecuteRequested;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         platformView.SwipeStarted -= OnSwipeStarted;
@@ -64,49 +73,74 @@ public partial class SwipeViewHandler : ViewHandler<ISwipeView, PlatformView>
         platformView.ExecuteRequested -= OnExecuteRequested;
         base.DisconnectHandler(platformView);
     }
-    
+
+    /// <summary>Maps the Background property to the platform view.</summary>
+    /// <param name="handler">The handler for the swipe view.</param>
+    /// <param name="swipeView">The virtual swipe view.</param>
     public static void MapBackground(SwipeViewHandler handler, ISwipeView swipeView)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateBackground(swipeView);
     }
 
+    /// <summary>Maps the Content property to the platform view.</summary>
+    /// <param name="handler">The handler for the swipe view.</param>
+    /// <param name="swipeView">The virtual swipe view.</param>
     public static void MapContent(SwipeViewHandler handler, ISwipeView swipeView)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateContent(swipeView, handler.MauiContext);
     }
 
+    /// <summary>Maps the LeftItems property to the platform view.</summary>
+    /// <param name="handler">The handler for the swipe view.</param>
+    /// <param name="swipeView">The virtual swipe view.</param>
     public static void MapLeftItems(SwipeViewHandler handler, ISwipeView swipeView)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateLeftItems(swipeView, handler.MauiContext);
     }
 
+    /// <summary>Maps the RightItems property to the platform view.</summary>
+    /// <param name="handler">The handler for the swipe view.</param>
+    /// <param name="swipeView">The virtual swipe view.</param>
     public static void MapRightItems(SwipeViewHandler handler, ISwipeView swipeView)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateRightItems(swipeView, handler.MauiContext);
     }
 
+    /// <summary>Maps the TopItems property to the platform view.</summary>
+    /// <param name="handler">The handler for the swipe view.</param>
+    /// <param name="swipeView">The virtual swipe view.</param>
     public static void MapTopItems(SwipeViewHandler handler, ISwipeView swipeView)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateTopItems(swipeView, handler.MauiContext);
     }
 
+    /// <summary>Maps the BottomItems property to the platform view.</summary>
+    /// <param name="handler">The handler for the swipe view.</param>
+    /// <param name="swipeView">The virtual swipe view.</param>
     public static void MapBottomItems(SwipeViewHandler handler, ISwipeView swipeView)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateBottomItems(swipeView, handler.MauiContext);
     }
 
+    /// <summary>Maps the Threshold property to the platform view.</summary>
+    /// <param name="handler">The handler for the swipe view.</param>
+    /// <param name="swipeView">The virtual swipe view.</param>
     public static void MapThreshold(SwipeViewHandler handler, ISwipeView swipeView)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.UpdateThreshold(swipeView);
     }
 
+    /// <summary>Maps the RequestOpen command to the platform view.</summary>
+    /// <param name="handler">The handler for the swipe view.</param>
+    /// <param name="swipeView">The virtual swipe view.</param>
+    /// <param name="args">The open request arguments.</param>
     public static void MapRequestOpen(SwipeViewHandler handler, ISwipeView swipeView, object? args)
     {
         if (handler.PlatformView is PlatformView platformView && args is SwipeViewOpenRequest request)
@@ -124,12 +158,16 @@ public partial class SwipeViewHandler : ViewHandler<ISwipeView, PlatformView>
         }
     }
 
+    /// <summary>Maps the RequestClose command to the platform view.</summary>
+    /// <param name="handler">The handler for the swipe view.</param>
+    /// <param name="swipeView">The virtual swipe view.</param>
+    /// <param name="args">The close request arguments.</param>
     public static void MapRequestClose(SwipeViewHandler handler, ISwipeView swipeView, object? args)
     {
         if (handler.PlatformView is PlatformView platformView)
             platformView.SetSwipeState(SwipeState.Hidden, animated: true);
     }
-    
+
     private void OnSwipeStarted(object? sender, SwipeStartedEventArgs e)
     {
         if (VirtualView == null) return;

--- a/src/Avalonia.Controls.Maui/Handlers/SwitchHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/SwitchHandler.cs
@@ -5,13 +5,12 @@ using PlatformView = Avalonia.Controls.ToggleSwitch;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-/// <summary>
-/// Handler that maps MAUI <see cref="ISwitch"/> to Avalonia <see cref="ToggleSwitch"/>.
-/// </summary>
+/// <summary>Avalonia handler for <see cref="ISwitch"/>.</summary>
 public partial class SwitchHandler : ViewHandler<ISwitch, PlatformView>
 {
     private bool _isUpdating;
 
+    /// <summary>Property mapper for <see cref="SwitchHandler"/>.</summary>
     public static IPropertyMapper<ISwitch, SwitchHandler> Mapper = new PropertyMapper<ISwitch, SwitchHandler>(ViewHandler.ViewMapper)
     {
         [nameof(ISwitch.IsOn)] = MapIsOn,
@@ -21,24 +20,32 @@ public partial class SwitchHandler : ViewHandler<ISwitch, PlatformView>
         [nameof(Microsoft.Maui.Controls.Switch.OnColor)] = MapTrackColor,
     };
 
+    /// <summary>Command mapper for <see cref="SwitchHandler"/>.</summary>
     public static CommandMapper<ISwitch, SwitchHandler> CommandMapper = new(ViewHandler.ViewCommandMapper)
     {
     };
 
+    /// <summary>Initializes a new instance of <see cref="SwitchHandler"/>.</summary>
     public SwitchHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="SwitchHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
     public SwitchHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="SwitchHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
+    /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
     public SwitchHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView()
     {
         return new PlatformView
@@ -48,18 +55,23 @@ public partial class SwitchHandler : ViewHandler<ISwitch, PlatformView>
         };
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         base.ConnectHandler(platformView);
         platformView.IsCheckedChanged += OnIsCheckedChanged;
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         platformView.IsCheckedChanged -= OnIsCheckedChanged;
         base.DisconnectHandler(platformView);
     }
 
+    /// <summary>Maps the IsOn property to the platform view.</summary>
+    /// <param name="handler">The handler for the switch.</param>
+    /// <param name="view">The virtual view.</param>
     public static void MapIsOn(SwitchHandler handler, ISwitch view)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -85,6 +97,9 @@ public partial class SwitchHandler : ViewHandler<ISwitch, PlatformView>
         }
     }
 
+    /// <summary>Maps the TrackColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the switch.</param>
+    /// <param name="view">The virtual view.</param>
     public static void MapTrackColor(SwitchHandler handler, ISwitch view)
     {
         if (handler is SwitchHandler switchHandler)
@@ -93,6 +108,9 @@ public partial class SwitchHandler : ViewHandler<ISwitch, PlatformView>
         }
     }
 
+    /// <summary>Maps the ThumbColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the switch.</param>
+    /// <param name="view">The virtual view.</param>
     public static void MapThumbColor(SwitchHandler handler, ISwitch view)
     {
         if (handler is SwitchHandler switchHandler)

--- a/src/Avalonia.Controls.Maui/Handlers/TabbedPageHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/TabbedPageHandler.cs
@@ -5,8 +5,10 @@ using System.Collections.Specialized;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="TabbedPage"/>.</summary>
 public partial class TabbedPageHandler : ViewHandler<TabbedPage, TabControl>
 {
+    /// <summary>Property mapper for <see cref="TabbedPageHandler"/>.</summary>
     public static IPropertyMapper<TabbedPage, TabbedPageHandler> Mapper =
         new PropertyMapper<TabbedPage, TabbedPageHandler>(ViewMapper)
         {
@@ -21,23 +23,31 @@ public partial class TabbedPageHandler : ViewHandler<TabbedPage, TabControl>
             [nameof(MultiPage<Page>.SelectedItem)] = MapSelectedItem,
         };
 
+    /// <summary>Command mapper for <see cref="TabbedPageHandler"/>.</summary>
     public static CommandMapper<TabbedPage, TabbedPageHandler> CommandMapper =
         new(ViewCommandMapper);
-    
+
+    /// <summary>Initializes a new instance of <see cref="TabbedPageHandler"/>.</summary>
     public TabbedPageHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="TabbedPageHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public TabbedPageHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="TabbedPageHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public TabbedPageHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override TabControl CreatePlatformView()
     {
         if (VirtualView == null)
@@ -58,6 +68,7 @@ public partial class TabbedPageHandler : ViewHandler<TabbedPage, TabControl>
         return tabControl;
     }
 
+    /// <inheritdoc/>
     public override void SetVirtualView(IView view)
     {
         base.SetVirtualView(view);
@@ -71,7 +82,8 @@ public partial class TabbedPageHandler : ViewHandler<TabbedPage, TabControl>
         // Load initial pages - this is needed since Children is not a mapped property
         PlatformView.UpdateChildren(VirtualView, MauiContext);
     }
-    
+
+    /// <inheritdoc/>
     protected override void DisconnectHandler(TabControl platformView)
     {
         VirtualView.PagesChanged -= OnPagesChanged;
@@ -85,51 +97,79 @@ public partial class TabbedPageHandler : ViewHandler<TabbedPage, TabControl>
     {
         PlatformView.UpdateChildren(VirtualView, MauiContext);
     }
-    
+
+    /// <summary>Maps the BarBackground property to the platform view.</summary>
+    /// <param name="handler">The handler for the tabbed page.</param>
+    /// <param name="tabbedPage">The virtual tabbed page.</param>
     public static void MapBarBackground(TabbedPageHandler handler, TabbedPage tabbedPage)
     {
         handler.PlatformView?.UpdateBarBackground(tabbedPage);
     }
-    
+
+    /// <summary>Maps the BarBackgroundColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the tabbed page.</param>
+    /// <param name="tabbedPage">The virtual tabbed page.</param>
     public static void MapBarBackgroundColor(TabbedPageHandler handler, TabbedPage tabbedPage)
     {
         handler.PlatformView?.UpdateBarBackgroundColor(tabbedPage);
     }
-    
+
+    /// <summary>Maps the BarTextColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the tabbed page.</param>
+    /// <param name="tabbedPage">The virtual tabbed page.</param>
     public static void MapBarTextColor(TabbedPageHandler handler, TabbedPage tabbedPage)
     {
         handler.PlatformView?.UpdateBarTextColor(tabbedPage);
     }
 
+    /// <summary>Maps the SelectedTabColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the tabbed page.</param>
+    /// <param name="tabbedPage">The virtual tabbed page.</param>
     public static void MapSelectedTabColor(TabbedPageHandler handler, TabbedPage tabbedPage)
     {
         handler.PlatformView?.UpdateSelectedTabColor(tabbedPage);
     }
-    
+
+    /// <summary>Maps the UnselectedTabColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the tabbed page.</param>
+    /// <param name="tabbedPage">The virtual tabbed page.</param>
     public static void MapUnselectedTabColor(TabbedPageHandler handler, TabbedPage tabbedPage)
     {
         handler.PlatformView?.UpdateUnselectedTabColor(tabbedPage);
     }
 
+    /// <summary>Maps the CurrentPage property to the platform view.</summary>
+    /// <param name="handler">The handler for the tabbed page.</param>
+    /// <param name="tabbedPage">The virtual tabbed page.</param>
     public static void MapCurrentPage(TabbedPageHandler handler, TabbedPage tabbedPage)
     {
         handler.PlatformView?.UpdateCurrentPage(tabbedPage);
     }
+
+    /// <summary>Maps the ItemsSource property to the platform view.</summary>
+    /// <param name="handler">The handler for the tabbed page.</param>
+    /// <param name="tabbedPage">The virtual tabbed page.</param>
     public static void MapItemsSource(TabbedPageHandler handler, TabbedPage tabbedPage)
     {
         handler.PlatformView?.UpdateChildren(tabbedPage, handler.MauiContext);
     }
 
+    /// <summary>Maps the ItemTemplate property to the platform view.</summary>
+    /// <param name="handler">The handler for the tabbed page.</param>
+    /// <param name="tabbedPage">The virtual tabbed page.</param>
     public static void MapItemTemplate(TabbedPageHandler handler, TabbedPage tabbedPage)
     {
         handler.PlatformView?.UpdateChildren(tabbedPage, handler.MauiContext);
     }
 
+    /// <summary>Maps the SelectedItem property to the platform view.</summary>
+    /// <param name="handler">The handler for the tabbed page.</param>
+    /// <param name="tabbedPage">The virtual tabbed page.</param>
     public static void MapSelectedItem(TabbedPageHandler handler, TabbedPage tabbedPage)
     {
         handler.PlatformView?.UpdateSelectedItem(tabbedPage);
     }
-    
+
     private void OnTabSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
         var selectedIndex = PlatformView.SelectedIndex;
@@ -141,7 +181,7 @@ public partial class TabbedPageHandler : ViewHandler<TabbedPage, TabControl>
                 VirtualView.CurrentPage = selectedPage;
             }
         }
-        
+
         // Re-apply tab colors when selection changes to update Selected/Unselected states
         PlatformView.UpdateTabColors(VirtualView);
     }

--- a/src/Avalonia.Controls.Maui/Handlers/TimePickerHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/TimePickerHandler.cs
@@ -4,8 +4,10 @@ using PlatformView = Avalonia.Controls.TimePicker;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="ITimePicker"/>.</summary>
 public class TimePickerHandler : ViewHandler<ITimePicker, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="TimePickerHandler"/>.</summary>
     public static IPropertyMapper<ITimePicker, TimePickerHandler> Mapper = new PropertyMapper<ITimePicker, TimePickerHandler>(ViewHandler.ViewMapper)
     {
         [nameof(ITimePicker.CharacterSpacing)] = MapCharacterSpacing,
@@ -15,40 +17,54 @@ public class TimePickerHandler : ViewHandler<ITimePicker, PlatformView>
         [nameof(ITimePicker.Time)] = MapTime,
     };
 
+    /// <summary>Command mapper for <see cref="TimePickerHandler"/>.</summary>
     public static CommandMapper<ITimePicker, TimePickerHandler> CommandMapper = new(ViewCommandMapper)
     {
     };
 
+    /// <summary>Initializes a new instance of <see cref="TimePickerHandler"/>.</summary>
     public TimePickerHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="TimePickerHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
     public TimePickerHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="TimePickerHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <see langword="null"/> to use the default.</param>
+    /// <param name="commandMapper">The command mapper to use, or <see langword="null"/> to use the default.</param>
     public TimePickerHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformView() => new PlatformView();
 
+    /// <summary>Gets a value indicating whether this handler requires a container view.</summary>
     public override bool NeedsContainer => false;
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(PlatformView platformView)
     {
         platformView.SelectedTimeChanged += OnSelectedTimeChanged;
         base.ConnectHandler(platformView);
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(PlatformView platformView)
     {
         platformView.SelectedTimeChanged -= OnSelectedTimeChanged;
         base.DisconnectHandler(platformView);
     }
 
+    /// <summary>Maps the Time property to the platform view.</summary>
+    /// <param name="handler">The handler for the time picker.</param>
+    /// <param name="timePicker">The virtual view.</param>
     public static void MapTime(TimePickerHandler handler, ITimePicker timePicker)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -57,6 +73,9 @@ public class TimePickerHandler : ViewHandler<ITimePicker, PlatformView>
         platformView.UpdateTime(timePicker);
     }
 
+    /// <summary>Maps the Format property to the platform view.</summary>
+    /// <param name="handler">The handler for the time picker.</param>
+    /// <param name="timePicker">The virtual view.</param>
     public static void MapFormat(TimePickerHandler handler, ITimePicker timePicker)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -65,6 +84,9 @@ public class TimePickerHandler : ViewHandler<ITimePicker, PlatformView>
         platformView.UpdateFormat(timePicker);
     }
 
+    /// <summary>Maps the CharacterSpacing property to the platform view.</summary>
+    /// <param name="handler">The handler for the time picker.</param>
+    /// <param name="timePicker">The virtual view.</param>
     public static void MapCharacterSpacing(TimePickerHandler handler, ITimePicker timePicker)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -73,6 +95,9 @@ public class TimePickerHandler : ViewHandler<ITimePicker, PlatformView>
         platformView.UpdateCharacterSpacing(timePicker);
     }
 
+    /// <summary>Maps the Font property to the platform view.</summary>
+    /// <param name="handler">The handler for the time picker.</param>
+    /// <param name="timePicker">The virtual view.</param>
     public static void MapFont(TimePickerHandler handler, ITimePicker timePicker)
     {
         if (handler.PlatformView is not PlatformView platformView)
@@ -82,6 +107,9 @@ public class TimePickerHandler : ViewHandler<ITimePicker, PlatformView>
         platformView.UpdateFont(timePicker, fontManager);
     }
 
+    /// <summary>Maps the TextColor property to the platform view.</summary>
+    /// <param name="handler">The handler for the time picker.</param>
+    /// <param name="timePicker">The virtual view.</param>
     public static void MapTextColor(TimePickerHandler handler, ITimePicker timePicker)
     {
         if (handler.PlatformView is not PlatformView platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/TitleBarHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/TitleBarHandler.cs
@@ -6,11 +6,10 @@ using System;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
-/// <summary>
-/// Handler for MAUI TitleBar control on Avalonia.
-/// </summary>
+/// <summary>Avalonia handler for <see cref="ITitleBar"/>.</summary>
 public partial class TitleBarHandler : ViewHandler<ITitleBar, TitleBarView>
 {
+    /// <summary>Property mapper for <see cref="TitleBarHandler"/>.</summary>
     public static IPropertyMapper<ITitleBar, TitleBarHandler> Mapper =
         new PropertyMapper<ITitleBar, TitleBarHandler>(ViewMapper)
         {
@@ -20,23 +19,31 @@ public partial class TitleBarHandler : ViewHandler<ITitleBar, TitleBarView>
             [nameof(ITitleBar.PassthroughElements)] = MapPassthroughElements,
         };
 
+    /// <summary>Command mapper for <see cref="TitleBarHandler"/>.</summary>
     public static CommandMapper<ITitleBar, TitleBarHandler> CommandMapper =
         new(ViewCommandMapper);
 
+    /// <summary>Initializes a new instance of <see cref="TitleBarHandler"/>.</summary>
     public TitleBarHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="TitleBarHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public TitleBarHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="TitleBarHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public TitleBarHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override TitleBarView CreatePlatformView()
     {
         if (VirtualView == null)
@@ -54,6 +61,7 @@ public partial class TitleBarHandler : ViewHandler<ITitleBar, TitleBarView>
         return view;
     }
 
+    /// <inheritdoc/>
     public override void SetVirtualView(IView view)
     {
         base.SetVirtualView(view);
@@ -65,21 +73,33 @@ public partial class TitleBarHandler : ViewHandler<ITitleBar, TitleBarView>
         PlatformView.CrossPlatformLayout = VirtualView;
     }
 
+    /// <summary>Maps the Title property to the platform view.</summary>
+    /// <param name="handler">The handler for the title bar.</param>
+    /// <param name="titleBar">The virtual title bar.</param>
     public static void MapTitle(TitleBarHandler handler, ITitleBar titleBar)
     {
         handler.PlatformView.TitleBar = titleBar;
     }
 
+    /// <summary>Maps the Subtitle property to the platform view.</summary>
+    /// <param name="handler">The handler for the title bar.</param>
+    /// <param name="titleBar">The virtual title bar.</param>
     public static void MapSubtitle(TitleBarHandler handler, ITitleBar titleBar)
     {
         handler.PlatformView.TitleBar = titleBar;
     }
 
+    /// <summary>Maps the Content property to the platform view.</summary>
+    /// <param name="handler">The handler for the title bar.</param>
+    /// <param name="titleBar">The virtual title bar.</param>
     public static void MapContent(TitleBarHandler handler, ITitleBar titleBar)
     {
         handler.UpdateContent();
     }
 
+    /// <summary>Maps the PassthroughElements property to the platform view.</summary>
+    /// <param name="handler">The handler for the title bar.</param>
+    /// <param name="titleBar">The virtual title bar.</param>
     public static void MapPassthroughElements(TitleBarHandler handler, ITitleBar titleBar)
     {
         handler.UpdatePassthroughElements();

--- a/src/Avalonia.Controls.Maui/Handlers/ToolbarHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ToolbarHandler.cs
@@ -4,35 +4,48 @@ using PlatformView = Avalonia.Controls.Menu;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="IToolbar"/>.</summary>
 public partial class ToolbarHandler : ElementHandler<IToolbar, PlatformView>
 {
+    /// <summary>Property mapper for <see cref="ToolbarHandler"/>.</summary>
     public static IPropertyMapper<IToolbar, ToolbarHandler> Mapper =
         new PropertyMapper<IToolbar, ToolbarHandler>(ElementMapper)
         {
             [nameof(IToolbar.Title)] = MapTitle,
         };
 
+    /// <summary>Command mapper for <see cref="ToolbarHandler"/>.</summary>
     public static CommandMapper<IToolbar, ToolbarHandler> CommandMapper = new();
 
+    /// <summary>Initializes a new instance of <see cref="ToolbarHandler"/>.</summary>
     public ToolbarHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="ToolbarHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public ToolbarHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="ToolbarHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public ToolbarHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlatformView CreatePlatformElement()
     {
         return new PlatformView();
     }
 
+    /// <summary>Maps the Title property to the platform view.</summary>
+    /// <param name="handler">The handler for the toolbar.</param>
+    /// <param name="toolbar">The virtual toolbar.</param>
     public static void MapTitle(ToolbarHandler handler, IToolbar toolbar)
     {
         // Avalonia Menu doesn't have a direct Title property

--- a/src/Avalonia.Controls.Maui/Handlers/ViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ViewHandler.cs
@@ -7,6 +7,10 @@ using PlatformView = Avalonia.Controls.Control;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>
+/// Base Avalonia handler for <see cref="IView"/>. Provides property and command mappers
+/// that translate MAUI view properties to Avalonia platform equivalents.
+/// </summary>
 public abstract partial class ViewHandler : ElementHandler, IViewHandler
 {
     /// <summary>
@@ -66,6 +70,9 @@ public abstract partial class ViewHandler : ElementHandler, IViewHandler
 
     bool _hasContainer;
 
+    /// <summary>
+    /// Gets or sets the data flow direction used for property mapping.
+    /// </summary>
     internal DataFlowDirection DataFlowDirection { get; set; }
 
     /// <summary>
@@ -170,6 +177,13 @@ public abstract partial class ViewHandler : ElementHandler, IViewHandler
         }
     }
 
+    /// <summary>
+    /// Performs the core measurement of the platform view against the given constraints.
+    /// </summary>
+    /// <param name="platformView">The Avalonia platform view to measure.</param>
+    /// <param name="widthConstraint">The maximum width constraint.</param>
+    /// <param name="heightConstraint">The maximum height constraint.</param>
+    /// <returns>The desired size of the platform view.</returns>
     private static Microsoft.Maui.Graphics.Size MeasureCore(PlatformView platformView, double widthConstraint, double heightConstraint)
     {
         var avaloniaConstraint = new global::Avalonia.Size(
@@ -193,6 +207,10 @@ public abstract partial class ViewHandler : ElementHandler, IViewHandler
             Avalonia.Threading.Dispatcher.UIThread.Invoke(() => Arrange(frame));
     }
 
+    /// <summary>
+    /// Arranges the platform view within the specified frame, compensating for MAUI/Avalonia margin differences.
+    /// </summary>
+    /// <param name="frame">The frame rectangle provided by the MAUI layout system.</param>
     private protected void Arrange(Microsoft.Maui.Graphics.Rect frame)
     {
         if (PlatformView is null)
@@ -212,8 +230,13 @@ public abstract partial class ViewHandler : ElementHandler, IViewHandler
     }
 
 
+    /// <summary>
+    /// Creates the Avalonia platform view for this handler.
+    /// </summary>
+    /// <returns>The newly created platform view.</returns>
     private protected abstract PlatformView OnCreatePlatformView();
 
+    /// <inheritdoc/>
     public sealed override object OnCreatePlatformElement() =>
         OnCreatePlatformView();
 
@@ -719,6 +742,11 @@ public abstract partial class ViewHandler : ElementHandler, IViewHandler
         }
     }
 
+    /// <summary>
+    /// Maps the context flyout from a <see cref="IContextFlyoutElement"/> to the Avalonia platform view.
+    /// </summary>
+    /// <param name="handler">The associated element handler.</param>
+    /// <param name="contextFlyoutContainer">The context flyout element containing the flyout to map.</param>
     internal static void MapContextFlyout(IElementHandler handler, IContextFlyoutElement contextFlyoutContainer)
     {
         _ = handler.MauiContext ?? throw new InvalidOperationException($"The handler's {nameof(handler.MauiContext)} cannot be null.");

--- a/src/Avalonia.Controls.Maui/Handlers/ViewHandlerOfT.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ViewHandlerOfT.cs
@@ -8,6 +8,12 @@ using PlatformView = Avalonia.Controls.Control;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>
+/// Generic base Avalonia handler for <see cref="IView"/>. Maps a MAUI virtual view of type
+/// <typeparamref name="TVirtualView"/> to an Avalonia control of type <typeparamref name="TPlatformView"/>.
+/// </summary>
+/// <typeparam name="TVirtualView">The MAUI virtual view interface type.</typeparam>
+/// <typeparam name="TPlatformView">The Avalonia platform view type.</typeparam>
 public abstract partial class ViewHandler<TVirtualView, TPlatformView> : ViewHandler, IViewHandler
         where TVirtualView : class, IView
         where TPlatformView : PlatformView
@@ -15,32 +21,51 @@ public abstract partial class ViewHandler<TVirtualView, TPlatformView> : ViewHan
     private Avalonia.Controls.Maui.Platform.GestureManager? _gestureManager;
     private bool _isLoaded;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ViewHandler{TVirtualView, TPlatformView}"/> class.
+    /// </summary>
+    /// <param name="mapper">The property mapper to use for this handler.</param>
+    /// <param name="commandMapper">The command mapper to use for this handler.</param>
     protected ViewHandler(IPropertyMapper mapper, CommandMapper? commandMapper = null)
         : base(mapper, commandMapper)
     {
     }
 
+    /// <summary>
+    /// Gets the strongly-typed Avalonia platform view associated with this handler.
+    /// </summary>
     public new TPlatformView PlatformView
     {
         get => (TPlatformView?)base.PlatformView ?? throw new InvalidOperationException($"PlatformView cannot be null here");
         private protected set => base.PlatformView = value;
     }
 
+    /// <summary>
+    /// Gets the strongly-typed MAUI virtual view associated with this handler.
+    /// </summary>
     public new TVirtualView VirtualView
     {
         get => (TVirtualView?)base.VirtualView ?? throw new InvalidOperationException($"VirtualView cannot be null here");
         private protected set => base.VirtualView = value;
     }
 
+    /// <inheritdoc/>
     IView? IViewHandler.VirtualView => base.VirtualView;
 
+    /// <inheritdoc/>
     IElement? IElementHandler.VirtualView => base.VirtualView;
 
+    /// <inheritdoc/>
     object? IElementHandler.PlatformView => base.PlatformView;
 
+    /// <summary>
+    /// Sets the MAUI virtual view for this handler.
+    /// </summary>
+    /// <param name="view">The <see cref="IView"/> to associate with this handler.</param>
     public virtual void SetVirtualView(IView view) =>
         base.SetVirtualView(view);
 
+    /// <inheritdoc/>
     public sealed override void SetVirtualView(IElement view) =>
         SetVirtualView((IView)view);
 
@@ -89,17 +114,21 @@ public abstract partial class ViewHandler<TVirtualView, TPlatformView> : ViewHan
         _gestureManager = null;
     }
 
+    /// <inheritdoc/>
     private protected override PlatformView OnCreatePlatformView()
     {
         return PlatformViewFactory?.Invoke(this) ?? CreatePlatformView();
     }
 
+    /// <inheritdoc/>
     public override void OnConnectHandler(object platformView) =>
         ConnectHandler((TPlatformView)platformView);
 
+    /// <inheritdoc/>
     public override void OnDisconnectHandler(object platformView) =>
         DisconnectHandler((TPlatformView)platformView);
 
+    /// <inheritdoc/>
     protected override void SetupContainer()
     {
         if (PlatformView == null)
@@ -110,6 +139,7 @@ public abstract partial class ViewHandler<TVirtualView, TPlatformView> : ViewHan
         ContainerView = containerView;
     }
 
+    /// <inheritdoc/>
     protected override void RemoveContainer()
     {
         if (ContainerView is Avalonia.Controls.Maui.Platform.ContentView container && PlatformView != null)
@@ -120,6 +150,9 @@ public abstract partial class ViewHandler<TVirtualView, TPlatformView> : ViewHan
         ContainerView = null;
     }
 
+    /// <summary>
+    /// Attaches event handlers to the platform view for lifecycle, focus, and bounds tracking.
+    /// </summary>
     private void AttachPlatformViewEvents(TPlatformView platformView)
     {
         platformView.AttachedToVisualTree += OnPlatformViewAttachedToVisualTree;
@@ -140,6 +173,9 @@ public abstract partial class ViewHandler<TVirtualView, TPlatformView> : ViewHan
         }
     }
 
+    /// <summary>
+    /// Detaches event handlers from the platform view.
+    /// </summary>
     private void DetachPlatformViewEvents(TPlatformView platformView)
     {
         platformView.AttachedToVisualTree -= OnPlatformViewAttachedToVisualTree;

--- a/src/Avalonia.Controls.Maui/Handlers/WebViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/WebViewHandler.cs
@@ -5,27 +5,37 @@ using Microsoft.Maui.Controls;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>Avalonia handler for <see cref="WebView"/>.</summary>
 [Avalonia.Controls.Maui.Platform.NotImplemented("WebView is not yet implemented for the Avalonia backend")]
 public class WebViewHandler : ViewHandler<WebView, PlaceholderControl>
 {
+    /// <summary>Property mapper for <see cref="WebViewHandler"/>.</summary>
     public static IPropertyMapper<WebView, WebViewHandler> Mapper = new PropertyMapper<WebView, WebViewHandler>(ViewHandler.ViewMapper);
 
+    /// <summary>Command mapper for <see cref="WebViewHandler"/>.</summary>
     public static CommandMapper<WebView, WebViewHandler> CommandMapper = new(ViewCommandMapper);
 
+    /// <summary>Initializes a new instance of <see cref="WebViewHandler"/>.</summary>
     public WebViewHandler() : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="WebViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
     public WebViewHandler(IPropertyMapper? mapper)
         : base(mapper ?? Mapper, CommandMapper)
     {
     }
 
+    /// <summary>Initializes a new instance of <see cref="WebViewHandler"/>.</summary>
+    /// <param name="mapper">The property mapper to use, or <c>null</c> to use the default mapper.</param>
+    /// <param name="commandMapper">The command mapper to use, or <c>null</c> to use the default command mapper.</param>
     public WebViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper)
     {
     }
 
+    /// <summary>Creates the Avalonia platform view for this handler.</summary>
     protected override PlaceholderControl CreatePlatformView()
     {
         return new PlaceholderControl("WebView is not available in this version of Avalonia.Controls.Maui");

--- a/src/Avalonia.Controls.Maui/Handlers/WindowHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/WindowHandler.cs
@@ -10,10 +10,17 @@ using System.Text;
 
 namespace Avalonia.Controls.Maui.Handlers;
 
+/// <summary>
+/// Avalonia handler for <see cref="IWindow"/>. Creates and manages an Avalonia <see cref="Avalonia.Controls.Window"/>
+/// for desktop application lifetimes.
+/// </summary>
 public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.Window>
 {
     static readonly AlertManager s_alertManager = new();
 
+    /// <summary>
+    /// Property mapper for <see cref="WindowHandler"/>.
+    /// </summary>
     public static IPropertyMapper<IWindow, WindowHandler> Mapper = new PropertyMapper<IWindow, WindowHandler>(ElementHandler.ElementMapper)
     {
         [nameof(IWindow.Title)] = mapTitle,
@@ -30,11 +37,20 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
         [nameof(IWindow.FlowDirection)] = mapFlowDirection,
     };
 
+    /// <summary>
+    /// Command mapper for <see cref="WindowHandler"/>.
+    /// </summary>
     static CommandMapper<IWindow, WindowHandler> CommandMapper = new(ElementCommandMapper)
     {
         [nameof(IWindow.RequestDisplayDensity)] = MapRequestDisplayDensity,
     };
 
+    /// <summary>
+    /// Maps the <see cref="IWindow.RequestDisplayDensity"/> command to return the current rendering scale.
+    /// </summary>
+    /// <param name="handler">The associated handler.</param>
+    /// <param name="window">The associated <see cref="IWindow"/> instance.</param>
+    /// <param name="arg3">The associated command arguments.</param>
     private static void MapRequestDisplayDensity(WindowHandler handler, IWindow window, object? arg3)
     {
         if (arg3 is DisplayDensityRequest request)
@@ -44,16 +60,24 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
         }
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="WindowHandler"/>.
+    /// </summary>
     public WindowHandler()
         : base(Mapper, CommandMapper)
     {
     }
 
+    /// <summary>
+    /// Creates the Avalonia platform view for this handler.
+    /// </summary>
+    /// <returns>A new <see cref="MauiAvaloniaWindow"/> instance.</returns>
     protected override Avalonia.Controls.Window CreatePlatformElement()
     {
         return new MauiAvaloniaWindow();
     }
 
+    /// <inheritdoc/>
     protected override void ConnectHandler(Avalonia.Controls.Window platformView)
     {
         base.ConnectHandler(platformView);
@@ -74,6 +98,7 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
         }
     }
 
+    /// <inheritdoc/>
     protected override void DisconnectHandler(Avalonia.Controls.Window platformView)
     {
         var avWindow = (Window)platformView;
@@ -102,9 +127,15 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
         DismissModalPage(animated);
     }
 
+    /// <summary>
+    /// Maps the Title property to the platform view.
+    /// </summary>
     static void mapTitle(WindowHandler handler, IWindow window) =>
         ((Window)handler.PlatformView).UpdateTitle(window);
 
+    /// <summary>
+    /// Maps the <see cref="IWindow.Content"/> property to the platform view.
+    /// </summary>
     static void mapContent(WindowHandler handler, IWindow window)
     {
         var avWindow = GetMauiWindow(handler);
@@ -112,6 +143,9 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
         avWindow.SetMainContent(content);
     }
 
+    /// <summary>
+    /// Maps the <see cref="Microsoft.Maui.Controls.Window.TitleBar"/> property to the platform view.
+    /// </summary>
     static void mapTitleBar(WindowHandler handler, IWindow window)
     {
         var avWindow = GetMauiWindow(handler);
@@ -120,18 +154,27 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
         avWindow.SetTitleBar(controlsWindow?.TitleBar, handler.MauiContext);
     }
 
+    /// <summary>
+    /// Maps the <see cref="IWindow.X"/> property to the platform view.
+    /// </summary>
     static void mapX(WindowHandler handler, IWindow window)
     {
         var avWindow = GetWindow(handler, window);
         avWindow.Position = new PixelPoint((int)window.X, avWindow.Position.Y);
     }
 
+    /// <summary>
+    /// Maps the <see cref="IWindow.Y"/> property to the platform view.
+    /// </summary>
     static void mapY(WindowHandler handler, IWindow window)
     {
         var avWindow = GetWindow(handler, window);
         avWindow.Position = new PixelPoint(avWindow.Position.X, (int)window.Y);
     }
 
+    /// <summary>
+    /// Maps the <see cref="IWindow.Width"/> property to the platform view.
+    /// </summary>
     static void mapWidth(WindowHandler handler, IWindow window)
     {
         var avWindow = GetWindow(handler, window);
@@ -141,6 +184,9 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
             avWindow.Width = avWindow.ClientSize.Width;
     }
 
+    /// <summary>
+    /// Maps the <see cref="IWindow.Height"/> property to the platform view.
+    /// </summary>
     static void mapHeight(WindowHandler handler, IWindow window)
     {
         var avWindow = GetWindow(handler, window);
@@ -150,6 +196,9 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
             avWindow.Height = avWindow.ClientSize.Height;
     }
 
+    /// <summary>
+    /// Gets the Avalonia <see cref="Window"/> from the handler, ensuring <see cref="IMauiContext"/> is set.
+    /// </summary>
     static Window GetWindow(WindowHandler handler, IWindow window)
     {
         _ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
@@ -157,6 +206,9 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
         return (Window)handler.PlatformView;
     }
 
+    /// <summary>
+    /// Gets the <see cref="MauiAvaloniaWindow"/> from the handler, ensuring <see cref="IMauiContext"/> is set.
+    /// </summary>
     static MauiAvaloniaWindow GetMauiWindow(WindowHandler handler)
     {
         _ = handler.MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} should have been set by base class.");
@@ -186,6 +238,9 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
         mauiWindow.DismissModal(animated);
     }
 
+    /// <summary>
+    /// Maps the <see cref="IWindow.MaximumWidth"/> property to the platform view.
+    /// </summary>
     static void mapMaximumWidth(WindowHandler handler, IWindow window)
     {
         var avWindow = GetWindow(handler, window);
@@ -195,6 +250,9 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
             avWindow.MaxWidth = window.MaximumWidth;
     }
 
+    /// <summary>
+    /// Maps the <see cref="IWindow.MaximumHeight"/> property to the platform view.
+    /// </summary>
     static void mapMaximumHeight(WindowHandler handler, IWindow window)
     {
         var avWindow = GetWindow(handler, window);
@@ -204,6 +262,9 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
             avWindow.MaxHeight = window.MaximumHeight;
     }
 
+    /// <summary>
+    /// Maps the <see cref="IWindow.MinimumWidth"/> property to the platform view.
+    /// </summary>
     static void mapMinimumWidth(WindowHandler handler, IWindow window)
     {
         var avWindow = GetWindow(handler, window);
@@ -213,6 +274,9 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
             avWindow.MinWidth = window.MinimumWidth;
     }
 
+    /// <summary>
+    /// Maps the <see cref="IWindow.MinimumHeight"/> property to the platform view.
+    /// </summary>
     static void mapMinimumHeight(WindowHandler handler, IWindow window)
     {
         var avWindow = GetWindow(handler, window);
@@ -222,6 +286,9 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
             avWindow.MinHeight = window.MinimumHeight;
     }
 
+    /// <summary>
+    /// Maps the <see cref="IWindow.FlowDirection"/> property to the platform view.
+    /// </summary>
     static void mapFlowDirection(WindowHandler handler, IWindow window)
     {
         var avWindow = (Window)handler.PlatformView;

--- a/src/Avalonia.Controls.Maui/Platform/ContentView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/ContentView.cs
@@ -6,6 +6,9 @@ using MauiRect = Microsoft.Maui.Graphics.Rect;
 
 namespace Avalonia.Controls.Maui.Platform;
 
+/// <summary>
+/// Avalonia content presenter control used as a container for hosting MAUI ContentView content.
+/// </summary>
 public class ContentView : MauiView
 {
 }

--- a/src/Avalonia.Controls.Maui/Platform/LayoutPanel.cs
+++ b/src/Avalonia.Controls.Maui/Platform/LayoutPanel.cs
@@ -6,11 +6,22 @@ using MauiRect = Microsoft.Maui.Graphics.Rect;
 
 namespace Avalonia.Controls.Maui.Platform;
 
+/// <summary>
+/// Avalonia panel that delegates measure and arrange passes to MAUI's cross-platform layout system.
+/// </summary>
 public class LayoutPanel : Panel
 {
+    /// <summary>
+    /// Gets or sets the delegate invoked during the measure pass to compute the desired size using MAUI's cross-platform layout.
+    /// </summary>
     internal Func<double, double, MauiSize>? CrossPlatformMeasure { get; set; }
+
+    /// <summary>
+    /// Gets or sets the delegate invoked during the arrange pass to position children using MAUI's cross-platform layout.
+    /// </summary>
     internal Func<MauiRect, MauiSize>? CrossPlatformArrange { get; set; }
 
+    /// <inheritdoc/>
     protected override AvaloniaSize MeasureOverride(AvaloniaSize availableSize)
     {
         if (CrossPlatformMeasure == null)
@@ -29,6 +40,7 @@ public class LayoutPanel : Panel
         return new AvaloniaSize(width, height);
     }
 
+    /// <inheritdoc/>
     protected override AvaloniaSize ArrangeOverride(AvaloniaSize finalSize)
     {
         if (CrossPlatformArrange == null)

--- a/src/Avalonia.Controls.Maui/Platform/MauiActionSheetDialog.axaml.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiActionSheetDialog.axaml.cs
@@ -4,32 +4,86 @@ using System.Windows.Input;
 
 namespace Avalonia.Controls.Maui.Platform;
 
+/// <summary>
+/// Avalonia dialog control that presents a MAUI action sheet with optional title, cancel, destruction, and additional action buttons.
+/// </summary>
 public partial class MauiActionSheetDialog : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MauiActionSheetDialog"/> class.
+    /// </summary>
     public MauiActionSheetDialog()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Gets the text of the button that was selected to close the dialog.
+    /// </summary>
     public string? Result { get; private set; }
 
+    /// <summary>
+    /// Gets a value indicating whether the dialog has a non-empty title.
+    /// </summary>
     public bool HasTitle => !string.IsNullOrEmpty(Title);
 
+    /// <summary>
+    /// Gets or sets the title displayed at the top of the action sheet.
+    /// </summary>
     public string? Title { get; set; }
 
+    /// <summary>
+    /// Gets or sets the text for the cancel button.
+    /// </summary>
     public string? CancelButtonText { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the cancel button should be displayed.
+    /// </summary>
     public bool HasCancelButton => !string.IsNullOrEmpty(CancelButtonText);
+
+    /// <summary>
+    /// Gets the command that closes the dialog with the cancel button text as the result.
+    /// </summary>
     public ICommand CancelCommand => new RelayCommand<object>(_ => CloseWithResult(CancelButtonText));
 
+    /// <summary>
+    /// Gets or sets the text for the destructive action button.
+    /// </summary>
     public string? DestructionButtonText { get; set; }
+
+    /// <summary>
+    /// Gets the formatted text for the destructive action button.
+    /// </summary>
     public string? DestructionButtonFormatted => DestructionButtonText;
+
+    /// <summary>
+    /// Gets a value indicating whether the destructive action button should be displayed.
+    /// </summary>
     public bool HasDestructionButton => !string.IsNullOrEmpty(DestructionButtonText);
+
+    /// <summary>
+    /// Gets the command that closes the dialog with the destruction button text as the result.
+    /// </summary>
     public ICommand DestructionCommand => new RelayCommand<object>(_ => CloseWithResult(DestructionButtonText));
 
+    /// <summary>
+    /// Gets the collection of additional action buttons displayed in the dialog.
+    /// </summary>
     public ObservableCollection<ActionSheetButtonViewModel>? Buttons { get; private set; }
-    
+
+    /// <summary>
+    /// Occurs when the dialog is closed with a result, providing the selected button text.
+    /// </summary>
     public event Action<string?>? OnResult;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MauiActionSheetDialog"/> class with the specified title, cancel text, destruction text, and additional buttons.
+    /// </summary>
+    /// <param name="title">The title to display at the top of the action sheet.</param>
+    /// <param name="cancel">The text for the cancel button, or an empty string to hide it.</param>
+    /// <param name="destruction">The text for the destructive action button, or an empty string to hide it.</param>
+    /// <param name="buttons">An optional array of additional button labels to display.</param>
     public MauiActionSheetDialog(string title, string cancel, string destruction, string[]? buttons) : this()
     {
         Title = title;
@@ -70,11 +124,26 @@ public partial class MauiActionSheetDialog : UserControl
     }
 }
 
+/// <summary>
+/// View model representing a single button in an action sheet dialog.
+/// </summary>
 public class ActionSheetButtonViewModel
 {
+    /// <summary>
+    /// Gets the display text of the button.
+    /// </summary>
     public string Text { get; }
+
+    /// <summary>
+    /// Gets the command executed when the button is clicked.
+    /// </summary>
     public ICommand Command { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ActionSheetButtonViewModel"/> class.
+    /// </summary>
+    /// <param name="text">The display text of the button.</param>
+    /// <param name="command">The command to execute when the button is clicked.</param>
     public ActionSheetButtonViewModel(string text, ICommand command)
     {
         Text = text;

--- a/src/Avalonia.Controls.Maui/Platform/MauiAlertDialog.axaml.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiAlertDialog.axaml.cs
@@ -3,13 +3,26 @@ using Avalonia.Interactivity;
 
 namespace Avalonia.Controls.Maui.Platform;
 
+/// <summary>
+/// Avalonia dialog control that presents a MAUI alert message with optional accept and cancel buttons.
+/// </summary>
 public partial class MauiAlertDialog : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MauiAlertDialog"/> class.
+    /// </summary>
     public MauiAlertDialog()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MauiAlertDialog"/> class with the specified title, message, and button texts.
+    /// </summary>
+    /// <param name="title">The title displayed at the top of the alert dialog.</param>
+    /// <param name="message">The message body displayed in the alert dialog.</param>
+    /// <param name="acceptText">The text for the accept button, or <see langword="null"/> to hide it.</param>
+    /// <param name="cancelText">The text for the cancel button.</param>
     public MauiAlertDialog(string title, string message, string? acceptText, string cancelText)
         : this()
     {
@@ -22,12 +35,34 @@ public partial class MauiAlertDialog : UserControl
         DataContext = this;
     }
 
+    /// <summary>
+    /// Gets or sets the title text displayed at the top of the alert dialog.
+    /// </summary>
     public string AlertTitle { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the message body text displayed in the alert dialog.
+    /// </summary>
     public string AlertMessage { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the text displayed on the accept button.
+    /// </summary>
     public string? AcceptText { get; set; }
+
+    /// <summary>
+    /// Gets or sets the text displayed on the cancel button.
+    /// </summary>
     public string CancelText { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the accept button is visible.
+    /// </summary>
     public bool HasAcceptButton { get; set; }
 
+    /// <summary>
+    /// Occurs when the dialog is closed, providing <see langword="true"/> if accepted or <see langword="false"/> if cancelled.
+    /// </summary>
     public event Action<bool?>? OnResult;
 
     private void OnAcceptClicked(object? sender, RoutedEventArgs e)

--- a/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaApplication.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaApplication.cs
@@ -12,17 +12,40 @@ using Microsoft.Maui.ApplicationModel;
 
 namespace Avalonia.Controls.Maui.Platform;
 
+/// <summary>
+/// Abstract base class for Avalonia-based MAUI applications that bridges the Avalonia application lifecycle with the MAUI platform.
+/// </summary>
+/// <remarks>
+/// Subclasses must implement <see cref="CreateMauiApp"/> to provide the configured <see cref="MauiApp"/> instance.
+/// This class implements <see cref="IPlatformApplication"/> so that MAUI's platform services resolve against the Avalonia host.
+/// </remarks>
 public abstract class MauiAvaloniaApplication : Application, IPlatformApplication
 {
+    /// <summary>
+    /// Creates and returns the configured <see cref="MauiApp"/> instance for this application.
+    /// </summary>
+    /// <returns>A fully configured <see cref="MauiApp"/>.</returns>
     protected abstract MauiApp CreateMauiApp();
 
+    /// <summary>
+    /// Gets the current <see cref="MauiAvaloniaApplication"/> instance.
+    /// </summary>
     public static new MauiAvaloniaApplication Current => (MauiAvaloniaApplication)global::Avalonia.Application.Current!;
 
 
+    /// <summary>
+    /// Gets the main Avalonia <see cref="Window"/> created during application initialization.
+    /// </summary>
     public Window MainWindow { get; protected set; } = null!;
 
+    /// <summary>
+    /// Gets the application-level <see cref="IServiceProvider"/> resolved from the MAUI dependency injection container.
+    /// </summary>
     public IServiceProvider Services { get; protected set; } = null!;
 
+    /// <summary>
+    /// Gets the MAUI <see cref="IApplication"/> instance managed by this host.
+    /// </summary>
     public IApplication Application { get; protected set; } = null!;
 
 
@@ -31,6 +54,14 @@ public abstract class MauiAvaloniaApplication : Application, IPlatformApplicatio
     /// </summary>
     protected IMauiContext? ApplicationContext { get; private set; }
 
+    /// <summary>
+    /// Bootstraps the MAUI application within the Avalonia framework initialization pipeline.
+    /// </summary>
+    /// <remarks>
+    /// This method creates the <see cref="MauiApp"/>, registers platform services, sets up the DI scope,
+    /// connects the MAUI <see cref="IApplication"/> to its handler, and creates the platform window or single-view content
+    /// depending on the active <see cref="Avalonia.Controls.ApplicationLifetimes"/> lifetime.
+    /// </remarks>
     public override void OnFrameworkInitializationCompleted()
     {
         IPlatformApplication.Current = this;

--- a/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaContent.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaContent.cs
@@ -9,10 +9,16 @@ namespace Avalonia.Controls.Maui.Platform;
 /// </summary>
 public class MauiAvaloniaContent : ContentControl, IDisposable
 {
+    /// <summary>
+    /// Initializes a new instance of <see cref="MauiAvaloniaContent"/>.
+    /// </summary>
     public MauiAvaloniaContent()
     {
     }
 
+    /// <summary>
+    /// Releases any resources held by this content container.
+    /// </summary>
     public void Dispose()
     {
     }

--- a/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaWindow.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaWindow.cs
@@ -10,6 +10,14 @@ using System.Threading.Tasks;
 
 namespace Avalonia.Controls.Maui.Platform;
 
+/// <summary>
+/// Main window for MAUI applications running on Avalonia, providing root layout, title bar, and modal overlay support.
+/// </summary>
+/// <remarks>
+/// The window uses a <see cref="DockPanel"/> inside a <see cref="Grid"/> as its root layout.
+/// The <see cref="DockPanel"/> hosts the optional title bar and main content, while the outer
+/// <see cref="Grid"/> allows modal overlays to be stacked on top of all other content.
+/// </remarks>
 public class MauiAvaloniaWindow : Window, IDisposable
 {
     private readonly Stack<(Control Content, Panel Scrim)> _modalStack = new();
@@ -24,6 +32,10 @@ public class MauiAvaloniaWindow : Window, IDisposable
     /// </summary>
     public TitleBarView? TitleBarView => _titleBarView;
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="MauiAvaloniaWindow"/> with a root layout consisting of a
+    /// <see cref="DockPanel"/> inside a <see cref="Grid"/> to support title bar docking and modal overlays.
+    /// </summary>
     public MauiAvaloniaWindow()
     {
         _rootPanel = new DockPanel
@@ -42,6 +54,9 @@ public class MauiAvaloniaWindow : Window, IDisposable
         Closed += OnClosed;
     }
 
+    /// <summary>
+    /// Releases resources by unsubscribing from window lifecycle event handlers.
+    /// </summary>
     public void Dispose()
     {
         Activated -= OnActivated;
@@ -49,16 +64,31 @@ public class MauiAvaloniaWindow : Window, IDisposable
         Closed -= OnClosed;
     }
 
+    /// <summary>
+    /// Handles window activation by updating the title bar to its active visual state.
+    /// </summary>
+    /// <param name="sender">The event source.</param>
+    /// <param name="e">The event data.</param>
     protected virtual void OnActivated(object? sender, EventArgs e)
     {
         _titleBarView?.SetActiveState(true);
     }
 
+    /// <summary>
+    /// Handles window deactivation by updating the title bar to its inactive visual state.
+    /// </summary>
+    /// <param name="sender">The event source.</param>
+    /// <param name="e">The event data.</param>
     protected virtual void OnDeactivated(object? sender, EventArgs e)
     {
         _titleBarView?.SetActiveState(false);
     }
 
+    /// <summary>
+    /// Handles the window close event.
+    /// </summary>
+    /// <param name="sender">The event source.</param>
+    /// <param name="e">The event data.</param>
     protected virtual void OnClosed(object? sender, EventArgs e)
     {
     }

--- a/src/Avalonia.Controls.Maui/Platform/MauiCarouselView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiCarouselView.cs
@@ -14,7 +14,7 @@ using Avalonia.Threading;
 namespace Avalonia.Controls.Maui.Platform;
 
 /// <summary>
-/// Custom Avalonia control for MAUI CarouselView with swipe gesture support
+/// Avalonia content control that implements a MAUI CarouselView with swipe gesture and keyboard navigation support.
 /// </summary>
 public class MauiCarouselView : ContentControl
 {
@@ -27,26 +27,44 @@ public class MauiCarouselView : ContentControl
     private const double SwipeThreshold = 80; // Threshold to commit to transition
     private const double AnimationDuration = 250; // milliseconds
 
+    /// <summary>
+    /// Defines the <see cref="ItemsSource"/> property.
+    /// </summary>
     public static readonly StyledProperty<IEnumerable?> ItemsSourceProperty =
         AvaloniaProperty.Register<MauiCarouselView, IEnumerable?>(nameof(ItemsSource));
 
+    /// <summary>
+    /// Defines the <see cref="ItemTemplate"/> property.
+    /// </summary>
     public static readonly StyledProperty<IDataTemplate?> ItemTemplateProperty =
         AvaloniaProperty.Register<MauiCarouselView, IDataTemplate?>(nameof(ItemTemplate));
 
+    /// <summary>
+    /// Defines the <see cref="SelectedIndex"/> property.
+    /// </summary>
     public static readonly StyledProperty<int> SelectedIndexProperty =
         AvaloniaProperty.Register<MauiCarouselView, int>(
             nameof(SelectedIndex),
             defaultValue: 0,
             defaultBindingMode: global::Avalonia.Data.BindingMode.TwoWay);
 
+    /// <summary>
+    /// Defines the <see cref="CurrentItem"/> property.
+    /// </summary>
     public static readonly StyledProperty<object?> CurrentItemProperty =
         AvaloniaProperty.Register<MauiCarouselView, object?>(
             nameof(CurrentItem),
             defaultBindingMode: global::Avalonia.Data.BindingMode.TwoWay);
 
+    /// <summary>
+    /// Defines the <see cref="Loop"/> property.
+    /// </summary>
     public static readonly StyledProperty<bool> LoopProperty =
         AvaloniaProperty.Register<MauiCarouselView, bool>(nameof(Loop), defaultValue: false);
 
+    /// <summary>
+    /// Registers property change handlers for <see cref="ItemsSourceProperty"/>, <see cref="ItemTemplateProperty"/>, and <see cref="SelectedIndexProperty"/>.
+    /// </summary>
     static MauiCarouselView()
     {
         ItemsSourceProperty.Changed.AddClassHandler<MauiCarouselView>((cv, e) => cv.OnItemsSourceChanged(e));
@@ -54,6 +72,9 @@ public class MauiCarouselView : ContentControl
         SelectedIndexProperty.Changed.AddClassHandler<MauiCarouselView>((cv, e) => cv.OnSelectedIndexChanged(e));
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MauiCarouselView"/> class and sets up pointer and keyboard event handlers.
+    /// </summary>
     public MauiCarouselView()
     {
         // Set a default minimum size to ensure the control gets layout space
@@ -80,36 +101,54 @@ public class MauiCarouselView : ContentControl
         PointerWheelChanged += OnPointerWheelChanged;
     }
 
+    /// <summary>
+    /// Gets or sets the collection of items to display in the carousel.
+    /// </summary>
     public IEnumerable? ItemsSource
     {
         get => GetValue(ItemsSourceProperty);
         set => SetValue(ItemsSourceProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the data template used to render each item in the carousel.
+    /// </summary>
     public IDataTemplate? ItemTemplate
     {
         get => GetValue(ItemTemplateProperty);
         set => SetValue(ItemTemplateProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the zero-based index of the currently selected item in the carousel.
+    /// </summary>
     public int SelectedIndex
     {
         get => GetValue(SelectedIndexProperty);
         set => SetValue(SelectedIndexProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the data object of the currently displayed item.
+    /// </summary>
     public object? CurrentItem
     {
         get => GetValue(CurrentItemProperty);
         set => SetValue(CurrentItemProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the carousel wraps around when reaching the first or last item.
+    /// </summary>
     public bool Loop
     {
         get => GetValue(LoopProperty);
         set => SetValue(LoopProperty, value);
     }
 
+    /// <summary>
+    /// Advances the carousel to the next item, wrapping to the first item if <see cref="Loop"/> is enabled.
+    /// </summary>
     public void Next()
     {
         var items = GetItemsList();
@@ -126,6 +165,9 @@ public class MauiCarouselView : ContentControl
         }
     }
 
+    /// <summary>
+    /// Moves the carousel to the previous item, wrapping to the last item if <see cref="Loop"/> is enabled.
+    /// </summary>
     public void Previous()
     {
         var items = GetItemsList();
@@ -142,6 +184,7 @@ public class MauiCarouselView : ContentControl
         }
     }
 
+    /// <inheritdoc/>
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);

--- a/src/Avalonia.Controls.Maui/Platform/MauiIndicatorView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiIndicatorView.cs
@@ -7,82 +7,134 @@ using Avalonia.Media;
 
 namespace Avalonia.Controls.Maui.Controls;
 
+/// <summary>
+/// Avalonia templated control that displays a set of position indicators for a carousel view, highlighting the currently selected item.
+/// </summary>
 public class MauiIndicatorView : TemplatedControl
 {
     private StackPanel? _indicatorPanel;
 
+    /// <summary>
+    /// Defines the <see cref="Count"/> property.
+    /// </summary>
     public static readonly StyledProperty<int> CountProperty =
         AvaloniaProperty.Register<MauiIndicatorView, int>(nameof(Count), defaultValue: 0);
 
+    /// <summary>
+    /// Defines the <see cref="Position"/> property.
+    /// </summary>
     public static readonly StyledProperty<int> PositionProperty =
         AvaloniaProperty.Register<MauiIndicatorView, int>(nameof(Position), defaultValue: 0);
 
+    /// <summary>
+    /// Defines the <see cref="IndicatorSize"/> property.
+    /// </summary>
     public static readonly StyledProperty<double> IndicatorSizeProperty =
         AvaloniaProperty.Register<MauiIndicatorView, double>(nameof(IndicatorSize), defaultValue: 6.0);
 
+    /// <summary>
+    /// Defines the <see cref="MaximumVisible"/> property.
+    /// </summary>
     public static readonly StyledProperty<int> MaximumVisibleProperty =
         AvaloniaProperty.Register<MauiIndicatorView, int>(nameof(MaximumVisible), defaultValue: int.MaxValue);
 
+    /// <summary>
+    /// Defines the <see cref="HideSingle"/> property.
+    /// </summary>
     public static readonly StyledProperty<bool> HideSingleProperty =
         AvaloniaProperty.Register<MauiIndicatorView, bool>(nameof(HideSingle), defaultValue: true);
 
+    /// <summary>
+    /// Defines the <see cref="IndicatorColor"/> property.
+    /// </summary>
     public static readonly StyledProperty<IBrush?> IndicatorColorProperty =
         AvaloniaProperty.Register<MauiIndicatorView, IBrush?>(nameof(IndicatorColor), defaultValue: new SolidColorBrush(Color.FromRgb(211, 211, 211))); // LightGray
 
+    /// <summary>
+    /// Defines the <see cref="SelectedIndicatorColor"/> property.
+    /// </summary>
     public static readonly StyledProperty<IBrush?> SelectedIndicatorColorProperty =
         AvaloniaProperty.Register<MauiIndicatorView, IBrush?>(nameof(SelectedIndicatorColor), defaultValue: new SolidColorBrush(Colors.Black));
 
+    /// <summary>
+    /// Defines the <see cref="IsCircleShape"/> property.
+    /// </summary>
     public static readonly StyledProperty<bool> IsCircleShapeProperty =
         AvaloniaProperty.Register<MauiIndicatorView, bool>(nameof(IsCircleShape), defaultValue: true);
 
+    /// <summary>
+    /// Gets or sets the total number of indicators to display.
+    /// </summary>
     public int Count
     {
         get => GetValue(CountProperty);
         set => SetValue(CountProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the zero-based index of the currently selected indicator.
+    /// </summary>
     public int Position
     {
         get => GetValue(PositionProperty);
         set => SetValue(PositionProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the width and height of each indicator element in device-independent pixels.
+    /// </summary>
     public double IndicatorSize
     {
         get => GetValue(IndicatorSizeProperty);
         set => SetValue(IndicatorSizeProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the maximum number of indicators that are visible at one time.
+    /// </summary>
     public int MaximumVisible
     {
         get => GetValue(MaximumVisibleProperty);
         set => SetValue(MaximumVisibleProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the indicator view is hidden when there is only a single item.
+    /// </summary>
     public bool HideSingle
     {
         get => GetValue(HideSingleProperty);
         set => SetValue(HideSingleProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the brush used to paint unselected indicators.
+    /// </summary>
     public IBrush? IndicatorColor
     {
         get => GetValue(IndicatorColorProperty);
         set => SetValue(IndicatorColorProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the brush used to paint the currently selected indicator.
+    /// </summary>
     public IBrush? SelectedIndicatorColor
     {
         get => GetValue(SelectedIndicatorColorProperty);
         set => SetValue(SelectedIndicatorColorProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether indicators are rendered as circles; when <see langword="false"/>, rectangles are used.
+    /// </summary>
     public bool IsCircleShape
     {
         get => GetValue(IsCircleShapeProperty);
         set => SetValue(IsCircleShapeProperty, value);
     }
 
+    /// <inheritdoc/>
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);
@@ -90,6 +142,7 @@ public class MauiIndicatorView : TemplatedControl
         UpdateIndicators();
     }
 
+    /// <inheritdoc/>
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
@@ -107,6 +160,9 @@ public class MauiIndicatorView : TemplatedControl
         }
     }
 
+    /// <summary>
+    /// Rebuilds the indicator elements in the panel based on the current <see cref="Count"/>, <see cref="Position"/>, and styling properties.
+    /// </summary>
     public void UpdateIndicators()
     {
         if (_indicatorPanel == null)

--- a/src/Avalonia.Controls.Maui/Platform/MauiPromptDialog.axaml.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiPromptDialog.axaml.cs
@@ -7,13 +7,30 @@ using Avalonia.Threading;
 
 namespace Avalonia.Controls.Maui.Platform;
 
+/// <summary>
+/// Avalonia dialog control that presents a MAUI prompt for user text input with configurable title, message, and validation options.
+/// </summary>
 public partial class MauiPromptDialog : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MauiPromptDialog"/> class.
+    /// </summary>
     public MauiPromptDialog()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MauiPromptDialog"/> class with the specified prompt configuration.
+    /// </summary>
+    /// <param name="title">The title displayed at the top of the prompt dialog.</param>
+    /// <param name="message">The message displayed below the title.</param>
+    /// <param name="accept">The text for the accept button, defaulting to "OK" if empty.</param>
+    /// <param name="cancel">The text for the cancel button, defaulting to "Cancel" if empty.</param>
+    /// <param name="placeholder">The placeholder text displayed in the input field when empty.</param>
+    /// <param name="maxLength">The maximum number of characters allowed, or -1 for unlimited.</param>
+    /// <param name="keyboard">The <see cref="Keyboard"/> type to use for the input field.</param>
+    /// <param name="initialValue">The initial text value pre-populated in the input field.</param>
     public MauiPromptDialog(string title, string message, string accept, string cancel, string? placeholder = null, int maxLength = -1, Keyboard? keyboard = null, string initialValue = "") : this()
     {
         Title = title;
@@ -30,8 +47,12 @@ public partial class MauiPromptDialog : UserControl
         DataContext = this;
     }
     
+    /// <summary>
+    /// Gets or sets the title displayed at the top of the prompt dialog.
+    /// </summary>
     public string? Title { get; set; }
 
+    /// <inheritdoc/>
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnAttachedToVisualTree(e);
@@ -44,18 +65,40 @@ public partial class MauiPromptDialog : UserControl
         });
     }
 
+    /// <summary>
+    /// Gets or sets the descriptive message displayed in the prompt dialog.
+    /// </summary>
     public string? Message { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the dialog has a non-empty message to display.
+    /// </summary>
     public bool HasMessage => !string.IsNullOrEmpty(Message);
 
+    /// <summary>
+    /// Gets or sets the text displayed on the accept button.
+    /// </summary>
     public string? AcceptText { get; set; }
+
+    /// <summary>
+    /// Gets or sets the text displayed on the cancel button.
+    /// </summary>
     public string? CancelText { get; set; }
 
+    /// <summary>
+    /// Gets or sets the placeholder text shown in the input field when it is empty.
+    /// </summary>
     public string? Placeholder { get; set; }
 
-    // Bindable property for InputValue
+    /// <summary>
+    /// Defines the <see cref="InputValue"/> styled property.
+    /// </summary>
     public static readonly StyledProperty<string> InputValueProperty =
         AvaloniaProperty.Register<MauiPromptDialog, string>(nameof(InputValue));
 
+    /// <summary>
+    /// Gets or sets the current text value entered by the user in the input field.
+    /// </summary>
     public string InputValue
     {
         get => GetValue(InputValueProperty);
@@ -72,8 +115,14 @@ public partial class MauiPromptDialog : UserControl
         Close(null);
     }
 
+    /// <summary>
+    /// Gets or sets the maximum number of characters allowed in the input field, where 0 indicates no limit.
+    /// </summary>
     public int MaxLength { get; set; }
-    
+
+    /// <summary>
+    /// Occurs when the dialog is closed, providing the entered text or <see langword="null"/> if cancelled.
+    /// </summary>
     public event Action<string?>? OnResult;
 
     private void Close(string? result)

--- a/src/Avalonia.Controls.Maui/Platform/MauiRoundRectangle.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiRoundRectangle.cs
@@ -5,22 +5,35 @@ using global::Avalonia.Media;
 
 namespace Avalonia.Controls.Maui.Platform;
 
+/// <summary>
+/// Avalonia shape control that renders a rectangle with individually configurable rounded corners, used to implement MAUI Border shapes.
+/// </summary>
 public class MauiRoundRectangle : Shape
 {
+    /// <summary>
+    /// Defines the <see cref="CornerRadius"/> styled property.
+    /// </summary>
     public static readonly StyledProperty<CornerRadius> CornerRadiusProperty =
         AvaloniaProperty.Register<MauiRoundRectangle, CornerRadius>(nameof(CornerRadius));
 
+    /// <summary>
+    /// Registers property change handlers that invalidate the geometry when corner radius or bounds change.
+    /// </summary>
     static MauiRoundRectangle()
     {
         AffectsGeometry<MauiRoundRectangle>(CornerRadiusProperty, BoundsProperty);
     }
 
+    /// <summary>
+    /// Gets or sets the corner radius applied to each corner of the rectangle.
+    /// </summary>
     public CornerRadius CornerRadius
     {
         get => GetValue(CornerRadiusProperty);
         set => SetValue(CornerRadiusProperty, value);
     }
 
+    /// <inheritdoc/>
     protected override Geometry CreateDefiningGeometry()
     {
         var bounds = new Rect(0, 0, Bounds.Width, Bounds.Height);

--- a/src/Avalonia.Controls.Maui/Platform/MauiView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiView.cs
@@ -5,6 +5,9 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Avalonia.Controls.Maui.Platform;
 
+/// <summary>
+/// Abstract base panel that bridges MAUI's cross-platform layout system with Avalonia's layout infrastructure.
+/// </summary>
 public abstract partial class MauiView : Panel, ICrossPlatformLayoutBacking, IVisualTreeElementProvidable
 {
     bool _invalidateParentWhenMovedToWindow;
@@ -14,6 +17,9 @@ public abstract partial class MauiView : Panel, ICrossPlatformLayoutBacking, IVi
     WeakReference<IView>? _reference;
     WeakReference<ICrossPlatformLayout>? _crossPlatformLayoutReference;
 
+    /// <summary>
+    /// Gets or sets the MAUI view associated with this panel.
+    /// </summary>
     public IView? View
     {
         get => _reference != null && _reference.TryGetTarget(out var v) ? v : null;
@@ -22,6 +28,9 @@ public abstract partial class MauiView : Panel, ICrossPlatformLayoutBacking, IVi
 
     bool HasFixedConstraints => CrossPlatformLayout is IConstrainedView { HasFixedConstraints: true };
 
+    /// <summary>
+    /// Gets or sets the cross-platform layout delegate used for measure and arrange passes.
+    /// </summary>
     public ICrossPlatformLayout? CrossPlatformLayout
     {
         get => _crossPlatformLayoutReference != null && _crossPlatformLayoutReference.TryGetTarget(out var v) ? v : null;
@@ -38,6 +47,12 @@ public abstract partial class MauiView : Panel, ICrossPlatformLayoutBacking, IVi
         return CrossPlatformLayout?.CrossPlatformArrange(bounds) ?? Microsoft.Maui.Graphics.Size.Zero;
     }
 
+    /// <summary>
+    /// Checks whether the cached measure constraints match the specified width and height constraints.
+    /// </summary>
+    /// <param name="widthConstraint">The width constraint to compare against the cached value.</param>
+    /// <param name="heightConstraint">The height constraint to compare against the cached value.</param>
+    /// <returns><see langword="true"/> if the cached constraints match the specified values; otherwise, <see langword="false"/>.</returns>
     protected new bool IsMeasureValid(double widthConstraint, double heightConstraint)
     {
         return heightConstraint == _lastMeasureHeight && widthConstraint == _lastMeasureWidth;
@@ -48,18 +63,31 @@ public abstract partial class MauiView : Panel, ICrossPlatformLayoutBacking, IVi
         return !double.IsNaN(_lastMeasureWidth) && !double.IsNaN(_lastMeasureHeight);
     }
 
+    /// <summary>
+    /// Clears the cached measure constraints by resetting them to <see cref="double.NaN"/>.
+    /// </summary>
     protected void InvalidateConstraintsCache()
     {
         _lastMeasureWidth = double.NaN;
         _lastMeasureHeight = double.NaN;
     }
 
+    /// <summary>
+    /// Stores the specified measure constraints for subsequent cache validation via <see cref="IsMeasureValid"/>.
+    /// </summary>
+    /// <param name="widthConstraint">The width constraint to cache.</param>
+    /// <param name="heightConstraint">The height constraint to cache.</param>
     protected void CacheMeasureConstraints(double widthConstraint, double heightConstraint)
     {
         _lastMeasureWidth = widthConstraint;
         _lastMeasureHeight = heightConstraint;
     }
 
+    /// <summary>
+    /// Measures the view by delegating to the cross-platform layout system when available.
+    /// </summary>
+    /// <param name="availableSize">The available size that the parent element can allocate to this view.</param>
+    /// <returns>The desired size computed by the cross-platform layout, or the base measurement if no cross-platform layout is set.</returns>
     protected override Size MeasureOverride(Size availableSize)
     {
         if (_crossPlatformLayoutReference == null)
@@ -77,6 +105,11 @@ public abstract partial class MauiView : Panel, ICrossPlatformLayoutBacking, IVi
         return new Size(crossPlatformSize.Width, crossPlatformSize.Height);
     }
 
+    /// <summary>
+    /// Arranges the view by delegating to the cross-platform layout system, re-measuring if constraints have changed.
+    /// </summary>
+    /// <param name="finalSize">The final area within the parent that this view should use to arrange itself and its children.</param>
+    /// <returns>The actual size used after arrangement by the cross-platform layout, or the base arrangement if no cross-platform layout is set.</returns>
     protected override Size ArrangeOverride(Size finalSize)
     {
         if (_crossPlatformLayoutReference == null)
@@ -101,6 +134,10 @@ public abstract partial class MauiView : Panel, ICrossPlatformLayoutBacking, IVi
         return new Size(arrangedSize.Width, arrangedSize.Height);
     }
 
+    /// <summary>
+    /// Gets the <see cref="IVisualTreeElement"/> associated with this view by matching against the current <see cref="View"/> or <see cref="CrossPlatformLayout"/>.
+    /// </summary>
+    /// <returns>The matching <see cref="IVisualTreeElement"/>, or <see langword="null"/> if no match is found.</returns>
     public IVisualTreeElement? GetElement()
     {
 #if IOS || MACCATALYST || ANDROID || WINDOWS
@@ -155,11 +192,19 @@ public abstract partial class MauiView : Panel, ICrossPlatformLayoutBacking, IVi
     }
 #endif
 
+    /// <summary>
+    /// Schedules invalidation of ancestor layout measures when this view is next attached to the visual tree.
+    /// </summary>
     public void InvalidateAncestorsMeasuresWhenMovedToWindow()
     {
         _invalidateParentWhenMovedToWindow = true;
     }
 
+    /// <summary>
+    /// Invalidates the measure of this view, clearing the constraints cache and optionally stopping propagation for views with fixed constraints.
+    /// </summary>
+    /// <param name="isPropagating">When <see langword="true"/>, indicates the invalidation is propagating up the tree and may be stopped if this view has fixed constraints.</param>
+    /// <returns><see langword="true"/> if invalidation should continue propagating to ancestors; <see langword="false"/> if propagation was stopped due to fixed constraints.</returns>
     public bool InvalidateMeasure(bool isPropagating = false)
     {
         InvalidateConstraintsCache();
@@ -175,12 +220,17 @@ public abstract partial class MauiView : Panel, ICrossPlatformLayoutBacking, IVi
 
     [UnconditionalSuppressMessage("Memory", "MEM0002", Justification = "Event used for lifecycle management")]
     EventHandler? _lifecycleEvent;
+
+    /// <summary>
+    /// Occurs when this view is attached to the visual tree. Shadows the base event to provide lifecycle notification.
+    /// </summary>
     public new event EventHandler? AttachedToVisualTree
     {
         add => _lifecycleEvent += value;
         remove => _lifecycleEvent -= value;
     }
 
+    /// <inheritdoc/>
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnAttachedToVisualTree(e);

--- a/src/Avalonia.Controls.Maui/Platform/NavigationView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/NavigationView.cs
@@ -6,6 +6,9 @@ using Microsoft.Maui;
 
 namespace Avalonia.Controls.Maui.Platform;
 
+/// <summary>
+/// Avalonia control that provides MAUI-style stack navigation with a navigation bar containing a back button, title, and toolbar items.
+/// </summary>
 public class NavigationView : DockPanel
 {
     private readonly TransitioningContentControl _contentControl;
@@ -88,6 +91,9 @@ public class NavigationView : DockPanel
         set => _navigationBar.Background = value;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NavigationView"/> class, constructing the navigation bar, back button, title area, toolbar, and content host.
+    /// </summary>
     public NavigationView()
     {
         LastChildFill = true;

--- a/src/Avalonia.Controls.Maui/Platform/NotImplementedAttribute.cs
+++ b/src/Avalonia.Controls.Maui/Platform/NotImplementedAttribute.cs
@@ -6,14 +6,32 @@ namespace Avalonia.Controls.Maui.Platform;
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Class)]
 public sealed class NotImplementedAttribute : Attribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotImplementedAttribute"/> class with no reason specified.
+    /// </summary>
     public NotImplementedAttribute() { }
-    
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotImplementedAttribute"/> class with a reason describing why the member is not implemented.
+    /// </summary>
+    /// <param name="reason">A description of why the member is not implemented.</param>
     public NotImplementedAttribute(string reason)
     {
         Reason = reason;
     }
 
+    /// <summary>
+    /// Gets the explanation of why the member is not implemented.
+    /// </summary>
     public string? Reason { get; }
+
+    /// <summary>
+    /// Gets or sets the tracking issue identifier associated with the incomplete implementation.
+    /// </summary>
     public string? IssueId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the dependency that blocks this implementation from being completed.
+    /// </summary>
     public string? DependsOn { get; set; }
 }

--- a/src/Avalonia.Controls.Maui/Platform/StackNavigationManager.cs
+++ b/src/Avalonia.Controls.Maui/Platform/StackNavigationManager.cs
@@ -13,6 +13,9 @@ using Microsoft.Maui.Platform;
 
 namespace Avalonia.Controls.Maui.Platform;
 
+/// <summary>
+/// Manages stack-based navigation for MAUI NavigationPage, coordinating page transitions and toolbar updates within an Avalonia <see cref="NavigationView"/>.
+/// </summary>
 public class StackNavigationManager
 {
     private readonly IMauiContext _mauiContext;
@@ -24,14 +27,30 @@ public class StackNavigationManager
     private ILogger? _logger;
     private FlyoutPage? _parentFlyoutPage;
 
+    /// <summary>
+    /// Gets the current page navigation stack.
+    /// </summary>
     public IReadOnlyList<IView> NavigationStack { get; private set; } = new List<IView>();
 
+    /// <summary>
+    /// Gets the currently displayed page.
+    /// </summary>
     public IView CurrentPage => _currentPage ?? throw new InvalidOperationException("CurrentPage cannot be null");
 
+    /// <summary>
+    /// Gets the MAUI context used for handler resolution and service access.
+    /// </summary>
     public IMauiContext MauiContext => _mauiContext;
 
+    /// <summary>
+    /// Gets the Avalonia <see cref="Platform.NavigationView"/> control that hosts the navigation UI.
+    /// </summary>
     public NavigationView NavigationView => _navigationView ?? throw new InvalidOperationException("NavigationView is null");
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StackNavigationManager"/> class.
+    /// </summary>
+    /// <param name="mauiContext">The MAUI context used for handler resolution and service access.</param>
     public StackNavigationManager(IMauiContext mauiContext)
     {
         _mauiContext = mauiContext;

--- a/src/Avalonia.Controls.Maui/Platform/TitleBarView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/TitleBarView.cs
@@ -51,6 +51,9 @@ public class TitleBarView : MauiView
         }
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TitleBarView"/> class, constructing the title bar layout with icon, title, subtitle, and content areas.
+    /// </summary>
     public TitleBarView()
     {
         Height = 32; // Standard title bar height

--- a/src/Avalonia.Controls.Maui/Services/AvaloniaFileImageSourceService.Windows.cs
+++ b/src/Avalonia.Controls.Maui/Services/AvaloniaFileImageSourceService.Windows.cs
@@ -8,6 +8,14 @@ namespace Avalonia.Controls.Maui.Services;
 /// </summary>
 public partial class AvaloniaFileImageSourceService
 {
+    /// <summary>
+    /// Returns <see langword="null"/> because Avalonia handles all image rendering directly via GetImageAsync.
+    /// This stub satisfies the Windows-specific IImageSourceService contract.
+    /// </summary>
+    /// <param name="imageSource">The image source to resolve.</param>
+    /// <param name="scale">The display scale factor.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>Always <see langword="null"/>.</returns>
     public Task<IImageSourceServiceResult<Microsoft.UI.Xaml.Media.ImageSource>?> GetImageSourceAsync(IImageSource imageSource, float scale = 1, CancellationToken cancellationToken = default)
     {
         // Avalonia handles image rendering, return null to indicate no native image

--- a/src/Avalonia.Controls.Maui/Services/AvaloniaFileImageSourceService.cs
+++ b/src/Avalonia.Controls.Maui/Services/AvaloniaFileImageSourceService.cs
@@ -10,19 +10,43 @@ using Microsoft.Maui;
 
 namespace Avalonia.Controls.Maui.Services;
 
+/// <summary>
+/// Avalonia implementation of <see cref="IImageSourceService"/> that loads images from file-based sources.
+/// </summary>
+/// <remarks>
+/// This service resolves images by first attempting to locate them as Avalonia embedded resources
+/// and then falling back to the local filesystem.
+/// </remarks>
 public partial class AvaloniaFileImageSourceService : IAvaloniaImageSourceService, IImageSourceService<IFileImageSource>
 {
     private readonly ILogger<AvaloniaFileImageSourceService>? _logger;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AvaloniaFileImageSourceService"/> class.
+    /// </summary>
+    /// <param name="logger">An optional logger for diagnostic messages during image loading.</param>
     public AvaloniaFileImageSourceService(ILogger<AvaloniaFileImageSourceService>? logger = null)
     {
         _logger = logger;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AvaloniaFileImageSourceService"/> class with no logger.
+    /// </summary>
     public AvaloniaFileImageSourceService()
     {
     }
 
+    /// <summary>
+    /// Attempts to load a bitmap from the specified image source by casting it to <see cref="IFileImageSource"/>.
+    /// </summary>
+    /// <param name="imageSource">The image source to load. Must implement <see cref="IFileImageSource"/> to produce a result.</param>
+    /// <param name="scale">The display scale factor applied during image loading.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// An <see cref="IImageSourceServiceResult{Bitmap}"/> containing the loaded bitmap, or <see langword="null"/>
+    /// if the source is not a file image source.
+    /// </returns>
     public Task<IImageSourceServiceResult<Bitmap>?> GetImageAsync(
         IImageSource imageSource,
         float scale = 1,
@@ -36,6 +60,16 @@ public partial class AvaloniaFileImageSourceService : IAvaloniaImageSourceServic
         return Task.FromResult<IImageSourceServiceResult<Bitmap>?>(null);
     }
 
+    /// <summary>
+    /// Loads a bitmap from the specified file image source, first trying Avalonia resources and then the filesystem.
+    /// </summary>
+    /// <param name="imageSource">The file image source containing the file name or path to load.</param>
+    /// <param name="scale">The display scale factor applied during image loading.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// An <see cref="IImageSourceServiceResult{Bitmap}"/> containing the loaded bitmap, or <see langword="null"/>
+    /// if the file could not be found.
+    /// </returns>
     public Task<IImageSourceServiceResult<Bitmap>?> GetImageAsync(
         IFileImageSource imageSource,
         float scale = 1,
@@ -97,8 +131,21 @@ public partial class AvaloniaFileImageSourceService : IAvaloniaImageSourceServic
     }
 }
 
+/// <summary>
+/// Wraps an Avalonia <see cref="Bitmap"/> as an <see cref="IImageSourceServiceResult{Bitmap}"/>.
+/// </summary>
+/// <remarks>
+/// This type manages the lifetime of the bitmap and an optional disposal action, ensuring
+/// resources are released when the result is no longer needed.
+/// </remarks>
 public class ImageSourceServiceResult : IImageSourceServiceResult<Bitmap>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImageSourceServiceResult"/> class.
+    /// </summary>
+    /// <param name="value">The loaded <see cref="Bitmap"/> instance.</param>
+    /// <param name="resolutionDependent">Indicates whether the image varies with display resolution.</param>
+    /// <param name="dispose">An optional callback invoked during disposal for additional cleanup.</param>
     public ImageSourceServiceResult(Bitmap value, bool resolutionDependent = false, Action? dispose = null)
     {
         Value = value;
@@ -106,12 +153,25 @@ public class ImageSourceServiceResult : IImageSourceServiceResult<Bitmap>
         DisposeAction = dispose;
     }
 
+    /// <summary>
+    /// Gets the loaded <see cref="Bitmap"/> image.
+    /// </summary>
     public Bitmap Value { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the image is resolution-dependent.
+    /// </summary>
     public bool IsResolutionDependent { get; }
     private Action? DisposeAction { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether this result has been disposed.
+    /// </summary>
     public bool IsDisposed { get; private set; }
 
+    /// <summary>
+    /// Disposes the bitmap and invokes any additional cleanup action.
+    /// </summary>
     public void Dispose()
     {
         if (IsDisposed)

--- a/src/Avalonia.Controls.Maui/Services/AvaloniaFontImageSourceService.Windows.cs
+++ b/src/Avalonia.Controls.Maui/Services/AvaloniaFontImageSourceService.Windows.cs
@@ -8,6 +8,14 @@ namespace Avalonia.Controls.Maui.Services;
 /// </summary>
 public partial class AvaloniaFontImageSourceService
 {
+    /// <summary>
+    /// Returns <see langword="null"/> because Avalonia handles all image rendering directly via GetImageAsync.
+    /// This stub satisfies the Windows-specific IImageSourceService contract.
+    /// </summary>
+    /// <param name="imageSource">The image source to resolve.</param>
+    /// <param name="scale">The display scale factor.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>Always <see langword="null"/>.</returns>
     public Task<IImageSourceServiceResult<Microsoft.UI.Xaml.Media.ImageSource>?> GetImageSourceAsync(IImageSource imageSource, float scale = 1, CancellationToken cancellationToken = default)
     {
         return Task.FromResult<IImageSourceServiceResult<Microsoft.UI.Xaml.Media.ImageSource>?>(null);

--- a/src/Avalonia.Controls.Maui/Services/AvaloniaFontImageSourceService.cs
+++ b/src/Avalonia.Controls.Maui/Services/AvaloniaFontImageSourceService.cs
@@ -13,18 +13,33 @@ using AvaloniaFontManager = Avalonia.Controls.Maui.FontManager;
 
 namespace Avalonia.Controls.Maui.Services;
 
+/// <summary>
+/// Avalonia implementation of <see cref="IImageSourceService"/> that renders font glyphs as bitmap images.
+/// </summary>
+/// <remarks>
+/// The service uses Avalonia's text rendering pipeline to draw a single glyph onto a
+/// <see cref="RenderTargetBitmap"/>, applying the specified color, font family, weight, and style.
+/// </remarks>
 public partial class AvaloniaFontImageSourceService : IAvaloniaImageSourceService, IImageSourceService<IFontImageSource>
 {
     private readonly ILogger<AvaloniaFontImageSourceService>? _logger;
     private readonly IFontManager? _fontManager;
     private const int DefaultSize = 100;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AvaloniaFontImageSourceService"/> class.
+    /// </summary>
+    /// <param name="fontManager">An optional MAUI font manager used to resolve registered font families.</param>
+    /// <param name="logger">An optional logger for diagnostic messages during glyph rendering.</param>
     public AvaloniaFontImageSourceService(IFontManager? fontManager = null, ILogger<AvaloniaFontImageSourceService>? logger = null)
     {
         _fontManager = fontManager;
         _logger = logger;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AvaloniaFontImageSourceService"/> class with no dependencies.
+    /// </summary>
     public AvaloniaFontImageSourceService()
     {
     }
@@ -42,6 +57,16 @@ public partial class AvaloniaFontImageSourceService : IAvaloniaImageSourceServic
         return IPlatformApplication.Current?.Services?.GetService<IFontManager>();
     }
 
+    /// <summary>
+    /// Attempts to render a bitmap from the specified image source by casting it to <see cref="IFontImageSource"/>.
+    /// </summary>
+    /// <param name="imageSource">The image source to render. Must implement <see cref="IFontImageSource"/> to produce a result.</param>
+    /// <param name="scale">The display scale factor applied during glyph rendering.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// An <see cref="IImageSourceServiceResult{Bitmap}"/> containing the rendered glyph bitmap, or <see langword="null"/>
+    /// if the source is not a font image source.
+    /// </returns>
     public Task<IImageSourceServiceResult<Bitmap>?> GetImageAsync(
         IImageSource imageSource,
         float scale = 1,
@@ -55,6 +80,16 @@ public partial class AvaloniaFontImageSourceService : IAvaloniaImageSourceServic
         return Task.FromResult<IImageSourceServiceResult<Bitmap>?>(null);
     }
 
+    /// <summary>
+    /// Renders the font glyph specified by the <see cref="IFontImageSource"/> into an Avalonia bitmap.
+    /// </summary>
+    /// <param name="imageSource">The font image source containing the glyph, font, and color information.</param>
+    /// <param name="scale">The display scale factor applied during glyph rendering.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// An <see cref="IImageSourceServiceResult{Bitmap}"/> containing the rendered glyph bitmap, or <see langword="null"/>
+    /// if the source or its glyph is <see langword="null"/> or empty.
+    /// </returns>
     public Task<IImageSourceServiceResult<Bitmap>?> GetImageAsync(
         IFontImageSource imageSource,
         float scale = 1,

--- a/src/Avalonia.Controls.Maui/Services/AvaloniaStreamImageSourceService.Windows.cs
+++ b/src/Avalonia.Controls.Maui/Services/AvaloniaStreamImageSourceService.Windows.cs
@@ -8,6 +8,14 @@ namespace Avalonia.Controls.Maui.Services;
 /// </summary>
 public partial class AvaloniaStreamImageSourceService
 {
+    /// <summary>
+    /// Returns <see langword="null"/> because Avalonia handles all image rendering directly via GetImageAsync.
+    /// This stub satisfies the Windows-specific IImageSourceService contract.
+    /// </summary>
+    /// <param name="imageSource">The image source to resolve.</param>
+    /// <param name="scale">The display scale factor.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>Always <see langword="null"/>.</returns>
     public Task<IImageSourceServiceResult<Microsoft.UI.Xaml.Media.ImageSource>?> GetImageSourceAsync(IImageSource imageSource, float scale = 1, CancellationToken cancellationToken = default)
     {
         return Task.FromResult<IImageSourceServiceResult<Microsoft.UI.Xaml.Media.ImageSource>?>(null);

--- a/src/Avalonia.Controls.Maui/Services/AvaloniaStreamImageSourceService.cs
+++ b/src/Avalonia.Controls.Maui/Services/AvaloniaStreamImageSourceService.cs
@@ -8,19 +8,43 @@ using Microsoft.Maui;
 
 namespace Avalonia.Controls.Maui.Services;
 
+/// <summary>
+/// Avalonia implementation of <see cref="IImageSourceService"/> that loads images from stream-based sources.
+/// </summary>
+/// <remarks>
+/// If the provided stream is not seekable, the service copies its contents into a seekable
+/// <see cref="MemoryStream"/> before creating the bitmap.
+/// </remarks>
 public partial class AvaloniaStreamImageSourceService : IAvaloniaImageSourceService, IImageSourceService<IStreamImageSource>
 {
     private readonly ILogger<AvaloniaStreamImageSourceService>? _logger;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AvaloniaStreamImageSourceService"/> class.
+    /// </summary>
+    /// <param name="logger">An optional logger for diagnostic messages during image loading.</param>
     public AvaloniaStreamImageSourceService(ILogger<AvaloniaStreamImageSourceService>? logger = null)
     {
         _logger = logger;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AvaloniaStreamImageSourceService"/> class with no logger.
+    /// </summary>
     public AvaloniaStreamImageSourceService()
     {
     }
 
+    /// <summary>
+    /// Attempts to load a bitmap from the specified image source by casting it to <see cref="IStreamImageSource"/>.
+    /// </summary>
+    /// <param name="imageSource">The image source to load. Must implement <see cref="IStreamImageSource"/> to produce a result.</param>
+    /// <param name="scale">The display scale factor applied during image loading.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// An <see cref="IImageSourceServiceResult{Bitmap}"/> containing the loaded bitmap, or <see langword="null"/>
+    /// if the source is not a stream image source.
+    /// </returns>
     public Task<IImageSourceServiceResult<Bitmap>?> GetImageAsync(
         IImageSource imageSource,
         float scale = 1,
@@ -34,6 +58,16 @@ public partial class AvaloniaStreamImageSourceService : IAvaloniaImageSourceServ
         return Task.FromResult<IImageSourceServiceResult<Bitmap>?>(null);
     }
 
+    /// <summary>
+    /// Loads a bitmap by reading from the stream provided by the specified <see cref="IStreamImageSource"/>.
+    /// </summary>
+    /// <param name="imageSource">The stream image source from which to obtain the image data.</param>
+    /// <param name="scale">The display scale factor applied during image loading.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// An <see cref="IImageSourceServiceResult{Bitmap}"/> containing the loaded bitmap, or <see langword="null"/>
+    /// if the source is <see langword="null"/> or returns a <see langword="null"/> stream.
+    /// </returns>
     public async Task<IImageSourceServiceResult<Bitmap>?> GetImageAsync(
         IStreamImageSource imageSource,
         float scale = 1,

--- a/src/Avalonia.Controls.Maui/Services/AvaloniaUriImageSourceService.Windows.cs
+++ b/src/Avalonia.Controls.Maui/Services/AvaloniaUriImageSourceService.Windows.cs
@@ -8,6 +8,14 @@ namespace Avalonia.Controls.Maui.Services;
 /// </summary>
 public partial class AvaloniaUriImageSourceService
 {
+    /// <summary>
+    /// Returns <see langword="null"/> because Avalonia handles all image rendering directly via GetImageAsync.
+    /// This stub satisfies the Windows-specific IImageSourceService contract.
+    /// </summary>
+    /// <param name="imageSource">The image source to resolve.</param>
+    /// <param name="scale">The display scale factor.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>Always <see langword="null"/>.</returns>
     public Task<IImageSourceServiceResult<Microsoft.UI.Xaml.Media.ImageSource>?> GetImageSourceAsync(IImageSource imageSource, float scale = 1, CancellationToken cancellationToken = default)
     {
         // Avalonia handles image rendering, return null to indicate no native image

--- a/src/Avalonia.Controls.Maui/Services/AvaloniaUriImageSourceService.cs
+++ b/src/Avalonia.Controls.Maui/Services/AvaloniaUriImageSourceService.cs
@@ -12,6 +12,14 @@ using Microsoft.Maui;
 
 namespace Avalonia.Controls.Maui.Services;
 
+/// <summary>
+/// Avalonia implementation of <see cref="IImageSourceService"/> that loads images from URI-based sources with optional disk caching.
+/// </summary>
+/// <remarks>
+/// Supports HTTP/HTTPS and file URIs. When caching is enabled on the image source, downloaded images
+/// are persisted to a temporary directory and reused until the configured cache validity period expires.
+/// Concurrent requests for the same URI are coalesced to avoid duplicate downloads.
+/// </remarks>
 public partial class AvaloniaUriImageSourceService : IAvaloniaImageSourceService, IImageSourceService<IUriImageSource>
 {
     private readonly ILogger<AvaloniaUriImageSourceService>? _logger;
@@ -29,6 +37,11 @@ public partial class AvaloniaUriImageSourceService : IAvaloniaImageSourceService
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AvaloniaUriImageSourceService"/> class.
+    /// </summary>
+    /// <param name="logger">An optional logger for diagnostic messages during image loading and caching.</param>
+    /// <param name="httpClient">An optional <see cref="HttpClient"/> for downloading remote images. A default client is created if not provided.</param>
     public AvaloniaUriImageSourceService(ILogger<AvaloniaUriImageSourceService>? logger = null, HttpClient? httpClient = null)
     {
         _logger = logger;
@@ -39,6 +52,16 @@ public partial class AvaloniaUriImageSourceService : IAvaloniaImageSourceService
         EnsureCacheDirectory();
     }
 
+    /// <summary>
+    /// Attempts to load a bitmap from the specified image source by casting it to <see cref="IUriImageSource"/>.
+    /// </summary>
+    /// <param name="imageSource">The image source to load. Must implement <see cref="IUriImageSource"/> to produce a result.</param>
+    /// <param name="scale">The display scale factor applied during image loading.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// An <see cref="IImageSourceServiceResult{Bitmap}"/> containing the loaded bitmap, or <see langword="null"/>
+    /// if the source is not a URI image source.
+    /// </returns>
     public Task<IImageSourceServiceResult<Bitmap>?> GetImageAsync(
         IImageSource imageSource,
         float scale = 1,
@@ -52,6 +75,16 @@ public partial class AvaloniaUriImageSourceService : IAvaloniaImageSourceService
         return Task.FromResult<IImageSourceServiceResult<Bitmap>?>(null);
     }
 
+    /// <summary>
+    /// Loads a bitmap from the URI specified by the <see cref="IUriImageSource"/>, using disk caching when enabled.
+    /// </summary>
+    /// <param name="imageSource">The URI image source containing the target URI and caching configuration.</param>
+    /// <param name="scale">The display scale factor applied during image loading.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// An <see cref="IImageSourceServiceResult{Bitmap}"/> containing the loaded bitmap, or <see langword="null"/>
+    /// if the URI is <see langword="null"/> or uses an unsupported scheme.
+    /// </returns>
     public async Task<IImageSourceServiceResult<Bitmap>?> GetImageAsync(
         IUriImageSource imageSource,
         float scale = 1,

--- a/src/Avalonia.Controls.Maui/Services/IAvaloniaImageSourceService.cs
+++ b/src/Avalonia.Controls.Maui/Services/IAvaloniaImageSourceService.cs
@@ -29,6 +29,18 @@ public interface IAvaloniaImageSourceService : IImageSourceService
 /// </summary>
 public static class ImageSourceServiceExtensions
 {
+    /// <summary>
+    /// Retrieves an image from the specified image source service, delegating to
+    /// <see cref="IAvaloniaImageSourceService"/> when the service supports Avalonia.
+    /// </summary>
+    /// <param name="service">The image source service to invoke.</param>
+    /// <param name="imageSource">The image source describing the image to load.</param>
+    /// <param name="scale">The display scale factor applied during image loading.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// An <see cref="IImageSourceServiceResult"/> containing the loaded image, or <see langword="null"/>
+    /// if the service does not implement <see cref="IAvaloniaImageSourceService"/>.
+    /// </returns>
     public static async Task<IImageSourceServiceResult?> GetImageAsync(
         this IImageSourceService service,
         IImageSource imageSource,

--- a/src/Avalonia.Controls.Maui/Styles/Controls.axaml.cs
+++ b/src/Avalonia.Controls.Maui/Styles/Controls.axaml.cs
@@ -3,8 +3,15 @@ using Avalonia.Styling;
 
 namespace Avalonia.Controls.Maui;
 
+/// <summary>
+/// Provides Avalonia styles resources for .NET MAUI control theming.
+/// </summary>
 public partial class ControlStyles : Styles
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ControlStyles"/> class and loads the associated XAML styles.
+    /// </summary>
+    /// <param name="serviceProvider">An optional service provider used by the Avalonia XAML loader.</param>
     public ControlStyles(IServiceProvider? serviceProvider = null)
     {
         AvaloniaXamlLoader.Load(serviceProvider, this);


### PR DESCRIPTION
GenerateDocumentationFile was not actually be run, so warnings for missing comments were not being thrown. Oops.

This fixes it (with a little help from a friend, ;-) ) and now should be set up to always throw to enforce comments.