### PR TITLE
Don't disconnect handlers on ShellContent navigation

### DIFF
--- a/samples/BenchmarkApp/BenchmarkApp/BenchmarkRegistry.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/BenchmarkRegistry.cs
@@ -74,6 +74,7 @@ public static class BenchmarkRegistry
         Register<ShellNavigationWithModalsAndFlyoutBenchmark>();
         Register<PlatformViewLeakBenchmark>();
         Register<ShellItemSwitchLeakBenchmark>();
+        Register<ShellContentNavigationBenchmark>();
         Register<ShellSectionSwitchLeakBenchmark>();
         Register<TransformCleanupLeakBenchmark>();
         Register<BorderShapeSubscriptionLeakBenchmark>();

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/ShellContentNavigationBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/ShellContentNavigationBenchmark.cs
@@ -1,0 +1,162 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Maui.Controls;
+
+namespace BenchmarkApp.Tests;
+
+/// <summary>
+/// Tests that navigating between different ShellContent items (via FlyoutItem switching)
+/// preserves page content when navigating back. The page should be the same instance and
+/// its handler should remain connected, matching native MAUI Shell behavior.
+/// </summary>
+[BenchmarkTest("ShellContentNavigation", Description = "Verifies page content is preserved when navigating between Shell FlyoutItems and returning")]
+public class ShellContentNavigationBenchmark : BenchmarkTestPage
+{
+    /// <inheritdoc/>
+    public override async Task<BenchmarkResult> RunAsync(Window window, ILogger logger, CancellationToken cancellationToken)
+    {
+        var memBefore = MemorySnapshot.Capture(forceGC: true);
+
+        var result = await RunNavigationCycles(window, this, logger, cancellationToken);
+
+        var memAfter = MemorySnapshot.Capture(forceGC: true);
+        var memoryDelta = memAfter.Compare(memBefore);
+
+        var metrics = new Dictionary<string, object>
+        {
+            ["NavigationCycles"] = result.NavigationCycles,
+            ["Failures"] = result.Failures.Count > 0
+                ? string.Join("; ", result.Failures)
+                : "none",
+        };
+
+        foreach (var (key, value) in memoryDelta.ToMetrics())
+            metrics[key] = value;
+
+        if (result.Failures.Count > 0)
+        {
+            var msg = string.Join("; ", result.Failures);
+            logger.LogWarning("Shell content navigation failures: {Failures}", msg);
+            return BenchmarkResult.Fail(msg, metrics);
+        }
+
+        logger.LogInformation(
+            "Shell content preserved across {Cycles} navigation cycles",
+            result.NavigationCycles);
+        return BenchmarkResult.Pass(metrics);
+    }
+
+    private record NavigationResult(int NavigationCycles, List<string> Failures);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async Task<NavigationResult> RunNavigationCycles(
+        Window window,
+        Page restorePage,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        const int itemCount = 4;
+        const int cycles = 3;
+        var pages = new ContentPage[itemCount];
+        var shell = CreateShell(pages, itemCount);
+        window.Page = shell;
+
+        await Task.Delay(150, cancellationToken);
+
+        var failures = new List<string>();
+        int navigationCycles = 0;
+
+        for (int cycle = 0; cycle < cycles; cycle++)
+        {
+            // Navigate forward through all items
+            for (int i = 0; i < itemCount; i++)
+            {
+                shell.CurrentItem = shell.Items[i];
+                await Task.Delay(50, cancellationToken);
+
+                var section = ((ShellItem)shell.Items[i]).Items[0];
+                if (section.Handler == null)
+                {
+                    failures.Add($"Cycle {cycle}: Item[{i}] section handler is null after navigation");
+                    logger.LogWarning("Cycle {Cycle}: Item[{I}] section handler null", cycle, i);
+                }
+
+                var controller = (IShellContentController)section.CurrentItem;
+                if (controller.Page != pages[i])
+                {
+                    failures.Add($"Cycle {cycle}: Item[{i}] page is not the original instance");
+                    logger.LogWarning("Cycle {Cycle}: Item[{I}] page changed", cycle, i);
+                }
+            }
+
+            // Navigate backward through all items
+            for (int i = itemCount - 1; i >= 0; i--)
+            {
+                shell.CurrentItem = shell.Items[i];
+                await Task.Delay(50, cancellationToken);
+
+                var section = ((ShellItem)shell.Items[i]).Items[0];
+                if (section.Handler == null)
+                {
+                    failures.Add($"Cycle {cycle} (reverse): Item[{i}] section handler is null");
+                    logger.LogWarning("Cycle {Cycle} (reverse): Item[{I}] section handler null", cycle, i);
+                }
+
+                var controller = (IShellContentController)section.CurrentItem;
+                if (controller.Page != pages[i])
+                {
+                    failures.Add($"Cycle {cycle} (reverse): Item[{i}] page is not the original instance");
+                    logger.LogWarning("Cycle {Cycle} (reverse): Item[{I}] page changed", cycle, i);
+                }
+            }
+
+            navigationCycles++;
+        }
+
+        // Restore page to clean up
+        window.Page = restorePage;
+
+        return new NavigationResult(navigationCycles, failures);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Shell CreateShell(ContentPage[] pages, int itemCount)
+    {
+        var shell = new Shell { FlyoutBehavior = FlyoutBehavior.Disabled };
+
+        for (int i = 0; i < itemCount; i++)
+        {
+            var page = new ContentPage
+            {
+                Title = $"Page {i}",
+                Content = new VerticalStackLayout
+                {
+                    Children =
+                    {
+                        new Label { Text = $"Content for page {i}" },
+                        new Button { Text = $"Action {i}" },
+                    },
+                },
+            };
+
+            pages[i] = page;
+
+            var shellContent = new ShellContent
+            {
+                Title = $"Item {i}",
+                ContentTemplate = new DataTemplate(() => page),
+                Route = $"content{i}",
+            };
+
+            var shellSection = new ShellSection { Title = $"Section {i}" };
+            shellSection.Items.Add(shellContent);
+
+            var shellItem = new ShellItem { Title = $"Item {i}" };
+            shellItem.Items.Add(shellSection);
+
+            shell.Items.Add(shellItem);
+        }
+
+        return shell;
+    }
+}

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/ShellItemSwitchLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/ShellItemSwitchLeakBenchmark.cs
@@ -7,12 +7,12 @@ using Microsoft.Maui.Controls;
 namespace BenchmarkApp.Tests;
 
 /// <summary>
-/// Tests that switching Shell.CurrentItem releases the old item's section handler resources.
-/// Without cleanup, every ShellItem that was ever active keeps its section handler's full
-/// tree (navigation stack, page handlers, platform views) alive even though only the current
-/// item is visible. This test checks that inactive items' sections are disconnected.
+/// Tests that switching Shell.CurrentItem preserves page content and section handlers.
+/// Section handlers should remain connected when switching between FlyoutItems so that
+/// navigating back to a previously visited item shows the same page without re-creation.
+/// This matches the native MAUI behavior where pages are cached via ShellContent.ContentCache.
 /// </summary>
-[BenchmarkTest("ShellItemSwitchLeak", Description = "Verifies old section handlers are released when switching Shell.CurrentItem")]
+[BenchmarkTest("ShellItemSwitchLeak", Description = "Verifies section handlers stay connected and page content is preserved when switching Shell.CurrentItem")]
 public class ShellItemSwitchLeakBenchmark : BenchmarkTestPage
 {
     /// <inheritdoc/>
@@ -28,9 +28,12 @@ public class ShellItemSwitchLeakBenchmark : BenchmarkTestPage
         var metrics = new Dictionary<string, object>
         {
             ["TotalSwitches"] = result.TotalSwitches,
-            ["StaleHandlersFound"] = result.StaleHandlers.Count,
-            ["StaleHandlers"] = result.StaleHandlers.Count > 0
-                ? string.Join(", ", result.StaleHandlers)
+            ["MissingHandlersFound"] = result.MissingHandlers.Count,
+            ["MissingHandlers"] = result.MissingHandlers.Count > 0
+                ? string.Join(", ", result.MissingHandlers)
+                : "none",
+            ["MissingPages"] = result.MissingPages.Count > 0
+                ? string.Join(", ", result.MissingPages)
                 : "none",
         };
 
@@ -39,23 +42,26 @@ public class ShellItemSwitchLeakBenchmark : BenchmarkTestPage
             metrics[key] = value;
         }
 
-        if (result.StaleHandlers.Count > 0)
+        if (result.MissingHandlers.Count > 0 || result.MissingPages.Count > 0)
         {
-            var staleNames = string.Join(", ", result.StaleHandlers);
-            logger.LogWarning(
-                "Section handlers not disconnected after switching away: {StaleHandlers}",
-                staleNames);
-            return BenchmarkResult.Fail(
-                $"Section handlers still connected after item switch: {staleNames}", metrics);
+            var issues = new List<string>();
+            if (result.MissingHandlers.Count > 0)
+                issues.Add($"Section handlers missing: {string.Join(", ", result.MissingHandlers)}");
+            if (result.MissingPages.Count > 0)
+                issues.Add($"Pages missing: {string.Join(", ", result.MissingPages)}");
+
+            var msg = string.Join("; ", issues);
+            logger.LogWarning("Shell item switch issues: {Issues}", msg);
+            return BenchmarkResult.Fail(msg, metrics);
         }
 
         logger.LogInformation(
-            "All inactive items' section handlers properly disconnected after {Switches} switches",
+            "All items preserve section handlers and page content after {Switches} switches",
             result.TotalSwitches);
         return BenchmarkResult.Pass(metrics);
     }
 
-    private record SwitchResult(int TotalSwitches, List<string> StaleHandlers);
+    private record SwitchResult(int TotalSwitches, List<string> MissingHandlers, List<string> MissingPages);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static async Task<SwitchResult> RunShellLifecycle(
@@ -64,12 +70,14 @@ public class ShellItemSwitchLeakBenchmark : BenchmarkTestPage
         ILogger logger,
         CancellationToken cancellationToken)
     {
-        var shell = CreateShellWithItems();
+        var pages = new ContentPage[3];
+        var shell = CreateShellWithItems(pages);
         window.Page = shell;
 
         await Task.Delay(150, cancellationToken);
 
-        var staleHandlers = new List<string>();
+        var missingHandlers = new List<string>();
+        var missingPages = new List<string>();
         int totalSwitches = 0;
 
         // Verify initial state: Item 0's section should have a handler
@@ -81,12 +89,12 @@ public class ShellItemSwitchLeakBenchmark : BenchmarkTestPage
         await Task.Delay(100, cancellationToken);
         totalSwitches++;
 
-        // After switching to Item 1, Item 0's section handler should be disconnected.
-        // Without the fix, Item 0's section keeps its full handler tree alive.
-        if (section0.Handler != null)
+        // After switching to Item 1, Item 0's section handler should still be connected.
+        // Section handlers are intentionally kept alive so navigating back shows the same page.
+        if (section0.Handler == null)
         {
-            staleHandlers.Add("Item[0].Section (after switch to Item[1])");
-            logger.LogWarning("Item[0]'s section handler still connected after switching to Item[1]");
+            missingHandlers.Add("Item[0].Section (after switch to Item[1])");
+            logger.LogWarning("Item[0]'s section handler was disconnected after switching to Item[1]");
         }
 
         // Switch from Item 1 to Item 2
@@ -95,32 +103,46 @@ public class ShellItemSwitchLeakBenchmark : BenchmarkTestPage
         await Task.Delay(100, cancellationToken);
         totalSwitches++;
 
-        if (section1.Handler != null)
+        if (section1.Handler == null)
         {
-            staleHandlers.Add("Item[1].Section (after switch to Item[2])");
-            logger.LogWarning("Item[1]'s section handler still connected after switching to Item[2]");
+            missingHandlers.Add("Item[1].Section (after switch to Item[2])");
+            logger.LogWarning("Item[1]'s section handler was disconnected after switching to Item[2]");
         }
 
-        // Switch back to Item 0 (creates fresh section handler)
+        // Switch back to Item 0 — the same section handler should still be there
         var section2 = ((ShellItem)shell.Items[2]).Items[0];
         shell.CurrentItem = shell.Items[0];
         await Task.Delay(100, cancellationToken);
         totalSwitches++;
 
-        if (section2.Handler != null)
+        if (section0.Handler == null)
         {
-            staleHandlers.Add("Item[2].Section (after switch to Item[0])");
-            logger.LogWarning("Item[2]'s section handler still connected after switching to Item[0]");
+            missingHandlers.Add("Item[0].Section (after switch back)");
+            logger.LogWarning("Item[0]'s section handler was missing after switching back");
+        }
+
+        // Verify that the page content is still the same (not re-created)
+        var controller0 = (IShellContentController)section0.CurrentItem;
+        if (controller0.Page != pages[0])
+        {
+            missingPages.Add("Item[0] page changed after switch back");
+            logger.LogWarning("Item[0]'s page was not preserved after switching back");
+        }
+
+        if (section2.Handler == null)
+        {
+            missingHandlers.Add("Item[2].Section (after switch to Item[0])");
+            logger.LogWarning("Item[2]'s section handler was disconnected after switching to Item[0]");
         }
 
         // Restore page to clean up
         window.Page = restorePage;
 
-        return new SwitchResult(totalSwitches, staleHandlers);
+        return new SwitchResult(totalSwitches, missingHandlers, missingPages);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static Shell CreateShellWithItems()
+    private static Shell CreateShellWithItems(ContentPage[] pages)
     {
         var shell = new Shell { FlyoutBehavior = FlyoutBehavior.Disabled };
 
@@ -146,6 +168,8 @@ public class ShellItemSwitchLeakBenchmark : BenchmarkTestPage
                     },
                 },
             };
+
+            pages[i] = page;
 
             var shellContent = new ShellContent
             {

--- a/src/Avalonia.Controls.Maui/Extensions/ShellExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/ShellExtensions.cs
@@ -630,21 +630,8 @@ public static class ShellExtensions
             // transition's hidden presenter releases its content reference.
             // Without this, cancelled CrossFade transitions skip HideOldPresenter(),
             // leaving old control trees alive and leaking native render resources.
-            var savedTransition = handler._mainContentControl.PageTransition;
             handler._mainContentControl.PageTransition = null;
             handler._mainContentControl.Content = null;
-
-            // Release the old item's section handler resources (navigation stack,
-            // page references, event subscriptions) now that its platform view is
-            // detached from the visual tree. We only disconnect the section handler,
-            // not the ShellItemHandler itself, so the item can be re-activated later.
-            if (oldItemHandler != null
-                && oldItemHandler != handler._currentItemHandler
-                && oldItemHandler._currentSectionHandler != null)
-            {
-                oldItemHandler._currentSectionHandler.VirtualView?.Handler?.DisconnectHandler();
-                oldItemHandler._currentSectionHandler = null;
-            }
 
             handler._mainContentControl.PageTransition = new CrossFade(ShellHandler.DefaultTransitionDuration);
 

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/ShellHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/ShellHandlerTests.cs
@@ -942,6 +942,128 @@ public partial class ShellHandlerTests : HandlerTestBase
         Assert.True(handler._backButton.IsEnabled);
     }
 
+    [AvaloniaFact(DisplayName = "Shell Navigating Between FlyoutItems Preserves Page Content")]
+    public async Task ShellNavigatingBetweenFlyoutItemsPreservesPageContent()
+    {
+        var page1 = new ContentPage { Title = "Page 1", Content = new MauiLabel { Text = "Content 1" } };
+        var page2 = new ContentPage { Title = "Page 2", Content = new MauiLabel { Text = "Content 2" } };
+        var page3 = new ContentPage { Title = "Page 3", Content = new MauiLabel { Text = "Content 3" } };
+
+        var shell = new Shell
+        {
+            WidthRequest = 800,
+            HeightRequest = 600,
+            Items =
+            {
+                new FlyoutItem
+                {
+                    Title = "Item 1",
+                    Items =
+                    {
+                        new ShellContent { Title = "Content 1", Content = page1 }
+                    }
+                },
+                new FlyoutItem
+                {
+                    Title = "Item 2",
+                    Items =
+                    {
+                        new ShellContent { Title = "Content 2", Content = page2 }
+                    }
+                },
+                new FlyoutItem
+                {
+                    Title = "Item 3",
+                    Items =
+                    {
+                        new ShellContent { Title = "Content 3", Content = page3 }
+                    }
+                }
+            }
+        };
+
+        var handler = await CreateHandlerAsync<MauiShellHandler>(shell);
+
+        // Verify initial state: Item 1 is current, its section has a handler
+        var section1 = ((ShellItem)shell.Items[0]).Items[0];
+        Assert.NotNull(section1.Handler);
+
+        // Switch to Item 2
+        await InvokeOnMainThreadAsync(() =>
+        {
+            shell.CurrentItem = shell.Items[1];
+            handler.UpdateValue(nameof(Shell.CurrentItem));
+        });
+
+        var section2 = ((ShellItem)shell.Items[1]).Items[0];
+        Assert.NotNull(section2.Handler);
+
+        // Switch to Item 3
+        await InvokeOnMainThreadAsync(() =>
+        {
+            shell.CurrentItem = shell.Items[2];
+            handler.UpdateValue(nameof(Shell.CurrentItem));
+        });
+
+        var section3 = ((ShellItem)shell.Items[2]).Items[0];
+        Assert.NotNull(section3.Handler);
+
+        // Switch back to Item 1 — page should still be there
+        await InvokeOnMainThreadAsync(() =>
+        {
+            shell.CurrentItem = shell.Items[0];
+            handler.UpdateValue(nameof(Shell.CurrentItem));
+        });
+
+        // The section handler should still be present and the page should be accessible
+        Assert.NotNull(section1.Handler);
+        Assert.Equal(page1, ((IShellContentController)section1.CurrentItem).Page);
+
+        // Switch back to Item 2 — page should still be there
+        await InvokeOnMainThreadAsync(() =>
+        {
+            shell.CurrentItem = shell.Items[1];
+            handler.UpdateValue(nameof(Shell.CurrentItem));
+        });
+
+        Assert.NotNull(section2.Handler);
+        Assert.Equal(page2, ((IShellContentController)section2.CurrentItem).Page);
+    }
+
+    [AvaloniaFact(DisplayName = "Shell Section Handler Stays Connected During FlyoutItem Switch")]
+    public async Task ShellSectionHandlerStaysConnectedDuringFlyoutItemSwitch()
+    {
+        var shell = CreateShellWithMultipleItems();
+
+        var handler = await CreateHandlerAsync<MauiShellHandler>(shell);
+
+        var section1 = ((ShellItem)shell.Items[0]).Items[0];
+        var initialHandler = section1.Handler;
+        Assert.NotNull(initialHandler);
+
+        // Switch to Item 2
+        await InvokeOnMainThreadAsync(() =>
+        {
+            shell.CurrentItem = shell.Items[1];
+            handler.UpdateValue(nameof(Shell.CurrentItem));
+        });
+
+        // Section 1's handler should NOT have been disconnected
+        Assert.NotNull(section1.Handler);
+        Assert.Same(initialHandler, section1.Handler);
+
+        // Switch back to Item 1
+        await InvokeOnMainThreadAsync(() =>
+        {
+            shell.CurrentItem = shell.Items[0];
+            handler.UpdateValue(nameof(Shell.CurrentItem));
+        });
+
+        // The same handler should still be there
+        Assert.NotNull(section1.Handler);
+        Assert.Same(initialHandler, section1.Handler);
+    }
+
     private Shell CreateShellWithNavigationStack()
     {
         var page1 = new ContentPage { Title = "Page 1" };


### PR DESCRIPTION
My benchmark PR was a little _too_ aggressive when clearing Shell. It shouldn't disconnect the handers on navigation, it needs to keep them to preserve state. That's the expected behavior for it. 