### PR TITLE
Disable Maps temporary

### DIFF
--- a/samples/ControlGallery/ControlGallery/MainPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/MainPage.xaml.cs
@@ -198,7 +198,8 @@ public partial class MainPage : FlyoutPage
                 new("Image", "Visual content display", typeof(ImagePage)),
                 new("ImageButton", "Interactive image button", typeof(ImageButtonPage)),
                 new("ListView", "Scrolling data items", typeof(ListViewPage)),
-                new("Map", "Interactive maps and pins", typeof(MapPage)),
+                // TODO: Re-enable when Map is ready
+                //new("Map", "Interactive maps and pins", typeof(MapPage)),
                 new("Picker", "Item selection dropdown", typeof(PickerPage)),
                 new("ProgressBar", "Visual progress status", typeof(ProgressBarPage)),
                 new("RadioButton", "Single-select option list", typeof(RadioButtonPage)),


### PR DESCRIPTION
Until Mapsui  https://github.com/Mapsui/Mapsui updates their Avalonia references, just avoid to launch the Maps sample from the Gallery.


The crash comes from Mapsui.Avalonia 5.1.0-beta.2 still targeting Avalonia 11, but the project is already on 12.0.999-alpha. When the Maps assembly is loaded, Mapsui's MapControl tries to resolve Avalonia 11 APIs that no longer exist.