### PR TITLE
Center titlebar for Nav/Shell

### DIFF
--- a/samples/ControlGallery/ControlGallery/Resources/Styles/Styles.xaml
+++ b/samples/ControlGallery/ControlGallery/Resources/Styles/Styles.xaml
@@ -420,8 +420,8 @@
 
     <Style TargetType="NavigationPage">
         <Setter Property="BarBackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource OffBlack}}" />
-        <Setter Property="BarTextColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource White}}" />
-        <Setter Property="IconColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource White}}" />
+        <Setter Property="BarTextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
+        <Setter Property="IconColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
     </Style>
 
     <Style TargetType="TabbedPage">

--- a/src/Avalonia.Controls.Maui/Extensions/ShellExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/ShellExtensions.cs
@@ -42,9 +42,9 @@ public static class ShellExtensions
         }
         else
         {
-            handler._mainContainer.ClearValue(DockPanel.BackgroundProperty);
+            handler._mainContainer.ClearValue(Panel.BackgroundProperty);
             if (handler._topBar != null)
-                handler._topBar.ClearValue(DockPanel.BackgroundProperty);
+                handler._topBar.ClearValue(Panel.BackgroundProperty);
         }
     }
 
@@ -907,13 +907,6 @@ public static class ShellExtensions
         if (handler._titleViewControl == null || handler._topBar == null || shell == null || handler.MauiContext == null)
             return;
 
-        if (handler._searchControl != null && handler._searchControl.IsVisible)
-        {
-            handler._titleViewControl.IsVisible = false;
-            if (handler._titleTextBlock != null) handler._titleTextBlock.IsVisible = false;
-            return;
-        }
-
         var titleView = (shell.CurrentPage != null ? MauiShell.GetTitleView(shell.CurrentPage) : null)
             ?? MauiShell.GetTitleView(shell);
 
@@ -990,10 +983,16 @@ public static class ShellExtensions
             if (handler._searchControl != null)
             {
                 handler._searchControl.CleanUp();
-                handler._topBar.Children.Remove(handler._searchControl);
+                if (handler._searchHostControl != null)
+                {
+                    handler._searchHostControl.Content = null;
+                    handler._searchHostControl.IsVisible = false;
+                }
+
                 handler._searchControl = null;
             }
-                handler.UpdateTitleView(shell);
+
+            handler.UpdateTitleView(shell);
             return;
         }
 
@@ -1005,17 +1004,26 @@ public static class ShellExtensions
         if (handler._searchControl != null)
         {
             handler._searchControl.CleanUp();
-            handler._topBar.Children.Remove(handler._searchControl);
+            if (handler._searchHostControl != null)
+            {
+                handler._searchHostControl.Content = null;
+                handler._searchHostControl.IsVisible = false;
+            }
+
             handler._searchControl = null;
         }
 
         handler._searchControl = new ShellSearchControl(searchHandler, handler.MauiContext);
         handler._searchControl.HorizontalAlignment = HorizontalAlignment.Stretch;
+        handler._searchControl.VerticalAlignment = VerticalAlignment.Stretch;
 
-        handler._topBar.Children.Add(handler._searchControl);
+        if (handler._searchHostControl != null)
+        {
+            handler._searchHostControl.Content = handler._searchControl;
+            handler._searchHostControl.IsVisible = true;
+        }
 
-        if (handler._titleTextBlock != null) handler._titleTextBlock.IsVisible = false;
-        if (handler._titleViewControl != null) handler._titleViewControl.IsVisible = false;
+        handler.UpdateTitleView(shell);
     }
 
     /// <summary>

--- a/src/Avalonia.Controls.Maui/Handlers/Shell/ShellHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shell/ShellHandler.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Styling;
@@ -115,8 +116,14 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
     /// <summary>Main container dock panel holding the top bar and content area.</summary>
     internal DockPanel? _mainContainer;
 
-    /// <summary>Dock panel for the top navigation bar.</summary>
-    internal DockPanel? _topBar;
+    /// <summary>Panel for the top navigation bar.</summary>
+    internal Panel? _topBar;
+
+    /// <summary>Left-aligned container for navigation buttons in the top bar.</summary>
+    internal StackPanel? _topBarLeftButtons;
+
+    /// <summary>Content host for the full-width search control row.</summary>
+    internal ContentControl? _searchHostControl;
 
     /// <summary>Border used as the shadow below the top navigation bar.</summary>
     internal Border? _topBarShadow;
@@ -260,11 +267,17 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
             LastChildFill = true
         };
 
-        _topBar = new DockPanel
+        _topBar = new TopBarPanel
         {
             Height = DefaultBarHeight,
             [DockPanel.DockProperty] = Dock.Top,
             ZIndex = 1
+        };
+
+        _topBarLeftButtons = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center
         };
 
         _topBarShadow = new Border
@@ -284,13 +297,10 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
             HorizontalContentAlignment = HorizontalAlignment.Center,
             VerticalContentAlignment = VerticalAlignment.Center,
             Background = Brushes.Transparent,
-            IsVisible = false,
-            [DockPanel.DockProperty] = Dock.Left
+            IsVisible = false
         };
         _backButton.Click += OnBackButtonClick;
-        
-        _topBar.Children.Add(_backButton);
-
+        _topBarLeftButtons.Children.Add(_backButton);
 
         _hamburgerButton = new Button
         {
@@ -300,19 +310,19 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
             Height = 48,
             HorizontalContentAlignment = HorizontalAlignment.Center,
             VerticalContentAlignment = VerticalAlignment.Center,
-            Background = Brushes.Transparent,
-            [DockPanel.DockProperty] = Dock.Left
+            Background = Brushes.Transparent
         };
         _hamburgerButton.Click += OnHamburgerButtonClick;
-        _topBar.Children.Add(_hamburgerButton);
+        _topBarLeftButtons.Children.Add(_hamburgerButton);
 
         _titleViewControl = new ContentControl
         {
             IsVisible = false,
             VerticalAlignment = VerticalAlignment.Center,
-            HorizontalAlignment = HorizontalAlignment.Stretch
+            HorizontalAlignment = HorizontalAlignment.Center,
+            HorizontalContentAlignment = HorizontalAlignment.Center,
+            VerticalContentAlignment = VerticalAlignment.Center
         };
-        _topBar.Children.Add(_titleViewControl);
 
         _titleTextBlock = new TextBlock
         {
@@ -320,10 +330,37 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
             FontWeight = Media.FontWeight.SemiBold,
             VerticalAlignment = VerticalAlignment.Center,
             HorizontalAlignment = HorizontalAlignment.Center,
-            Margin = new Thickness(8, 0),
+            TextAlignment = Media.TextAlignment.Center,
+            Margin = new Thickness(0),
             ZIndex = 0
         };
-        _topBar.Children.Add(_titleTextBlock);
+
+        _searchHostControl = new ContentControl
+        {
+            [DockPanel.DockProperty] = Dock.Top,
+            IsVisible = false,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            VerticalContentAlignment = VerticalAlignment.Stretch,
+            ClipToBounds = false,
+            ZIndex = 2
+        };
+
+        var centerHost = new Panel
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            ClipToBounds = true
+        };
+        centerHost.Children.Add(_titleTextBlock);
+        centerHost.Children.Add(_titleViewControl);
+
+        // Placeholder right host keeps a stable 3-child layout for centered clamping.
+        var rightHost = new Panel();
+
+        _topBar.Children.Add(_topBarLeftButtons);
+        _topBar.Children.Add(centerHost);
+        _topBar.Children.Add(rightHost);
 
         _mainContentControl = new TransitioningContentControl
         {
@@ -336,6 +373,7 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
 
         _mainContainer.Children.Add(_topBar);
         _mainContainer.Children.Add(_topBarShadow);
+        _mainContainer.Children.Add(_searchHostControl);
         _mainContainer.Children.Add(_mainContentControl);
 
 
@@ -1131,6 +1169,75 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
             unselectedStateStyle.Setters.Add(new Styling.Setter { Property = Border.BackgroundProperty, Value = Brushes.Transparent });
             unselectedStateStyle.Setters.Add(new Styling.Setter { Property = Border.BorderBrushProperty, Value = Brushes.Transparent });
             panel.Styles.Add(unselectedStateStyle);
+        }
+    }
+
+    /// <summary>
+    /// Lays out three children (left, center, right), keeping center page-centered while
+    /// clamping it to avoid overlap with side content.
+    /// </summary>
+    private sealed class TopBarPanel : Panel
+    {
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            if (Children.Count < 3)
+            {
+                return base.MeasureOverride(availableSize);
+            }
+
+            var left = Children[0];
+            var center = Children[1];
+            var right = Children[2];
+
+            left.Measure(availableSize);
+            right.Measure(availableSize);
+
+            double remainingWidth = Math.Max(0, availableSize.Width - left.DesiredSize.Width - right.DesiredSize.Width);
+            center.Measure(new Size(remainingWidth, availableSize.Height));
+
+            double height = Math.Max(Math.Max(left.DesiredSize.Height, center.DesiredSize.Height), right.DesiredSize.Height);
+            double width = left.DesiredSize.Width + center.DesiredSize.Width + right.DesiredSize.Width;
+
+            return new Size(
+                double.IsInfinity(availableSize.Width) ? width : availableSize.Width,
+                height);
+        }
+
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            if (Children.Count < 3)
+            {
+                return base.ArrangeOverride(finalSize);
+            }
+
+            var left = Children[0];
+            var center = Children[1];
+            var right = Children[2];
+
+            double panelHeight = finalSize.Height;
+
+            double leftWidth = left.DesiredSize.Width;
+            double leftHeight = left.DesiredSize.Height;
+            double leftY = (panelHeight - leftHeight) / 2;
+            left.Arrange(new Rect(0, leftY, leftWidth, leftHeight));
+
+            double rightWidth = right.DesiredSize.Width;
+            double rightHeight = right.DesiredSize.Height;
+            double rightY = (panelHeight - rightHeight) / 2;
+            right.Arrange(new Rect(finalSize.Width - rightWidth, rightY, rightWidth, rightHeight));
+
+            double centerWidth = center.DesiredSize.Width;
+            double centerHeight = center.DesiredSize.Height;
+
+            double centeredX = (finalSize.Width - centerWidth) / 2;
+            double minX = leftWidth;
+            double maxX = finalSize.Width - rightWidth - centerWidth;
+            double centerX = Math.Max(minX, Math.Min(centeredX, maxX));
+            double centerY = (panelHeight - centerHeight) / 2;
+
+            center.Arrange(new Rect(centerX, centerY, centerWidth, centerHeight));
+
+            return finalSize;
         }
     }
 }

--- a/src/Avalonia.Controls.Maui/Platform/NavigationView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/NavigationView.cs
@@ -16,7 +16,7 @@ public class NavigationView : DockPanel
     private readonly TextBlock _titleTextBlock;
     private readonly Button _hamburgerButton;
     private readonly Button _backButton;
-    private readonly DockPanel _navigationBar;
+    private readonly NavigationBarPanel _navigationBar;
     private readonly Image _titleIconImage;
     private readonly StackPanel _titleStack;
     private readonly StackPanel _toolbarItemsContainer;
@@ -98,11 +98,10 @@ public class NavigationView : DockPanel
     {
         LastChildFill = true;
 
-        _navigationBar = new DockPanel
+        _navigationBar = new NavigationBarPanel
         {
             Height = 44,
-            Background = Brushes.Transparent, // Will be set by UpdateNavigationBarColors
-            LastChildFill = true
+            Background = Brushes.Transparent // Will be set by UpdateNavigationBarColors
         };
         DockPanel.SetDock(_navigationBar, Dock.Top);
 
@@ -119,8 +118,6 @@ public class NavigationView : DockPanel
             HorizontalContentAlignment = HorizontalAlignment.Center,
             VerticalContentAlignment = VerticalAlignment.Center
         };
-        DockPanel.SetDock(_hamburgerButton, Dock.Left);
-        _navigationBar.Children.Add(_hamburgerButton);
 
         _backButton = new Button
         {
@@ -135,8 +132,15 @@ public class NavigationView : DockPanel
             HorizontalContentAlignment = HorizontalAlignment.Center,
             VerticalContentAlignment = VerticalAlignment.Center
         };
-        DockPanel.SetDock(_backButton, Dock.Left);
-        _navigationBar.Children.Add(_backButton);
+
+        // Left buttons
+        var leftButtons = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        leftButtons.Children.Add(_hamburgerButton);
+        leftButtons.Children.Add(_backButton);
 
         _titleViewContainer = new ContentControl
         {
@@ -161,7 +165,8 @@ public class NavigationView : DockPanel
             FontWeight = Media.FontWeight.SemiBold,
             VerticalAlignment = VerticalAlignment.Center,
             HorizontalAlignment = HorizontalAlignment.Center,
-            TextAlignment = Media.TextAlignment.Center
+            TextAlignment = Media.TextAlignment.Center,
+            TextTrimming = Media.TextTrimming.CharacterEllipsis
         };
 
         // Stack for title icon and text
@@ -175,7 +180,11 @@ public class NavigationView : DockPanel
         _titleStack.Children.Add(_titleIconImage);
         _titleStack.Children.Add(_titleTextBlock);
 
-        var centerStack = new Panel();
+        var centerStack = new Panel
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            ClipToBounds = true
+        };
         centerStack.Children.Add(_titleStack);
         centerStack.Children.Add(_titleViewContainer);
 
@@ -186,11 +195,9 @@ public class NavigationView : DockPanel
             Spacing = 8,
             Margin = new Thickness(0, 0, 8, 0)
         };
-        DockPanel.SetDock(_toolbarItemsContainer, Dock.Right);
-        _navigationBar.Children.Add(_toolbarItemsContainer);
 
         _toolbarOverflowMenu = new ContextMenu();
-        
+
         _toolbarOverflowButton = new Button
         {
             Content = "...",
@@ -201,13 +208,16 @@ public class NavigationView : DockPanel
             BorderThickness = new Thickness(0),
             IsVisible = false // Hidden by default
         };
-        
+
         _toolbarOverflowButton.Click += (s, e) => _toolbarOverflowMenu.Open(_toolbarOverflowButton);
-        
+
         // Add overflow button to the container (at the end)
         _toolbarItemsContainer.Children.Add(_toolbarOverflowButton);
 
+        // Children order matters: left (0), center (1), right (2)
+        _navigationBar.Children.Add(leftButtons);
         _navigationBar.Children.Add(centerStack);
+        _navigationBar.Children.Add(_toolbarItemsContainer);
 
         _contentControl = new TransitioningContentControl
         {
@@ -267,6 +277,73 @@ public class NavigationView : DockPanel
         else
         {
             _contentControl.Content = page;
+        }
+    }
+
+    /// <summary>
+    /// Panel that lays out three children (left, center, right) where the center child is
+    /// page-centered but clamped so it never overlaps the left or right children.
+    /// </summary>
+    private sealed class NavigationBarPanel : Panel
+    {
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            if (Children.Count < 3)
+            {
+                return base.MeasureOverride(availableSize);
+            }
+
+            var left = Children[0];
+            var center = Children[1];
+            var right = Children[2];
+
+            // Measure left and right first to determine available space for center
+            left.Measure(availableSize);
+            right.Measure(availableSize);
+
+            double remainingWidth = Math.Max(0, availableSize.Width - left.DesiredSize.Width - right.DesiredSize.Width);
+            center.Measure(new Size(remainingWidth, availableSize.Height));
+
+            double height = Math.Max(Math.Max(left.DesiredSize.Height, center.DesiredSize.Height), right.DesiredSize.Height);
+            double width = left.DesiredSize.Width + center.DesiredSize.Width + right.DesiredSize.Width;
+
+            return new Size(
+                double.IsInfinity(availableSize.Width) ? width : availableSize.Width,
+                height);
+        }
+
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            if (Children.Count < 3)
+            {
+                return base.ArrangeOverride(finalSize);
+            }
+
+            var left = Children[0];
+            var center = Children[1];
+            var right = Children[2];
+
+            double leftWidth = left.DesiredSize.Width;
+            double rightWidth = right.DesiredSize.Width;
+            double centerWidth = center.DesiredSize.Width;
+
+            // Position left items at the left edge
+            left.Arrange(new Rect(0, 0, leftWidth, finalSize.Height));
+
+            // Position right items at the right edge
+            right.Arrange(new Rect(finalSize.Width - rightWidth, 0, rightWidth, finalSize.Height));
+
+            // Center title in the full width, but clamp to avoid overlapping left/right
+            double availableForCenter = Math.Max(0, finalSize.Width - leftWidth - rightWidth);
+            double actualCenterWidth = Math.Min(centerWidth, availableForCenter);
+            double idealX = (finalSize.Width - actualCenterWidth) / 2;
+            double minX = leftWidth;
+            double maxX = Math.Max(minX, finalSize.Width - rightWidth - actualCenterWidth);
+            double x = Math.Clamp(idealX, minX, maxX);
+
+            center.Arrange(new Rect(x, 0, actualCenterWidth, finalSize.Height));
+
+            return finalSize;
         }
     }
 }

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/ShellHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/ShellHandlerTests.cs
@@ -308,6 +308,96 @@ public partial class ShellHandlerTests : HandlerTestBase
         // Additional checks could involve inspecting the visual tree for ShellSearchControl
     }
 
+    [AvaloniaFact(DisplayName = "Shell SearchHandler Renders Full Width Below NavBar")]
+    public async Task ShellSearchHandlerRendersFullWidthBelowNavBar()
+    {
+        var shell = CreateBasicShell();
+        var searchHandler = new SearchHandler { Placeholder = "Search..." };
+
+        var page = shell.Items[0].Items[0].Items[0].Content as ContentPage;
+        Assert.NotNull(page);
+
+        Shell.SetSearchHandler(page, searchHandler);
+
+        var handler = await CreateHandlerAsync<MauiShellHandler>(shell);
+
+        Assert.NotNull(handler._mainContainer);
+        Assert.NotNull(handler._topBar);
+        Assert.NotNull(handler._searchHostControl);
+        Assert.NotNull(handler._searchControl);
+
+        await InvokeOnMainThreadAsync(() =>
+        {
+            const double width = 800;
+            const double height = 600;
+
+            handler._mainContainer!.Measure(new Avalonia.Size(width, height));
+            handler._mainContainer.Arrange(new Avalonia.Rect(0, 0, width, height));
+        });
+
+        Assert.True(handler._searchHostControl.IsVisible);
+        Assert.Same(handler._searchHostControl, handler._searchControl.Parent);
+        Assert.Same(handler._mainContainer, handler._searchHostControl.Parent);
+
+        // Search row should be below nav bar and use full page width.
+        Assert.True(handler._searchHostControl.Bounds.Y >= handler._topBar.Bounds.Bottom);
+        Assert.InRange(Math.Abs(handler._searchHostControl.Bounds.Width - handler._mainContainer.Bounds.Width), 0, 1.0);
+    }
+
+    [AvaloniaFact(DisplayName = "Shell SearchHandler Shows Suggestions While Typing")]
+    public async Task ShellSearchHandlerShowsSuggestionsWhileTyping()
+    {
+        var shell = CreateBasicShell();
+        var searchHandler = new SuggestionsSearchHandler();
+
+        var page = shell.Items[0].Items[0].Items[0].Content as ContentPage;
+        Assert.NotNull(page);
+
+        Shell.SetSearchHandler(page, searchHandler);
+
+        var handler = await CreateHandlerAsync<MauiShellHandler>(shell);
+
+        Assert.NotNull(handler._mainContainer);
+        Assert.NotNull(handler._mainContentControl);
+        Assert.NotNull(handler._searchHostControl);
+        Assert.NotNull(handler._searchControl);
+
+        await InvokeOnMainThreadAsync(() =>
+        {
+            const double width = 800;
+            const double height = 600;
+
+            handler._mainContainer!.Measure(new Avalonia.Size(width, height));
+            handler._mainContainer.Arrange(new Avalonia.Rect(0, 0, width, height));
+        });
+
+        var panel = handler._searchControl.Content as Panel;
+        Assert.NotNull(panel);
+
+        var searchBar = panel.Children.OfType<MauiSearchBar>().FirstOrDefault();
+
+        Assert.NotNull(searchBar);
+
+        await InvokeOnMainThreadAsync(() =>
+        {
+            searchBar!.Text = "na";
+        });
+
+        var overlayCanvas = panel.Children.OfType<Canvas>().FirstOrDefault();
+        var resultsOverlay = overlayCanvas?.Children.OfType<Border>().FirstOrDefault();
+        var resultsList = resultsOverlay?.Child as ListBox;
+
+        Assert.NotNull(resultsList);
+        Assert.NotNull(resultsOverlay);
+        Assert.Equal("na", searchHandler.Query);
+        Assert.True((resultsList.ItemsSource as System.Collections.IEnumerable)?.Cast<object>().Any() ?? false);
+        Assert.True(resultsOverlay.IsVisible);
+
+        // Suggestions must be able to render above page content.
+        Assert.False(handler._searchHostControl.ClipToBounds);
+        Assert.True(handler._searchHostControl.ZIndex > handler._mainContentControl.ZIndex);
+    }
+
     [AvaloniaFact(DisplayName = "Shell With ShellContent Creates Correctly")]
     public async Task ShellWithShellContentCreatesCorrectly()
     {
@@ -846,6 +936,44 @@ public partial class ShellHandlerTests : HandlerTestBase
         Assert.Equal("←", handler._backButton.Content);
     }
 
+    [AvaloniaFact(DisplayName = "Shell Title Remains Centered With Left Buttons Visible")]
+    public async Task ShellTitleRemainsCenteredWithLeftButtonsVisible()
+    {
+        var shell = CreateShellWithNavigationStack();
+
+        var handler = await CreateHandlerAsync<MauiShellHandler>(shell);
+
+        Assert.NotNull(handler._topBar);
+        Assert.NotNull(handler._titleTextBlock);
+        Assert.NotNull(handler._hamburgerButton);
+        Assert.NotNull(handler._backButton);
+
+        var deltaFromCenter = await InvokeOnMainThreadAsync(() =>
+        {
+            handler._hamburgerButton!.IsVisible = true;
+            handler._backButton!.IsVisible = true;
+
+            const double arrangedWidth = 800;
+            handler._topBar!.Measure(new Avalonia.Size(arrangedWidth, MauiShellHandler.DefaultBarHeight));
+            handler._topBar.Arrange(new Avalonia.Rect(0, 0, arrangedWidth, MauiShellHandler.DefaultBarHeight));
+
+            var titleBounds = handler._titleTextBlock!.Bounds;
+            var titleCenterXLocal = titleBounds.X + (titleBounds.Width / 2);
+            var titleCenterYLocal = titleBounds.Y + (titleBounds.Height / 2);
+
+            var titleCenterInTopBar = handler._titleTextBlock.TranslatePoint(
+                new Avalonia.Point(titleCenterXLocal, titleCenterYLocal),
+                handler._topBar);
+
+            Assert.NotNull(titleCenterInTopBar);
+            var expectedCenterX = arrangedWidth / 2;
+
+            return Math.Abs(titleCenterInTopBar.Value.X - expectedCenterX);
+        });
+
+        Assert.InRange(deltaFromCenter, 0, 1.0);
+    }
+
     [AvaloniaFact(DisplayName = "BackButtonBehavior Command Executes When Clicked")]
     public async Task BackButtonBehaviorCommandExecutesWhenClicked()
     {
@@ -1099,5 +1227,36 @@ public partial class ShellHandlerTests : HandlerTestBase
         shellSection.Navigation.PushAsync(page2);
 
         return shell;
+    }
+
+    private sealed class SuggestionsSearchHandler : SearchHandler
+    {
+        private static readonly string[] Suggestions =
+        {
+            "Navigation",
+            "Styling",
+            "Structure",
+            "Colors"
+        };
+
+        public SuggestionsSearchHandler()
+        {
+            ShowsResults = true;
+        }
+
+        protected override void OnQueryChanged(string oldValue, string newValue)
+        {
+            base.OnQueryChanged(oldValue, newValue);
+
+            if (string.IsNullOrWhiteSpace(newValue))
+            {
+                ItemsSource = null;
+                return;
+            }
+
+            ItemsSource = Suggestions
+                .Where(x => x.Contains(newValue, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
     }
 }


### PR DESCRIPTION
Replaces the DockPanel with a Panel for NavView and Shell, so the Title can be centered in the view. This also moves the Shell SearchBar down below the Nav bar, so you can both see the title of the page and search. This matches what macOS and WinUI do.