### PR TITLE
Add publish-nightly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,20 @@ jobs:
           path: ${{github.workspace}}/artifacts/**/*.nupkg
           retention-days: 1
 
+  publish-nightly:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+    - name: Download nupkg artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: nupkgs
+        path: ${{github.workspace}}/artifacts
+
+    - name: Push to nightly feed
+      run: dotnet nuget push "${{github.workspace}}/artifacts/**/*.nupkg" --source "${{ vars.NIGHTLY_FEED_UPLOAD_URL }}" --api-key "${{ secrets.NIGHTLY_FEED_API_KEY }}" --skip-duplicate
+
   test:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
That should be enough.
NIGHTLY_FEED_UPLOAD_URL and NIGHTLY_FEED_API_KEY are defined globally on the org.

For the release flow I recommend either doing it manually or adding a workflow trigger that pushes ready artifacts, which are then pushed again manually. Because we don't want to make public nuget api key used from the open source repositories. Alternative solution is moving nuget release pipeline to Azure DevOps (like core repo does).