### PR TITLE
Implemented Essentials Launcher and Browser

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -54,6 +54,11 @@
         <MicrosoftExtensionsVersion>11.0.0-preview.2.26159.112</MicrosoftExtensionsVersion>
     </PropertyGroup>
 
+    <ItemGroup Condition="'$(MSBuildProjectName)' == 'Avalonia.Controls.Maui.Desktop'">
+        <!-- Avalonia.FreeDesktop still declares the vulnerable version; force the patched one. -->
+        <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
+    </ItemGroup>
+
     <!--
         SkiaSharp, HarfBuzzSharp, and MicroCom versions must match what Avalonia uses.
         When AvaloniaSourcePath is set, read them directly from Avalonia's Directory.Packages.props

--- a/STATUS-ESSENTIALS.md
+++ b/STATUS-ESSENTIALS.md
@@ -96,15 +96,15 @@ Open a web browser to a specific URL.
 
 | Member | Type | Status |
 |--------|------|--------|
-| OpenAsync(Uri, BrowserLaunchOptions) | Method | ⏳ TODO |
+| OpenAsync(Uri, BrowserLaunchOptions) | Method | ✅ Implemented |
 
 ### Supporting Types
 
 | Type | Status |
 |------|--------|
-| BrowserLaunchMode | ⏳ TODO |
-| BrowserLaunchOptions | ⏳ TODO |
-| BrowserTitleMode | ⏳ TODO |
+| BrowserLaunchMode | ✅ Implemented |
+| BrowserLaunchOptions | ✅ Implemented |
+| BrowserTitleMode | ✅ Implemented |
 
 ---
 
@@ -393,16 +393,16 @@ Open another application by URI.
 
 | Member | Type | Status |
 |--------|------|--------|
-| CanOpenAsync(Uri) | Method | ⏳ TODO |
-| OpenAsync(Uri) | Method | ⏳ TODO |
-| OpenAsync(OpenFileRequest) | Method | ⏳ TODO |
-| TryOpenAsync(Uri) | Method | ⏳ TODO |
+| CanOpenAsync(Uri) | Method | ✅ Implemented |
+| OpenAsync(Uri) | Method | ✅ Implemented |
+| OpenAsync(OpenFileRequest) | Method | ✅ Implemented |
+| TryOpenAsync(Uri) | Method | ✅ Implemented |
 
 ### Supporting Types
 
 | Type | Status |
 |------|--------|
-| OpenFileRequest | ⏳ TODO |
+| OpenFileRequest | ✅ Implemented |
 
 ---
 

--- a/samples/ControlGallery/ControlGallery/MainPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/MainPage.xaml.cs
@@ -98,6 +98,8 @@ public partial class MainPage : FlyoutPage
         [typeof(VisualStateManagerPage)] = () => new VisualStateManagerPage(),
         [typeof(LifecycleEventsPage)] = () => new LifecycleEventsPage(),
         // Essentials
+        [typeof(BrowserPage)] = () => new BrowserPage(),
+        [typeof(LauncherPage)] = () => new LauncherPage(),
         [typeof(ScreenshotPage)] = () => new ScreenshotPage(),
         [typeof(PreferencesPage)] = () => new PreferencesPage(),
         [typeof(FilePickerPage)] = () => new FilePickerPage(),
@@ -276,7 +278,9 @@ public partial class MainPage : FlyoutPage
 
             new SampleGroup("Essentials", new List<SampleItem>
             {
+                new("Browser", "Open URLs in the system browser", typeof(BrowserPage)),
                 new("File Picker", "Pick files from the device", typeof(FilePickerPage)),
+                new("Launcher", "Open URIs with the default handler", typeof(LauncherPage)),
                 new("Preferences", "Key/value storage for app settings", typeof(PreferencesPage)),
                 new("Screenshot", "Capture window screenshots", typeof(ScreenshotPage)),
             }),

--- a/samples/ControlGallery/ControlGallery/Pages/BrowserPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/BrowserPage.xaml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="ControlGallery.Pages.BrowserPage"
+             Title="Browser">
+    <ScrollView>
+        <VerticalStackLayout Padding="20"
+                             Spacing="20">
+
+            <!-- Open URL -->
+            <Border Stroke="Gray"
+                    Padding="10">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10"/>
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Open URL in Browser"
+                           FontAttributes="Bold"/>
+                    <Entry x:Name="UrlEntry"
+                           Text="https://avaloniaui.net"
+                           Placeholder="Enter URL"/>
+                    <Button Text="Open"
+                            Clicked="OnOpenClicked"/>
+                    <Label x:Name="ResultLabel"
+                           Text=""
+                           FontAttributes="Italic"/>
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Quick Links -->
+            <Border Stroke="Gray"
+                    Padding="10">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10"/>
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Quick Links"
+                           FontAttributes="Bold"/>
+                    <Button Text="Avalonia UI"
+                            Clicked="OnAvaloniaClicked"/>
+                    <Button Text="GitHub"
+                            Clicked="OnGitHubClicked"/>
+                    <Button Text=".NET MAUI Docs"
+                            Clicked="OnMauiDocsClicked"/>
+                </VerticalStackLayout>
+            </Border>
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/samples/ControlGallery/ControlGallery/Pages/BrowserPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/BrowserPage.xaml.cs
@@ -13,7 +13,13 @@ public partial class BrowserPage : ContentPage
         if (string.IsNullOrWhiteSpace(url))
             return;
 
-        var result = await Browser.Default.OpenAsync(new Uri(url), BrowserLaunchMode.SystemPreferred);
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            ResultLabel.Text = "Invalid URL";
+            return;
+        }
+
+        var result = await Browser.Default.OpenAsync(uri, BrowserLaunchMode.SystemPreferred);
         ResultLabel.Text = result ? "Opened" : "Failed to open";
     }
 

--- a/samples/ControlGallery/ControlGallery/Pages/BrowserPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/BrowserPage.xaml.cs
@@ -1,0 +1,34 @@
+namespace ControlGallery.Pages;
+
+public partial class BrowserPage : ContentPage
+{
+    public BrowserPage()
+    {
+        InitializeComponent();
+    }
+
+    async void OnOpenClicked(object? sender, EventArgs e)
+    {
+        var url = UrlEntry.Text;
+        if (string.IsNullOrWhiteSpace(url))
+            return;
+
+        var result = await Browser.Default.OpenAsync(new Uri(url), BrowserLaunchMode.SystemPreferred);
+        ResultLabel.Text = result ? "Opened" : "Failed to open";
+    }
+
+    async void OnAvaloniaClicked(object? sender, EventArgs e)
+    {
+        await Browser.Default.OpenAsync(new Uri("https://avaloniaui.net"), BrowserLaunchMode.SystemPreferred);
+    }
+
+    async void OnGitHubClicked(object? sender, EventArgs e)
+    {
+        await Browser.Default.OpenAsync(new Uri("https://github.com/AvaloniaUI"), BrowserLaunchMode.SystemPreferred);
+    }
+
+    async void OnMauiDocsClicked(object? sender, EventArgs e)
+    {
+        await Browser.Default.OpenAsync(new Uri("https://learn.microsoft.com/dotnet/maui"), BrowserLaunchMode.SystemPreferred);
+    }
+}

--- a/samples/ControlGallery/ControlGallery/Pages/LauncherPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/LauncherPage.xaml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="ControlGallery.Pages.LauncherPage"
+             Title="Launcher">
+    <ScrollView>
+        <VerticalStackLayout Padding="20"
+                             Spacing="20">
+
+            <!-- Launch URI -->
+            <Border Stroke="Gray"
+                    Padding="10">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10"/>
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Launch URI"
+                           FontAttributes="Bold"/>
+                    <Entry x:Name="LauncherEntry"
+                           Text="https://github.com/AvaloniaUI"
+                           Placeholder="Enter URI"/>
+                    <HorizontalStackLayout Spacing="10">
+                        <Button Text="Can Open?"
+                                Clicked="OnCanOpenClicked"/>
+                        <Button Text="Open"
+                                Clicked="OnOpenClicked"/>
+                        <Button Text="Try Open"
+                                Clicked="OnTryOpenClicked"/>
+                    </HorizontalStackLayout>
+                    <Label x:Name="ResultLabel"
+                           Text=""
+                           FontAttributes="Italic"/>
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Quick Links -->
+            <Border Stroke="Gray"
+                    Padding="10">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10"/>
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Quick Links"
+                           FontAttributes="Bold"/>
+                    <Button Text="Open mailto:"
+                            Clicked="OnMailtoClicked"/>
+                    <Button Text="Open tel:"
+                            Clicked="OnTelClicked"/>
+                    <Label x:Name="QuickLinkResultLabel"
+                           Text=""
+                           FontAttributes="Italic"/>
+                </VerticalStackLayout>
+            </Border>
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/samples/ControlGallery/ControlGallery/Pages/LauncherPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/LauncherPage.xaml.cs
@@ -1,0 +1,51 @@
+namespace ControlGallery.Pages;
+
+public partial class LauncherPage : ContentPage
+{
+    public LauncherPage()
+    {
+        InitializeComponent();
+    }
+
+    async void OnCanOpenClicked(object? sender, EventArgs e)
+    {
+        var uri = LauncherEntry.Text;
+        if (string.IsNullOrWhiteSpace(uri))
+            return;
+
+        var canOpen = await Launcher.Default.CanOpenAsync(new Uri(uri));
+        ResultLabel.Text = $"CanOpen: {canOpen}";
+    }
+
+    async void OnOpenClicked(object? sender, EventArgs e)
+    {
+        var uri = LauncherEntry.Text;
+        if (string.IsNullOrWhiteSpace(uri))
+            return;
+
+        var result = await Launcher.Default.OpenAsync(new Uri(uri));
+        ResultLabel.Text = result ? "Opened" : "Failed to open";
+    }
+
+    async void OnTryOpenClicked(object? sender, EventArgs e)
+    {
+        var uri = LauncherEntry.Text;
+        if (string.IsNullOrWhiteSpace(uri))
+            return;
+
+        var result = await Launcher.Default.TryOpenAsync(new Uri(uri));
+        ResultLabel.Text = result ? "Opened" : "URI not supported or failed";
+    }
+
+    async void OnMailtoClicked(object? sender, EventArgs e)
+    {
+        var result = await Launcher.Default.TryOpenAsync(new Uri("mailto:test@example.com"));
+        QuickLinkResultLabel.Text = result ? "Mail client opened" : "Failed";
+    }
+
+    async void OnTelClicked(object? sender, EventArgs e)
+    {
+        var result = await Launcher.Default.TryOpenAsync(new Uri("tel:+1234567890"));
+        QuickLinkResultLabel.Text = result ? "Dialer opened" : "Failed";
+    }
+}

--- a/samples/ControlGallery/ControlGallery/Pages/LauncherPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/LauncherPage.xaml.cs
@@ -9,31 +9,28 @@ public partial class LauncherPage : ContentPage
 
     async void OnCanOpenClicked(object? sender, EventArgs e)
     {
-        var uri = LauncherEntry.Text;
-        if (string.IsNullOrWhiteSpace(uri))
+        if (!TryParseUri(LauncherEntry.Text, out var uri))
             return;
 
-        var canOpen = await Launcher.Default.CanOpenAsync(new Uri(uri));
+        var canOpen = await Launcher.Default.CanOpenAsync(uri);
         ResultLabel.Text = $"CanOpen: {canOpen}";
     }
 
     async void OnOpenClicked(object? sender, EventArgs e)
     {
-        var uri = LauncherEntry.Text;
-        if (string.IsNullOrWhiteSpace(uri))
+        if (!TryParseUri(LauncherEntry.Text, out var uri))
             return;
 
-        var result = await Launcher.Default.OpenAsync(new Uri(uri));
+        var result = await Launcher.Default.OpenAsync(uri);
         ResultLabel.Text = result ? "Opened" : "Failed to open";
     }
 
     async void OnTryOpenClicked(object? sender, EventArgs e)
     {
-        var uri = LauncherEntry.Text;
-        if (string.IsNullOrWhiteSpace(uri))
+        if (!TryParseUri(LauncherEntry.Text, out var uri))
             return;
 
-        var result = await Launcher.Default.TryOpenAsync(new Uri(uri));
+        var result = await Launcher.Default.TryOpenAsync(uri);
         ResultLabel.Text = result ? "Opened" : "URI not supported or failed";
     }
 
@@ -47,5 +44,20 @@ public partial class LauncherPage : ContentPage
     {
         var result = await Launcher.Default.TryOpenAsync(new Uri("tel:+1234567890"));
         QuickLinkResultLabel.Text = result ? "Dialer opened" : "Failed";
+    }
+
+    bool TryParseUri(string? text, out Uri uri)
+    {
+        uri = null!;
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        if (!Uri.TryCreate(text, UriKind.Absolute, out uri!))
+        {
+            ResultLabel.Text = "Invalid URI";
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Avalonia.Controls.Maui.Essentials/Browser/AvaloniaBrowser.Browser.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/Browser/AvaloniaBrowser.Browser.cs
@@ -7,7 +7,7 @@ public partial class AvaloniaBrowser
 {
     private partial Task<bool> PlatformOpenAsync(Uri uri)
     {
-        var window = LauncherInterop.WindowOpen(uri.AbsoluteUri, "_blank");
+        using var window = LauncherInterop.WindowOpen(uri.AbsoluteUri, "_blank");
         return Task.FromResult(window is not null);
     }
 }

--- a/src/Avalonia.Controls.Maui.Essentials/Browser/AvaloniaBrowser.Browser.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/Browser/AvaloniaBrowser.Browser.cs
@@ -1,0 +1,13 @@
+namespace Avalonia.Controls.Maui.Essentials;
+
+/// <summary>
+/// Browser/WASM implementation that opens URLs via <c>window.open()</c> JavaScript interop.
+/// </summary>
+public partial class AvaloniaBrowser
+{
+    private partial Task<bool> PlatformOpenAsync(Uri uri)
+    {
+        var window = LauncherInterop.WindowOpen(uri.AbsoluteUri, "_blank");
+        return Task.FromResult(window is not null);
+    }
+}

--- a/src/Avalonia.Controls.Maui.Essentials/Browser/AvaloniaBrowser.Default.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/Browser/AvaloniaBrowser.Default.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+
+namespace Avalonia.Controls.Maui.Essentials;
+
+/// <summary>
+/// Desktop implementation that opens URLs via the OS default browser.
+/// </summary>
+public partial class AvaloniaBrowser
+{
+    private partial Task<bool> PlatformOpenAsync(Uri uri)
+    {
+        var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = uri.AbsoluteUri,
+            UseShellExecute = true
+        });
+        return Task.FromResult(process is not null);
+    }
+}

--- a/src/Avalonia.Controls.Maui.Essentials/Browser/AvaloniaBrowser.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/Browser/AvaloniaBrowser.cs
@@ -10,6 +10,10 @@ public partial class AvaloniaBrowser : IBrowser
     /// <inheritdoc/>
     public async Task<bool> OpenAsync(Uri uri, BrowserLaunchOptions options)
     {
+        var scheme = uri.Scheme;
+        if (scheme != Uri.UriSchemeHttp && scheme != Uri.UriSchemeHttps)
+            return false;
+
         try
         {
             return await PlatformOpenAsync(uri);

--- a/src/Avalonia.Controls.Maui.Essentials/Browser/AvaloniaBrowser.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/Browser/AvaloniaBrowser.cs
@@ -1,0 +1,24 @@
+using Microsoft.Maui.ApplicationModel;
+
+namespace Avalonia.Controls.Maui.Essentials;
+
+/// <summary>
+/// Avalonia implementation of <see cref="IBrowser"/> that opens URLs in the system's default web browser.
+/// </summary>
+public partial class AvaloniaBrowser : IBrowser
+{
+    /// <inheritdoc/>
+    public async Task<bool> OpenAsync(Uri uri, BrowserLaunchOptions options)
+    {
+        try
+        {
+            return await PlatformOpenAsync(uri);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private partial Task<bool> PlatformOpenAsync(Uri uri);
+}

--- a/src/Avalonia.Controls.Maui.Essentials/Launcher/AvaloniaLauncher.Browser.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/Launcher/AvaloniaLauncher.Browser.cs
@@ -14,7 +14,7 @@ public partial class AvaloniaLauncher
 
     private partial Task<bool> PlatformOpenAsync(Uri uri)
     {
-        var window = LauncherInterop.WindowOpen(uri.AbsoluteUri, "_blank");
+        using var window = LauncherInterop.WindowOpen(uri.AbsoluteUri, "_blank");
         return Task.FromResult(window is not null);
     }
 }

--- a/src/Avalonia.Controls.Maui.Essentials/Launcher/AvaloniaLauncher.Browser.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/Launcher/AvaloniaLauncher.Browser.cs
@@ -1,0 +1,20 @@
+namespace Avalonia.Controls.Maui.Essentials;
+
+/// <summary>
+/// Browser implementation that opens URIs via <c>window.open()</c> JavaScript interop.
+/// </summary>
+public partial class AvaloniaLauncher
+{
+    private partial Task<bool> PlatformCanOpenAsync(Uri uri)
+    {
+        var scheme = uri.Scheme.ToLowerInvariant();
+        var supported = scheme is "http" or "https" or "mailto" or "tel";
+        return Task.FromResult(supported);
+    }
+
+    private partial Task<bool> PlatformOpenAsync(Uri uri)
+    {
+        var window = LauncherInterop.WindowOpen(uri.AbsoluteUri, "_blank");
+        return Task.FromResult(window is not null);
+    }
+}

--- a/src/Avalonia.Controls.Maui.Essentials/Launcher/AvaloniaLauncher.Default.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/Launcher/AvaloniaLauncher.Default.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics;
+
+namespace Avalonia.Controls.Maui.Essentials;
+
+/// <summary>
+/// Desktop implementation that opens URIs via the OS default handler.
+/// </summary>
+public partial class AvaloniaLauncher
+{
+    private partial Task<bool> PlatformCanOpenAsync(Uri uri)
+    {
+        var scheme = uri.Scheme.ToLowerInvariant();
+        var supported = scheme is "http" or "https" or "mailto" or "file" or "tel";
+        return Task.FromResult(supported);
+    }
+
+    private partial Task<bool> PlatformOpenAsync(Uri uri)
+    {
+        var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = uri.AbsoluteUri,
+            UseShellExecute = true
+        });
+        return Task.FromResult(process is not null);
+    }
+}

--- a/src/Avalonia.Controls.Maui.Essentials/Launcher/AvaloniaLauncher.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/Launcher/AvaloniaLauncher.cs
@@ -1,0 +1,64 @@
+using Microsoft.Maui.ApplicationModel;
+
+namespace Avalonia.Controls.Maui.Essentials;
+
+/// <summary>
+/// Avalonia implementation of <see cref="ILauncher"/> that opens URIs and files
+/// using the platform's default handler.
+/// </summary>
+public partial class AvaloniaLauncher : ILauncher
+{
+    /// <inheritdoc/>
+    public async Task<bool> CanOpenAsync(Uri uri)
+    {
+        try
+        {
+            return await PlatformCanOpenAsync(uri);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> OpenAsync(Uri uri)
+    {
+        try
+        {
+            return await PlatformOpenAsync(uri);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> OpenAsync(OpenFileRequest request)
+    {
+        if (request?.File?.FullPath is not { } path)
+            return Task.FromResult(false);
+
+        try
+        {
+            return PlatformOpenAsync(new Uri(path));
+        }
+        catch
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> TryOpenAsync(Uri uri)
+    {
+        if (!await CanOpenAsync(uri))
+            return false;
+
+        return await OpenAsync(uri);
+    }
+
+    private partial Task<bool> PlatformCanOpenAsync(Uri uri);
+    private partial Task<bool> PlatformOpenAsync(Uri uri);
+}

--- a/src/Avalonia.Controls.Maui.Essentials/Launcher/LauncherInterop.Browser.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/Launcher/LauncherInterop.Browser.cs
@@ -1,0 +1,18 @@
+using System.Runtime.InteropServices.JavaScript;
+
+namespace Avalonia.Controls.Maui.Essentials;
+
+/// <summary>
+/// Provides JavaScript interop bindings for opening URIs in the browser.
+/// </summary>
+internal static partial class LauncherInterop
+{
+    /// <summary>
+    /// Opens a URL in a new browser window/tab using <c>window.open()</c>.
+    /// Returns the window object, or <see langword="null"/> if blocked by a popup blocker.
+    /// </summary>
+    /// <param name="url">The URL to open.</param>
+    /// <param name="target">The target window name (e.g., "_blank").</param>
+    [JSImport("globalThis.window.open")]
+    internal static partial JSObject? WindowOpen(string url, string target);
+}

--- a/src/Avalonia.Controls.Maui.Essentials/MauiEssentialsBuilderExtensions.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/MauiEssentialsBuilderExtensions.cs
@@ -23,6 +23,8 @@ public static class MauiEssentialsBuilderExtensions
         Microsoft.Maui.Storage.Preferences.SetDefault(new Avalonia.Controls.Maui.Essentials.AvaloniaPreferences());
         FileSystem.SetCurrent(new Avalonia.Controls.Maui.Essentials.AvaloniaFileSystem());
         Microsoft.Maui.Authentication.WebAuthenticator.SetDefault(new Avalonia.Controls.Maui.Essentials.AvaloniaWebAuthenticator(platformProvider));
+        Microsoft.Maui.ApplicationModel.Launcher.SetDefault(new Avalonia.Controls.Maui.Essentials.AvaloniaLauncher());
+        Microsoft.Maui.ApplicationModel.Browser.SetDefault(new Avalonia.Controls.Maui.Essentials.AvaloniaBrowser());
 
         return builder;
     }

--- a/tests/Avalonia.Controls.Maui.Essentials.Tests/AvaloniaBrowserTests.cs
+++ b/tests/Avalonia.Controls.Maui.Essentials.Tests/AvaloniaBrowserTests.cs
@@ -1,0 +1,14 @@
+using Avalonia.Controls.Maui.Essentials;
+using Microsoft.Maui.ApplicationModel;
+
+namespace Avalonia.Controls.Maui.Tests.Services;
+
+public class AvaloniaBrowserTests
+{
+    [Fact]
+    public void Constructor_Does_Not_Throw()
+    {
+        var browser = new AvaloniaBrowser();
+        Assert.NotNull(browser);
+    }
+}

--- a/tests/Avalonia.Controls.Maui.Essentials.Tests/AvaloniaLauncherTests.cs
+++ b/tests/Avalonia.Controls.Maui.Essentials.Tests/AvaloniaLauncherTests.cs
@@ -1,0 +1,36 @@
+using Avalonia.Controls.Maui.Essentials;
+
+namespace Avalonia.Controls.Maui.Tests.Services;
+
+public class AvaloniaLauncherTests
+{
+    [Theory]
+    [InlineData("https://example.com", true)]
+    [InlineData("http://example.com", true)]
+    [InlineData("mailto:test@example.com", true)]
+    [InlineData("tel:+1234567890", true)]
+    [InlineData("file:///tmp/test.txt", true)]
+    [InlineData("custom://something", false)]
+    public async Task CanOpenAsync_Returns_Expected_For_Scheme(string url, bool expected)
+    {
+        var launcher = new AvaloniaLauncher();
+        var result = await launcher.CanOpenAsync(new Uri(url));
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public async Task TryOpenAsync_Returns_False_For_Unsupported_Scheme()
+    {
+        var launcher = new AvaloniaLauncher();
+        var result = await launcher.TryOpenAsync(new Uri("custom://unsupported"));
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task OpenAsync_FileRequest_Returns_False_For_Null_Request()
+    {
+        var launcher = new AvaloniaLauncher();
+        var result = await launcher.OpenAsync((Microsoft.Maui.ApplicationModel.OpenFileRequest)null!);
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
Changes:
- **Launcher** (`ILauncher`): Opens URIs via the OS default handler. Desktop uses `Process.Start` with UseShellExecute, browser uses `window.open()` via [JSImport]. Supports CanOpenAsync, OpenAsync, TryOpenAsync, and OpenAsync(OpenFileRequest).
- **Browser** (`IBrowser`): Opens URLs in the system browser. `Process.Start` result on desktop, `window.open()` return on WASM (also detects popup blockers).

<img width="3840" height="1858" alt="image" src="https://github.com/user-attachments/assets/2338dff1-895b-45c7-a800-d9479fca7435" />

<img width="3840" height="1858" alt="image" src="https://github.com/user-attachments/assets/0d0e812d-16d1-41be-8bd2-f18be70dde25" />
