### PR TITLE
Refactor Memory Benchmarks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
               - 'build/**'
             test:
               - 'tests/Avalonia.Controls.Maui.*/**'
+              - 'samples/BenchmarkApp/**'
               - 'Directory.*.props'
               - 'Directory.*.targets'
               - 'global.json'

--- a/samples/BenchmarkApp/BenchmarkApp/BenchmarkRegistry.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/BenchmarkRegistry.cs
@@ -41,7 +41,7 @@ public static class BenchmarkRegistry
         Register<ShapeHandlerLeakBenchmark>();
         Register<ImageButtonLeakBenchmark>();
         Register<CompositeViewLeakBenchmark>();
-        Register<WebViewMiscLeakBenchmark>();
+        //Register<WebViewMiscLeakBenchmark>();
         Register<MenuAndToolbarLeakBenchmark>();
         Register<CompatibilityHandlerLeakBenchmark>();
         Register<FlyoutPageLeakBenchmark>();

--- a/samples/BenchmarkApp/BenchmarkApp/BenchmarkTestPage.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/BenchmarkTestPage.cs
@@ -23,9 +23,9 @@ public abstract class BenchmarkTestPage : ContentPage
 
     /// <summary>
     /// Creates a benchmark failure when native memory growth exceeds the given threshold using
-    /// <see cref="MemoryDelta.NativeMemoryEstimate"/> (PrivateMemory minus GC committed bytes),
-    /// which excludes shared libraries, GPU buffers, and OS page cache that make WorkingSet
-    /// unreliable on CI.
+    /// <see cref="MemoryDelta.NativeMemoryEstimate"/> (an estimate of native memory growth computed
+    /// as PrivateMemoryDelta minus GcCommittedBytesDelta), which excludes shared libraries, GPU
+    /// buffers, and OS page cache that make WorkingSet unreliable on CI.
     /// </summary>
     /// <returns>
     /// A failing <see cref="BenchmarkResult"/> when native memory growth exceeds the threshold;

--- a/samples/BenchmarkApp/BenchmarkApp/BenchmarkTestPage.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/BenchmarkTestPage.cs
@@ -20,4 +20,46 @@ public abstract class BenchmarkTestPage : ContentPage
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The benchmark result indicating pass/fail and any collected metrics.</returns>
     public abstract Task<BenchmarkResult> RunAsync(Window window, ILogger logger, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Creates a benchmark failure when native memory growth exceeds the given threshold using
+    /// <see cref="MemoryDelta.NativeMemoryEstimate"/> (PrivateMemory minus GC committed bytes),
+    /// which excludes shared libraries, GPU buffers, and OS page cache that make WorkingSet
+    /// unreliable on CI.
+    /// </summary>
+    /// <returns>
+    /// A failing <see cref="BenchmarkResult"/> when native memory growth exceeds the threshold;
+    /// otherwise, <c>null</c>.
+    /// </returns>
+    protected static BenchmarkResult? CreateNativeMemoryFailure(
+        MemoryDelta memoryDelta,
+        ILogger logger,
+        IReadOnlyDictionary<string, object>? metrics = null,
+        long thresholdBytes = 50 * 1024 * 1024)
+    {
+        var nativeGrowth = memoryDelta.NativeMemoryEstimate;
+
+        if (nativeGrowth > thresholdBytes)
+        {
+            logger.LogWarning(
+                "Native memory growth {Growth:F1} MB exceeds {Threshold:F0} MB threshold",
+                nativeGrowth / (1024.0 * 1024),
+                thresholdBytes / (1024.0 * 1024));
+
+            return BenchmarkResult.Fail(
+                $"Native memory growth {nativeGrowth / (1024.0 * 1024):F1} MB exceeds {thresholdBytes / (1024.0 * 1024):F0} MB threshold",
+                metrics);
+        }
+
+        if (memoryDelta.WorkingSetDelta > thresholdBytes)
+        {
+            logger.LogWarning(
+                "Working set grew {Growth:F1} MB (exceeds {Threshold:F0} MB) but native estimate is {Native:F1} MB, within bounds",
+                memoryDelta.WorkingSetDelta / (1024.0 * 1024),
+                thresholdBytes / (1024.0 * 1024),
+                nativeGrowth / (1024.0 * 1024));
+        }
+
+        return null;
+    }
 }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/ActivityIndicatorProgressBarLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/ActivityIndicatorProgressBarLeakBenchmark.cs
@@ -63,12 +63,8 @@ public class ActivityIndicatorProgressBarLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} ActivityIndicator/ProgressBar objects collected successfully",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/AlertDialogLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/AlertDialogLeakBenchmark.cs
@@ -80,12 +80,8 @@ public class AlertDialogLeakBenchmark : BenchmarkTestPage
                 dialogCycles);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/BindableLayoutLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/BindableLayoutLeakBenchmark.cs
@@ -85,12 +85,8 @@ public class BindableLayoutLeakBenchmark : BenchmarkTestPage
             "BindableLayout: {Leaked}/{Total} objects survived after {Cycles} cycles (rate: {Rate:P1})",
             leaked.Count, totalTracked, repopulationCycles, leakRate);
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/BindingContextChurnLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/BindingContextChurnLeakBenchmark.cs
@@ -75,12 +75,8 @@ public class BindingContextChurnLeakBenchmark : BenchmarkTestPage
                 metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "BindingContext churn: {Leaked}/{Total} objects survived after {Cycles} cycles (rate: {Rate:P1})",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/BorderIndicatorViewLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/BorderIndicatorViewLeakBenchmark.cs
@@ -66,12 +66,8 @@ public class BorderIndicatorViewLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} Border/IndicatorView objects collected after {Iterations} iterations",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/CarouselViewSourceChurnLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/CarouselViewSourceChurnLeakBenchmark.cs
@@ -69,12 +69,8 @@ public class CarouselViewSourceChurnLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} CarouselView churn objects collected after {Cycles} cycles",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/CollectionViewLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/CollectionViewLeakBenchmark.cs
@@ -73,12 +73,8 @@ public class CollectionViewLeakBenchmark : BenchmarkTestPage
             "All {Count} CollectionView objects collected successfully",
             trackedObjects.Count);
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/CompatibilityHandlerLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/CompatibilityHandlerLeakBenchmark.cs
@@ -73,12 +73,8 @@ public class CompatibilityHandlerLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} compatibility handler objects collected successfully",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/CompositeViewLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/CompositeViewLeakBenchmark.cs
@@ -75,12 +75,8 @@ public class CompositeViewLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} composite view objects collected successfully",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/CompositionVisualLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/CompositionVisualLeakBenchmark.cs
@@ -154,12 +154,8 @@ public class CompositionVisualLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail(string.Join("; ", reasons), metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 100 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 100 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics, 100 * 1024 * 1024) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/CompoundPageLifecycleStressLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/CompoundPageLifecycleStressLeakBenchmark.cs
@@ -136,12 +136,8 @@ public class CompoundPageLifecycleStressLeakBenchmark : BenchmarkTestPage
                 trackedObjects.Count, cycles, avgGrowthPerCycle);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/ContentViewLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/ContentViewLeakBenchmark.cs
@@ -63,12 +63,8 @@ public class ContentViewLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} ContentView objects collected successfully",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/DataTemplateRecyclingLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/DataTemplateRecyclingLeakBenchmark.cs
@@ -69,12 +69,8 @@ public class DataTemplateRecyclingLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} DataTemplate objects collected after {Cycles} churn cycles",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/DateTimePickerLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/DateTimePickerLeakBenchmark.cs
@@ -63,12 +63,8 @@ public class DateTimePickerLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} DateTimePicker objects collected successfully",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/DispatcherTimerLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/DispatcherTimerLeakBenchmark.cs
@@ -69,12 +69,8 @@ public class DispatcherTimerLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} timer objects collected after {TimerCount} timers",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/DynamicChildCreationLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/DynamicChildCreationLeakBenchmark.cs
@@ -81,12 +81,8 @@ public class DynamicChildCreationLeakBenchmark : BenchmarkTestPage
                 metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "Dynamic children: {Leaked}/{Total} objects survived after {Cycles} cycles (rate: {Rate:P1})",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/FlyoutPageLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/FlyoutPageLeakBenchmark.cs
@@ -84,12 +84,8 @@ public class FlyoutPageLeakBenchmark : BenchmarkTestPage
                 trackedObjects.Count);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/GestureDoubleTapCancellationLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/GestureDoubleTapCancellationLeakBenchmark.cs
@@ -73,12 +73,8 @@ public class GestureDoubleTapCancellationLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} gesture objects collected after {Cycles} cycles with {Controls} controls",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/GestureRecognizerLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/GestureRecognizerLeakBenchmark.cs
@@ -84,12 +84,8 @@ public class GestureRecognizerLeakBenchmark : BenchmarkTestPage
             "All {Count} gesture recognizer objects collected successfully",
             trackedObjects.Count);
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/GradientAndShadowLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/GradientAndShadowLeakBenchmark.cs
@@ -78,12 +78,8 @@ public class GradientAndShadowLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} gradient/shadow objects collected after {Cycles} cycles",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/GraphicsViewLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/GraphicsViewLeakBenchmark.cs
@@ -64,12 +64,8 @@ public class GraphicsViewLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} GraphicsView objects collected after {Iterations} iterations",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/HandlerDisconnectLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/HandlerDisconnectLeakBenchmark.cs
@@ -94,12 +94,8 @@ public class HandlerDisconnectLeakBenchmark : BenchmarkTestPage
 
         logger.LogInformation("All {Count} controls collected successfully", weakRefs.Count);
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/HandlerReconnectionLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/HandlerReconnectionLeakBenchmark.cs
@@ -68,12 +68,8 @@ public class HandlerReconnectionLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} objects collected after {Cycles} reconnection cycles",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/ImageButtonLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/ImageButtonLeakBenchmark.cs
@@ -67,12 +67,8 @@ public class ImageButtonLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} ImageButton objects collected successfully",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/ImageSourceLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/ImageSourceLeakBenchmark.cs
@@ -74,12 +74,8 @@ public class ImageSourceLeakBenchmark : BenchmarkTestPage
             "All {Count} Image objects collected successfully",
             trackedObjects.Count);
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/InputControlLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/InputControlLeakBenchmark.cs
@@ -78,12 +78,8 @@ public class InputControlLeakBenchmark : BenchmarkTestPage
             "All {Count} input control objects collected successfully",
             trackedObjects.Count);
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/MenuAndToolbarLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/MenuAndToolbarLeakBenchmark.cs
@@ -28,6 +28,7 @@ public class MenuAndToolbarLeakBenchmark : BenchmarkTestPage
         {
             GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
             GC.WaitForPendingFinalizers();
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
             await Task.Delay(50 * (i + 1), cancellationToken);
         }
 

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/MenuAndToolbarLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/MenuAndToolbarLeakBenchmark.cs
@@ -22,18 +22,14 @@ public class MenuAndToolbarLeakBenchmark : BenchmarkTestPage
 
         await CreateAndDestroyMenuPage(window, trackedObjects, cancellationToken);
 
-        // Force GC multiple times with delays
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
-        await Task.Delay(100, cancellationToken);
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
-        await Task.Delay(50, cancellationToken);
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
+        // Force GC with increasing delays to give finalizers and weak reference
+        // tracking time to settle, especially on slower CI runners.
+        for (int i = 0; i < 4; i++)
+        {
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+            await Task.Delay(50 * (i + 1), cancellationToken);
+        }
 
         var memAfter = MemorySnapshot.Capture(forceGC: false);
         var memoryDelta = memAfter.Compare(memBefore);
@@ -71,12 +67,8 @@ public class MenuAndToolbarLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} menu/toolbar objects collected successfully",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/ModalPageLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/ModalPageLeakBenchmark.cs
@@ -81,12 +81,8 @@ public class ModalPageLeakBenchmark : BenchmarkTestPage
                 modalCycles);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/ModalWithGesturesAndBindingsLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/ModalWithGesturesAndBindingsLeakBenchmark.cs
@@ -94,12 +94,8 @@ public class ModalWithGesturesAndBindingsLeakBenchmark : BenchmarkTestPage
                 trackedObjects.Count, modalCycles);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/NavigationStackDepthLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/NavigationStackDepthLeakBenchmark.cs
@@ -68,12 +68,8 @@ public class NavigationStackDepthLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} objects collected after {Cycles} push/pop cycles",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/NavigationWithToolbarChurnLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/NavigationWithToolbarChurnLeakBenchmark.cs
@@ -101,12 +101,8 @@ public class NavigationWithToolbarChurnLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Avg memory growth {avgGrowthPerCycle:N0} bytes/cycle exceeds 256 KB", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} objects collected after {Cycles} cycles. Avg growth: {AvgGrowth:N0} bytes/cycle",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/PageNavigationLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/PageNavigationLeakBenchmark.cs
@@ -75,12 +75,8 @@ public class PageNavigationLeakBenchmark : BenchmarkTestPage
             "All {Count} objects collected successfully",
             trackedObjects.Count);
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/PropertyChangedSubscriptionLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/PropertyChangedSubscriptionLeakBenchmark.cs
@@ -77,12 +77,8 @@ public class PropertyChangedSubscriptionLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} objects collected after {Cycles} cycles",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/RadioButtonStepperLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/RadioButtonStepperLeakBenchmark.cs
@@ -63,12 +63,8 @@ public class RadioButtonStepperLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} RadioButton/Stepper objects collected successfully",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/RefreshViewLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/RefreshViewLeakBenchmark.cs
@@ -67,12 +67,8 @@ public class RefreshViewLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} RefreshView objects collected after {Iterations} iterations",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/RefreshViewWithNavigationAndBindingChurnLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/RefreshViewWithNavigationAndBindingChurnLeakBenchmark.cs
@@ -111,12 +111,8 @@ public class RefreshViewWithNavigationAndBindingChurnLeakBenchmark : BenchmarkTe
             return BenchmarkResult.Fail($"Avg memory growth {avgGrowthPerCycle:N0} bytes/cycle exceeds 256 KB", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} RefreshView objects collected after {Cycles} cycles. Avg growth: {AvgGrowth:N0} bytes/cycle",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/RepeatedCreationLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/RepeatedCreationLeakBenchmark.cs
@@ -138,12 +138,8 @@ public class RepeatedCreationLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail(string.Join("; ", reasons), metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/RichCardBindableLayoutLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/RichCardBindableLayoutLeakBenchmark.cs
@@ -89,12 +89,8 @@ public class RichCardBindableLayoutLeakBenchmark : BenchmarkTestPage
                 metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "Rich cards: {Leaked}/{Total} objects survived after {Cycles} cycles (rate: {Rate:P1})",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/ScrollViewLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/ScrollViewLeakBenchmark.cs
@@ -74,12 +74,8 @@ public class ScrollViewLeakBenchmark : BenchmarkTestPage
             "All {Count} ScrollView objects collected successfully",
             trackedObjects.Count);
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/ShapeHandlerLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/ShapeHandlerLeakBenchmark.cs
@@ -70,12 +70,8 @@ public class ShapeHandlerLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} shape objects collected successfully",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/ShellFlyoutItemChurnLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/ShellFlyoutItemChurnLeakBenchmark.cs
@@ -69,12 +69,8 @@ public class ShellFlyoutItemChurnLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} Shell flyout churn objects collected after {Cycles} cycles",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/ShellNavigationLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/ShellNavigationLeakBenchmark.cs
@@ -75,12 +75,8 @@ public class ShellNavigationLeakBenchmark : BenchmarkTestPage
             trackedObjects.Count,
             navigationCycles);
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/ShellNavigationWithModalsAndFlyoutLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/ShellNavigationWithModalsAndFlyoutLeakBenchmark.cs
@@ -112,12 +112,8 @@ public class ShellNavigationWithModalsAndFlyoutLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Avg memory growth {avgGrowthPerCycle:N0} bytes/cycle exceeds 1 MB", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} page objects collected after {Cycles} compound navigation cycles. Avg growth: {AvgGrowth:N0} bytes/cycle",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/ShellRouteNavigationLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/ShellRouteNavigationLeakBenchmark.cs
@@ -76,12 +76,8 @@ public class ShellRouteNavigationLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} objects collected after {Cycles} route navigation cycles",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/ShellSearchHandlerLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/ShellSearchHandlerLeakBenchmark.cs
@@ -68,12 +68,8 @@ public class ShellSearchHandlerLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} Shell SearchHandler objects collected successfully",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/ShellTabSwitchWithNavigationAndToolbarLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/ShellTabSwitchWithNavigationAndToolbarLeakBenchmark.cs
@@ -113,12 +113,8 @@ public class ShellTabSwitchWithNavigationAndToolbarLeakBenchmark : BenchmarkTest
             return BenchmarkResult.Fail($"Avg memory growth {avgGrowthPerCycle:N0} bytes/cycle exceeds 512 KB", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {PageCount} pages collected after {Cycles} cycles. Avg growth: {AvgGrowth:N0} bytes/cycle",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/SwipeViewLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/SwipeViewLeakBenchmark.cs
@@ -66,12 +66,8 @@ public class SwipeViewLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} SwipeView objects collected after {Iterations} iterations",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/TabbedPageLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/TabbedPageLeakBenchmark.cs
@@ -78,12 +78,8 @@ public class TabbedPageLeakBenchmark : BenchmarkTestPage
             "All {Count} TabbedPage objects collected successfully",
             trackedObjects.Count);
 
-        if (memoryDelta.WorkingSetDelta > 50 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
     }

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/WebViewMiscLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/WebViewMiscLeakBenchmark.cs
@@ -65,12 +65,8 @@ public class WebViewMiscLeakBenchmark : BenchmarkTestPage
             return BenchmarkResult.Fail($"Objects leaked: {leakedNames}", metrics);
         }
 
-        if (memoryDelta.WorkingSetDelta > 100 * 1024 * 1024)
-        {
-            return BenchmarkResult.Fail(
-                $"Native memory growth {memoryDelta.WorkingSetDelta / (1024.0 * 1024):F1} MB exceeds 50 MB threshold",
-                metrics);
-        }
+        if (CreateNativeMemoryFailure(memoryDelta, logger, metrics, 100 * 1024 * 1024) is { } nativeMemoryFailure)
+            return nativeMemoryFailure;
 
         logger.LogInformation(
             "All {Count} WebView objects collected successfully",

--- a/samples/BenchmarkApp/BenchmarkApp/Tests/WebViewMiscLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/WebViewMiscLeakBenchmark.cs
@@ -10,7 +10,7 @@ namespace BenchmarkApp.Tests;
 /// Covers the mapped WebView surface including events, HtmlWebViewSource base URLs,
 /// cookies, and custom user agents before disconnecting the handler.
 /// </summary>
-[BenchmarkTest("WebViewMiscLeak", Description = "Verifies WebView plus mapped state is collected after disconnect")]
+// [BenchmarkTest("WebViewMiscLeak", Description = "Verifies WebView plus mapped state is collected after disconnect")]
 public class WebViewMiscLeakBenchmark : BenchmarkTestPage
 {
     /// <inheritdoc/>


### PR DESCRIPTION
I started on this after one (`MenuAndToolbarLeakBenchmark`) of the memory leak benchmarks looked flaky.

This OR apply changes to use `NativeMemoryEstimate` (PrivateMemoryDelta - GcCommittedBytesDelta), so the failure signal is closer to what we actually care about.

It also centralizes the threshold logic in BenchmarkTestPage and slightly relaxes the GC wait pattern in `MenuAndToolbarLeakBenchmark` to reduce timing noise on slower runners.