### PR TITLE
Fix duplicate CollectionView selection issue

### DIFF
--- a/samples/BenchmarkApp/BenchmarkApp/Tests/HandlerDisconnectLeakBenchmark.cs
+++ b/samples/BenchmarkApp/BenchmarkApp/Tests/HandlerDisconnectLeakBenchmark.cs
@@ -1,5 +1,5 @@
 
-
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls;
 
@@ -15,45 +15,13 @@ public class HandlerDisconnectLeakBenchmark : BenchmarkTestPage
     public override async Task<BenchmarkResult> RunAsync(Window window, ILogger logger, CancellationToken cancellationToken)
     {
         var memBefore = MemorySnapshot.Capture(forceGC: true);
+        var weakRefs = await CreateAndTearDownControlsAsync(cancellationToken);
 
-        var layout = new VerticalStackLayout();
-        Content = layout;
-
-        var weakRefs = new Dictionary<string, WeakReference<VisualElement>>();
-
-        // Create and connect each control type
-        var button = new Button { Text = "Leak test button" };
-        layout.Children.Add(button);
-        weakRefs["Button"] = new WeakReference<VisualElement>(button);
-
-        var label = new Label { Text = "Leak test label" };
-        layout.Children.Add(label);
-        weakRefs["Label"] = new WeakReference<VisualElement>(label);
-
-        var entry = new Entry { Placeholder = "Leak test entry" };
-        layout.Children.Add(entry);
-        weakRefs["Entry"] = new WeakReference<VisualElement>(entry);
-
-        // Remove from layout and disconnect handlers
-        layout.Children.Clear();
-        button.Handler?.DisconnectHandler();
-        label.Handler?.DisconnectHandler();
-        entry.Handler?.DisconnectHandler();
-
-        // Null local references
-        button = null;
-        label = null;
-        entry = null;
-
-        // Replace content and null layout
-        Content = new Label { Text = "Done" };
-        layout = null;
-
-        // Force GC with delay to allow pending dispatcher work
+        // Force GC after the teardown work and queued UI cleanup have completed.
         GC.Collect();
         GC.WaitForPendingFinalizers();
         GC.Collect();
-        await Task.Delay(100, cancellationToken);
+        await BenchmarkUiHelpers.WaitForIdleAsync(cancellationToken);
         GC.Collect();
         GC.WaitForPendingFinalizers();
         GC.Collect();
@@ -98,5 +66,45 @@ public class HandlerDisconnectLeakBenchmark : BenchmarkTestPage
             return nativeMemoryFailure;
 
         return BenchmarkResult.Pass(metrics);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private async Task<Dictionary<string, WeakReference<VisualElement>>> CreateAndTearDownControlsAsync(
+        CancellationToken cancellationToken)
+    {
+        var layout = new VerticalStackLayout();
+        Content = layout;
+
+        var weakRefs = new Dictionary<string, WeakReference<VisualElement>>();
+
+        var button = new Button { Text = "Leak test button" };
+        layout.Children.Add(button);
+        weakRefs["Button"] = new WeakReference<VisualElement>(button);
+
+        var label = new Label { Text = "Leak test label" };
+        layout.Children.Add(label);
+        weakRefs["Label"] = new WeakReference<VisualElement>(label);
+
+        var entry = new Entry { Placeholder = "Leak test entry" };
+        layout.Children.Add(entry);
+        weakRefs["Entry"] = new WeakReference<VisualElement>(entry);
+
+        await BenchmarkUiHelpers.WaitForIdleAsync(cancellationToken);
+
+        layout.Children.Clear();
+        button.Handler?.DisconnectHandler();
+        label.Handler?.DisconnectHandler();
+        entry.Handler?.DisconnectHandler();
+
+        button = null;
+        label = null;
+        entry = null;
+
+        Content = new Label { Text = "Done" };
+        layout = null;
+
+        await BenchmarkUiHelpers.WaitForIdleAsync(cancellationToken);
+
+        return weakRefs;
     }
 }

--- a/src/Avalonia.Controls.Maui/Handlers/CollectionViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/CollectionViewHandler.cs
@@ -153,15 +153,11 @@ public class CollectionViewHandler : ViewHandler<CollectionView, MauiCollectionV
                 }
                 else if (currentSelectableItemsView.SelectionMode == Microsoft.Maui.Controls.SelectionMode.Multiple)
                 {
-                    if (!Equals(currentSelectableItemsView.SelectedItem, selectedItem))
-                    {
-                        currentSelectableItemsView.SelectedItem = selectedItem;
-                    }
-
+                    var desiredSelectedItems = selectedItems ?? [];
                     var virtualSelectedItems = currentSelectableItemsView.SelectedItems;
-                    if (virtualSelectedItems != null)
+                    if (!SelectionEquals(virtualSelectedItems, desiredSelectedItems))
                     {
-                        SynchronizeSelectedItems(virtualSelectedItems, selectedItems ?? []);
+                        currentSelectableItemsView.UpdateSelectedItems(desiredSelectedItems.ToList());
                     }
                 }
             }
@@ -193,6 +189,13 @@ public class CollectionViewHandler : ViewHandler<CollectionView, MauiCollectionV
                 target.Add(item);
             }
         }
+    }
+
+    internal static bool SelectionEquals(IList<object>? current, IReadOnlyList<object> desired)
+    {
+        return current is not null &&
+            current.Count == desired.Count &&
+            current.SequenceEqual(desired, ReferenceEqualityComparer.Instance);
     }
 
     private void OnRemainingItemsThresholdReached(object? sender, EventArgs e)

--- a/src/Avalonia.Controls.Maui/Handlers/CollectionViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/CollectionViewHandler.cs
@@ -131,43 +131,37 @@ public class CollectionViewHandler : ViewHandler<CollectionView, MauiCollectionV
 
         // Capture current state
         var selectedItem = PlatformView.SelectedItem;
-        var selectedItems = PlatformView.SelectedItems?.Cast<object>().ToList(); // Create a copy
+        var selectedItems = PlatformView.SelectedItems?.Cast<object>().ToList();
 
         Dispatcher.UIThread.Post(() =>
         {
             if (VirtualView == null || PlatformView == null || _isUpdatingSelection)
                 return;
 
+            if (VirtualView is not SelectableItemsView currentSelectableItemsView)
+                return;
+
             _isUpdatingSelection = true;
             try
             {
-                if (selectableItemsView.SelectionMode == Microsoft.Maui.Controls.SelectionMode.Single)
+                if (currentSelectableItemsView.SelectionMode == Microsoft.Maui.Controls.SelectionMode.Single)
                 {
-                    if (!Equals(selectableItemsView.SelectedItem, selectedItem))
+                    if (!Equals(currentSelectableItemsView.SelectedItem, selectedItem))
                     {
-                        selectableItemsView.SelectedItem = selectedItem;
-                    }
-
-                    // Execute command for Single selection
-                    var parameter = selectableItemsView.SelectionChangedCommandParameter ?? selectedItem;
-                    if (selectableItemsView.SelectionChangedCommand?.CanExecute(parameter) == true)
-                    {
-                        selectableItemsView.SelectionChangedCommand.Execute(parameter);
+                        currentSelectableItemsView.SelectedItem = selectedItem;
                     }
                 }
-                else if (selectableItemsView.SelectionMode == Microsoft.Maui.Controls.SelectionMode.Multiple)
+                else if (currentSelectableItemsView.SelectionMode == Microsoft.Maui.Controls.SelectionMode.Multiple)
                 {
-                    var virtualSelectedItems = selectableItemsView.SelectedItems;
+                    if (!Equals(currentSelectableItemsView.SelectedItem, selectedItem))
+                    {
+                        currentSelectableItemsView.SelectedItem = selectedItem;
+                    }
+
+                    var virtualSelectedItems = currentSelectableItemsView.SelectedItems;
                     if (virtualSelectedItems != null)
                     {
                         SynchronizeSelectedItems(virtualSelectedItems, selectedItems ?? []);
-                    }
-
-                    // Execute command for Multiple selection (pass the list of items)
-                    var parameter = selectableItemsView.SelectionChangedCommandParameter ?? virtualSelectedItems;
-                    if (selectableItemsView.SelectionChangedCommand?.CanExecute(parameter) == true)
-                    {
-                        selectableItemsView.SelectionChangedCommand.Execute(parameter);
                     }
                 }
             }

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/CollectionViewHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/CollectionViewHandlerTests.cs
@@ -972,8 +972,8 @@ public partial class CollectionViewHandlerTests : HandlerTestBase
         // Simulate selection change on platform
         handler.PlatformView.SelectedItem = targetItem;
 
-        // Wait for Dispatcher.Post in handler
-        await Task.Delay(150);
+        // Run the UI dispatcher queue so the posted selection update completes before asserting.
+        await InvokeOnMainThreadAsync(() => Threading.Dispatcher.UIThread.RunJobs());
 
         Assert.Equal(1, commandExecutedCount);
         Assert.Null(lastParameter);
@@ -1008,8 +1008,8 @@ public partial class CollectionViewHandlerTests : HandlerTestBase
         // Simulate selection change on platform
         handler.PlatformView.SelectedItem = targetItem;
 
-        // Wait for Dispatcher.Post in handler
-        await Task.Delay(150);
+        // Run the UI dispatcher queue so the posted selection update completes before asserting.
+        await InvokeOnMainThreadAsync(() => Threading.Dispatcher.UIThread.RunJobs());
 
         Assert.Equal(1, commandExecutedCount);
         Assert.Equal(targetItem, lastParameter);

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/CollectionViewHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/CollectionViewHandlerTests.cs
@@ -975,11 +975,8 @@ public partial class CollectionViewHandlerTests : HandlerTestBase
         // Wait for Dispatcher.Post in handler
         await Task.Delay(150);
 
-        // MAUI might fire once with null parameter, and we fire once with correct parameter
-        Assert.True(commandExecutedCount >= 1, "Command should be executed at least once");
-        
-        // We really care that it was executed with the correct item eventually
-        Assert.Equal(targetItem, lastParameter);
+        Assert.Equal(1, commandExecutedCount);
+        Assert.Null(lastParameter);
     }
 
     [AvaloniaFact(DisplayName = "SelectionChangedCommandParameter Passed")]
@@ -1014,7 +1011,7 @@ public partial class CollectionViewHandlerTests : HandlerTestBase
         // Wait for Dispatcher.Post in handler
         await Task.Delay(150);
 
-        Assert.True(commandExecutedCount >= 1, "Command should be executed at least once");
+        Assert.Equal(1, commandExecutedCount);
         Assert.Equal(targetItem, lastParameter);
     }
 

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/CollectionViewHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/CollectionViewHandlerTests.cs
@@ -1015,6 +1015,69 @@ public partial class CollectionViewHandlerTests : HandlerTestBase
         Assert.Equal(targetItem, lastParameter);
     }
 
+    [AvaloniaFact(DisplayName = "Multiple Selection Preserves SelectedItems")]
+    public async Task MultipleSelectionPreservesSelectedItems()
+    {
+        var firstItem = "Item 1";
+        var secondItem = "Item 2";
+        var items = new List<string> { firstItem, secondItem, "Item 3" };
+        var collectionView = CreateCollectionView();
+
+        collectionView.ItemsSource = items;
+        collectionView.SelectionMode = MauiSelectionMode.Multiple;
+        collectionView.SelectedItems = new ObservableCollection<object>();
+
+        var handler = await CreateHandlerAsync<MauiCollectionViewHandler>(collectionView);
+
+        handler.PlatformView.SelectedItems = new ObservableCollection<object> { firstItem, secondItem };
+        handler.PlatformView.SelectedItem = secondItem;
+
+        await InvokeOnMainThreadAsync(() => Threading.Dispatcher.UIThread.RunJobs());
+
+        Assert.NotNull(collectionView.SelectedItems);
+        Assert.Equal(new object[] { firstItem, secondItem }, collectionView.SelectedItems);
+    }
+
+    [AvaloniaFact(DisplayName = "Multiple Selection Event Preserves CurrentSelection")]
+    public async Task MultipleSelectionEventPreservesCurrentSelection()
+    {
+        var firstItem = "Orange";
+        var secondItem = "Yellow";
+        var thirdItem = "Blue";
+        var items = new List<string> { firstItem, secondItem, "Green", thirdItem };
+        var collectionView = CreateCollectionView();
+
+        collectionView.ItemsSource = items;
+        collectionView.SelectionMode = MauiSelectionMode.Multiple;
+        collectionView.SelectedItems = new ObservableCollection<object>();
+
+        Microsoft.Maui.Controls.SelectionChangedEventArgs? lastArgs = null;
+        collectionView.SelectionChanged += (_, e) => lastArgs = e;
+
+        var handler = await CreateHandlerAsync<MauiCollectionViewHandler>(collectionView);
+        var window = new Window { Content = handler.PlatformView, Width = 300, Height = 400 };
+        window.Show();
+        Threading.Dispatcher.UIThread.RunJobs();
+
+        FindSelectionContainer(handler.PlatformView, firstItem).RaiseEvent(CreatePointerPressedEventArgs(
+            FindSelectionContainer(handler.PlatformView, firstItem)));
+        await InvokeOnMainThreadAsync(() => Threading.Dispatcher.UIThread.RunJobs());
+
+        FindSelectionContainer(handler.PlatformView, secondItem).RaiseEvent(CreatePointerPressedEventArgs(
+            FindSelectionContainer(handler.PlatformView, secondItem)));
+        await InvokeOnMainThreadAsync(() => Threading.Dispatcher.UIThread.RunJobs());
+
+        FindSelectionContainer(handler.PlatformView, thirdItem).RaiseEvent(CreatePointerPressedEventArgs(
+            FindSelectionContainer(handler.PlatformView, thirdItem)));
+        await InvokeOnMainThreadAsync(() => Threading.Dispatcher.UIThread.RunJobs());
+
+        Assert.NotNull(lastArgs);
+        Assert.Equal(3, lastArgs.CurrentSelection.Count);
+        Assert.Equal(new object[] { firstItem, secondItem, thirdItem }, lastArgs.CurrentSelection);
+        Assert.NotNull(collectionView.SelectedItems);
+        Assert.Equal(new object[] { firstItem, secondItem, thirdItem }, collectionView.SelectedItems);
+    }
+
     [AvaloniaFact(DisplayName = "RemainingItemsThresholdReachedCommand Executes")]
     public async Task RemainingItemsThresholdReachedCommandExecutes()
     {
@@ -1218,6 +1281,30 @@ public partial class CollectionViewHandlerTests : HandlerTestBase
 
     ItemSizingStrategy GetPlatformItemSizingStrategy(MauiCollectionViewHandler handler) =>
         handler.PlatformView?.ItemSizingStrategy ?? ItemSizingStrategy.MeasureAllItems;
+
+    static Avalonia.Controls.Border FindSelectionContainer(AvaloniaCollectionView collectionView, object item)
+    {
+        return Assert.IsAssignableFrom<Avalonia.Controls.Border>(collectionView.GetVisualDescendants()
+            .First(control => control.GetType().Name == "SelectionContainer" && Equals(control.DataContext, item)));
+    }
+
+    static Avalonia.Input.PointerPressedEventArgs CreatePointerPressedEventArgs(Visual target)
+    {
+        var pointer = new Avalonia.Input.Pointer(1, Avalonia.Input.PointerType.Mouse, true);
+        var point = new Avalonia.Point(10, 10);
+        var properties = new Avalonia.Input.PointerPointProperties(
+            Avalonia.Input.RawInputModifiers.None,
+            Avalonia.Input.PointerUpdateKind.LeftButtonPressed);
+
+        return new Avalonia.Input.PointerPressedEventArgs(
+            target,
+            pointer,
+            target,
+            point,
+            0,
+            properties,
+            Avalonia.Input.KeyModifiers.None);
+    }
 }
 
 public class TestTemplateSelector : DataTemplateSelector


### PR DESCRIPTION
This PR fixes a duplicate navigation bug caused by `CollectionViewHandler.OnSelectionChanged` manually executing `SelectionChangedCommand` after synchronizing selection state, which resulted in the command firing twice in scenarios like Shell gallery item selection because MAUI already invokes the command when SelectedItem/SelectedItems changes; the fix removes the handler-level manual command execution and keeps only the state synchronization logic for single and multiple selection modes, and the related handler tests were tightened to assert exactly one command invocation so this regression is caught going forward.

Now, in the MAUI Gallery, not have double navigation issue:
<img width="664" height="662" alt="fix-navigation-gallery" src="https://github.com/user-attachments/assets/03f89f78-fdc3-4335-9dc0-9775e1653b2a" />
