### PR TITLE
Implement Page.Padding support

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -26,7 +26,7 @@ A container control that draws a border, background, or both, around another con
 | Property | Status |
 |----------|--------|
 | Content | ✅ Implemented |
- | Padding | ✅ Implemented |
+| Padding | ✅ Implemented |
 | StrokeShape | ✅ Implemented |
 | Stroke | ✅ Implemented |
 | StrokeThickness | ✅ Implemented |

--- a/STATUS.md
+++ b/STATUS.md
@@ -26,7 +26,7 @@ A container control that draws a border, background, or both, around another con
 | Property | Status |
 |----------|--------|
 | Content | ✅ Implemented |
-| Padding | ✅ Implemented |
+ | Padding | ✅ Implemented |
 | StrokeShape | ✅ Implemented |
 | Stroke | ✅ Implemented |
 | StrokeThickness | ✅ Implemented |
@@ -656,8 +656,8 @@ A Page that manages the navigation and user-experience of a stack of other pages
  | BackgroundImageSource | ✅ Implemented |
  | Content | ✅ Implemented |
  | IsBusy | ✅ Implemented |
- | Padding | ⏳ TODO |
- | Title | ⏳ TODO |
+ | Padding | ✅ Implemented |
+ | Title | ✅ Implemented |
  | IconImageSource | ✅ Implemented |
  | ToolbarItems | ✅ Implemented |
  

--- a/samples/ControlGallery/ControlGallery/MainPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/MainPage.xaml.cs
@@ -24,6 +24,7 @@ public partial class MainPage : FlyoutPage
         // Services
         [typeof(FontsPage)] = () => new FontsPage(),
         // Pages
+        [typeof(PageBasePage)] = () => new PageBasePage(),
         [typeof(NavigationDemoPage)] = () => new NavigationDemoPage(),
         [typeof(ControlGallery.Pages.TabbedPage)] = () => new ControlGallery.Pages.TabbedPage(),
         [typeof(TitleBarPage)] = () => new TitleBarPage(),
@@ -178,6 +179,7 @@ public partial class MainPage : FlyoutPage
 
             new SampleGroup("Pages", new List<SampleItem>
             {
+                new("Page", "Base page background and padding", typeof(PageBasePage)),
                 new("NavigationPage", "Navigation stack with animated transitions", typeof(NavigationDemoPage)),
                 new("TabbedPage", "Tabbed navigation", typeof(ControlGallery.Pages.TabbedPage)),
                 new("TitleBar", "Custom window title bar", typeof(TitleBarPage)),

--- a/samples/ControlGallery/ControlGallery/Pages/PageBasePage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/PageBasePage.xaml
@@ -2,13 +2,72 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="ControlGallery.Pages.PageBasePage"
-             Title="Page Base">
+             Title="Page">
     <ContentPage.BackgroundImageSource>
         <FileImageSource File="dotnet_bot.png" />
     </ContentPage.BackgroundImageSource>
     <ScrollView>
         <VerticalStackLayout Spacing="20" Padding="20">
-            
+            <!-- Padding Section -->
+            <Border Stroke="Gray"
+                    Padding="10"
+                    BackgroundColor="#80000000">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10"/>
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Padding"
+                           FontAttributes="Bold"
+                           TextColor="White"/>
+                    <Label x:Name="PaddingLabel"
+                           Text="Page padding: 0, 0, 0, 0"
+                           TextColor="White"/>
+                    <Grid ColumnDefinitions="60,*"
+                          RowDefinitions="Auto,Auto,Auto,Auto"
+                          ColumnSpacing="12"
+                          RowSpacing="8">
+                        <Label Text="Left"
+                               TextColor="White"
+                               VerticalOptions="Center"/>
+                        <Slider x:Name="LeftPaddingSlider"
+                                Grid.Column="1"
+                                Maximum="80"
+                                ValueChanged="OnPaddingSliderValueChanged"/>
+
+                        <Label Grid.Row="1"
+                               Text="Top"
+                               TextColor="White"
+                               VerticalOptions="Center"/>
+                        <Slider x:Name="TopPaddingSlider"
+                                Grid.Row="1"
+                                Grid.Column="1"
+                                Maximum="80"
+                                ValueChanged="OnPaddingSliderValueChanged"/>
+
+                        <Label Grid.Row="2"
+                               Text="Right"
+                               TextColor="White"
+                               VerticalOptions="Center"/>
+                        <Slider x:Name="RightPaddingSlider"
+                                Grid.Row="2"
+                                Grid.Column="1"
+                                Maximum="80"
+                                ValueChanged="OnPaddingSliderValueChanged"/>
+
+                        <Label Grid.Row="3"
+                               Text="Bottom"
+                               TextColor="White"
+                               VerticalOptions="Center"/>
+                        <Slider x:Name="BottomPaddingSlider"
+                                Grid.Row="3"
+                                Grid.Column="1"
+                                Maximum="80"
+                                ValueChanged="OnPaddingSliderValueChanged"/>
+                    </Grid>
+                    <Button Text="Reset Padding"
+                            Clicked="OnResetPadding"/>
+                </VerticalStackLayout>
+            </Border>
 
             <!-- Status Section -->
             <Border Stroke="Gray"

--- a/samples/ControlGallery/ControlGallery/Pages/PageBasePage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/PageBasePage.xaml.cs
@@ -5,6 +5,31 @@ public partial class PageBasePage : ContentPage
     public PageBasePage()
     {
         InitializeComponent();
+        UpdatePaddingLabel();
+    }
+
+    private void OnPaddingSliderValueChanged(object? sender, ValueChangedEventArgs e)
+    {
+        Padding = new Thickness(
+            Math.Round(LeftPaddingSlider.Value),
+            Math.Round(TopPaddingSlider.Value),
+            Math.Round(RightPaddingSlider.Value),
+            Math.Round(BottomPaddingSlider.Value));
+
+        UpdatePaddingLabel();
+    }
+
+    private void OnResetPadding(object? sender, EventArgs e)
+    {
+        LeftPaddingSlider.Value = 0;
+        TopPaddingSlider.Value = 0;
+        RightPaddingSlider.Value = 0;
+        BottomPaddingSlider.Value = 0;
+    }
+
+    private void UpdatePaddingLabel()
+    {
+        PaddingLabel.Text = $"Page padding: {Padding.Left:0}, {Padding.Top:0}, {Padding.Right:0}, {Padding.Bottom:0}";
     }
 
     private void OnChangeBackground(object? sender, EventArgs e)

--- a/src/Avalonia.Controls.Maui/Handlers/PageHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/PageHandler.cs
@@ -30,6 +30,7 @@ public partial class PageHandler : ViewHandler<MauiPage, AvaloniaContentPage>
         {
             [nameof(MauiPage.Background)] = MapBackground,
             [nameof(MauiPage.BackgroundImageSource)] = MapBackgroundImageSource,
+            [nameof(MauiPage.Padding)] = MapPadding,
             [nameof(MauiPage.Title)] = MapTitle,
 
             [nameof(ContentPage.Content)] = MapContent,
@@ -162,6 +163,20 @@ public partial class PageHandler : ViewHandler<MauiPage, AvaloniaContentPage>
         {
             ((AvaloniaPanel)contentView).UpdateBackgroundImageSource(page, handler.MauiContext);
         }
+    }
+
+    /// <summary>
+    /// Maps the <see cref="MauiPage.Padding"/> property to the platform view.
+    /// </summary>
+    /// <param name="handler">The associated handler.</param>
+    /// <param name="page">The associated <see cref="MauiPage"/> instance.</param>
+    public static void MapPadding(PageHandler handler, MauiPage page)
+    {
+        // Page padding is consumed by MAUI's cross-platform IContentView layout
+        // when arranging presented content. Invalidate the Avalonia wrapper so
+        // the next layout pass uses the updated MAUI padding without applying a
+        // second platform-side padding.
+        handler.InnerContentView?.InvalidateMeasure();
     }
 
     /// <summary>

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/PageHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/PageHandlerTests.cs
@@ -2,7 +2,11 @@ using Avalonia.Controls.Maui.Handlers;
 using Avalonia.Controls.Maui.Tests.Stubs;
 using Avalonia.Headless.XUnit;
 using Avalonia.Media;
+using Microsoft.Maui;
 using Microsoft.Maui.Graphics;
+using MauiContentPage = Microsoft.Maui.Controls.ContentPage;
+using MauiLabel = Microsoft.Maui.Controls.Label;
+using MauiThickness = Microsoft.Maui.Thickness;
 
 namespace Avalonia.Controls.Maui.Tests.Handlers;
 
@@ -163,6 +167,75 @@ public class PageHandlerTests : HandlerTestBase<PageHandler, PageStub>
             var brush = handler.InnerContentView!.Background as SolidColorBrush;
             Assert.NotNull(brush);
             Assert.Equal(Media.Colors.Green, brush.Color);
+        });
+    }
+
+    [AvaloniaFact(DisplayName = "MapPadding Arranges Content Inside Page Padding")]
+    public async Task MapPadding_Arranges_Content_Inside_Page_Padding()
+    {
+        var content = new MauiLabel { Text = "Padded content" };
+        var page = new MauiContentPage
+        {
+            Padding = new MauiThickness(12, 8, 4, 2),
+            Content = content,
+            WidthRequest = 200,
+            HeightRequest = 100
+        };
+
+        var handler = await CreateHandlerAsync<PageHandler>(page);
+
+        await InvokeOnMainThreadAsync(() =>
+        {
+            handler.UpdateValue(nameof(MauiContentPage.Content));
+            handler.UpdateValue(nameof(MauiContentPage.Padding));
+
+            handler.InnerContentView!.Measure(new Avalonia.Size(200, 100));
+            handler.InnerContentView.Arrange(new Avalonia.Rect(0, 0, 200, 100));
+
+            Assert.Equal(12, content.Frame.X);
+            Assert.Equal(8, content.Frame.Y);
+            Assert.Equal(184, content.Frame.Width);
+            Assert.Equal(90, content.Frame.Height);
+        });
+    }
+
+    [AvaloniaFact(DisplayName = "MapPadding Uses Updated Page Padding On Next Arrange")]
+    public async Task MapPadding_Uses_Updated_Page_Padding_On_Next_Arrange()
+    {
+        var content = new MauiLabel { Text = "Updated padded content" };
+        var page = new MauiContentPage
+        {
+            Content = content,
+            WidthRequest = 200,
+            HeightRequest = 100
+        };
+
+        var handler = await CreateHandlerAsync<PageHandler>(page);
+
+        await InvokeOnMainThreadAsync(() =>
+        {
+            handler.UpdateValue(nameof(MauiContentPage.Content));
+            handler.InnerContentView!.Measure(new Avalonia.Size(200, 100));
+            handler.InnerContentView.Arrange(new Avalonia.Rect(0, 0, 200, 100));
+
+            Assert.Equal(0, content.Frame.X);
+            Assert.Equal(0, content.Frame.Y);
+            Assert.Equal(200, content.Frame.Width);
+            Assert.Equal(100, content.Frame.Height);
+        });
+
+        await InvokeOnMainThreadAsync(() =>
+        {
+            page.Padding = new MauiThickness(10, 20, 30, 40);
+            handler.UpdateValue(nameof(MauiContentPage.Padding));
+
+            handler.InnerContentView!.Measure(new Avalonia.Size(200, 100));
+            handler.InnerContentView.Arrange(new Avalonia.Rect(0, 0, 200, 100));
+
+            Assert.Equal(10, content.Frame.X);
+            Assert.Equal(20, content.Frame.Y);
+            Assert.Equal(160, content.Frame.Width);
+            Assert.Equal(40, content.Frame.Height);
         });
     }
 }

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/PageHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/PageHandlerTests.cs
@@ -2,7 +2,6 @@ using Avalonia.Controls.Maui.Handlers;
 using Avalonia.Controls.Maui.Tests.Stubs;
 using Avalonia.Headless.XUnit;
 using Avalonia.Media;
-using Microsoft.Maui;
 using Microsoft.Maui.Graphics;
 using MauiContentPage = Microsoft.Maui.Controls.ContentPage;
 using MauiLabel = Microsoft.Maui.Controls.Label;
@@ -192,10 +191,10 @@ public class PageHandlerTests : HandlerTestBase<PageHandler, PageStub>
             handler.InnerContentView!.Measure(new Avalonia.Size(200, 100));
             handler.InnerContentView.Arrange(new Avalonia.Rect(0, 0, 200, 100));
 
-            Assert.Equal(12, content.Frame.X);
-            Assert.Equal(8, content.Frame.Y);
-            Assert.Equal(184, content.Frame.Width);
-            Assert.Equal(90, content.Frame.Height);
+            Assert.Equal(12, content.Frame.X, precision: 3);
+            Assert.Equal(8, content.Frame.Y, precision: 3);
+            Assert.Equal(184, content.Frame.Width, precision: 3);
+            Assert.Equal(90, content.Frame.Height, precision: 3);
         });
     }
 
@@ -218,10 +217,10 @@ public class PageHandlerTests : HandlerTestBase<PageHandler, PageStub>
             handler.InnerContentView!.Measure(new Avalonia.Size(200, 100));
             handler.InnerContentView.Arrange(new Avalonia.Rect(0, 0, 200, 100));
 
-            Assert.Equal(0, content.Frame.X);
-            Assert.Equal(0, content.Frame.Y);
-            Assert.Equal(200, content.Frame.Width);
-            Assert.Equal(100, content.Frame.Height);
+            Assert.Equal(0, content.Frame.X, precision: 3);
+            Assert.Equal(0, content.Frame.Y, precision: 3);
+            Assert.Equal(200, content.Frame.Width, precision: 3);
+            Assert.Equal(100, content.Frame.Height, precision: 3);
         });
 
         await InvokeOnMainThreadAsync(() =>
@@ -232,10 +231,10 @@ public class PageHandlerTests : HandlerTestBase<PageHandler, PageStub>
             handler.InnerContentView!.Measure(new Avalonia.Size(200, 100));
             handler.InnerContentView.Arrange(new Avalonia.Rect(0, 0, 200, 100));
 
-            Assert.Equal(10, content.Frame.X);
-            Assert.Equal(20, content.Frame.Y);
-            Assert.Equal(160, content.Frame.Width);
-            Assert.Equal(40, content.Frame.Height);
+            Assert.Equal(10, content.Frame.X, precision: 3);
+            Assert.Equal(20, content.Frame.Y, precision: 3);
+            Assert.Equal(160, content.Frame.Width, precision: 3);
+            Assert.Equal(40, content.Frame.Height, precision: 3);
         });
     }
 }


### PR DESCRIPTION
`Page.Padding` is already consumed by MAUI’s cross-platform `IContentView` arrange path, so the Avalonia handler does not apply platform padding directly. The mapper only invalidates layout to avoid double-insetting page content.

<img width="990" height="676" alt="page-padding" src="https://github.com/user-attachments/assets/49d59ad2-b5c5-4a00-989d-db23c0c07fef" />

Changes:
- Adds `Page.Padding` to the Avalonia `PageHandler` mapper.
- Invalidates the inner page content wrapper when padding changes so MAUI’s cross-platform layout reapplies the updated padding.
- Adds tests for initial and updated page padding layout.
- Adds a ControlGallery `Page` sample with sliders to adjust left, top, right, and bottom padding.
- Updates `STATUS.md` to mark `Page.Padding` as implemented.
