### PR TITLE
Implement AvaloniaFileResult for MediaPicker

### DIFF
--- a/STATUS-ESSENTIALS.md
+++ b/STATUS-ESSENTIALS.md
@@ -473,20 +473,26 @@ Pick or capture photos and videos from the device.
 
 | Member | Type | Status |
 |--------|------|--------|
-| IsCaptureSupported | Property | ⏳ TODO |
-| PickPhotoAsync(MediaPickerOptions) | Method | ⏳ TODO |
-| PickPhotosAsync(MediaPickerOptions) | Method | ⏳ TODO |
-| CapturePhotoAsync(MediaPickerOptions) | Method | ⏳ TODO |
-| PickVideoAsync(MediaPickerOptions) | Method | ⏳ TODO |
-| PickVideosAsync(MediaPickerOptions) | Method | ⏳ TODO |
-| CaptureVideoAsync(MediaPickerOptions) | Method | ⏳ TODO |
+| IsCaptureSupported | Property | ✅ Implemented |
+| PickPhotoAsync(MediaPickerOptions) | Method | ✅ Implemented |
+| PickPhotosAsync(MediaPickerOptions) | Method | ✅ Implemented |
+| CapturePhotoAsync(MediaPickerOptions) | Method | ❌ Not Applicable |
+| PickVideoAsync(MediaPickerOptions) | Method | ✅ Implemented |
+| PickVideosAsync(MediaPickerOptions) | Method | ✅ Implemented |
+| CaptureVideoAsync(MediaPickerOptions) | Method | ❌ Not Applicable |
 
 ### Supporting Types
 
 | Type | Status |
 |------|--------|
-| MediaPickerOptions | ⏳ TODO |
-| FileResult | ⏳ TODO |
+| MediaPickerOptions | ✅ Implemented |
+| FileResult | ✅ Implemented |
+
+`IsCaptureSupported` returns `false` and the `Capture*` methods throw
+`NotSupportedException`, as Avalonia desktop/Browser targets do not expose a
+camera capture API. Picked results are `AvaloniaFileResult` instances so
+`OpenReadAsync()` works on platforms without a local filesystem path
+(Avalonia.Browser, sandboxed storage providers).
 
 ---
 

--- a/samples/ControlGallery/ControlGallery/MainPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/MainPage.xaml.cs
@@ -104,6 +104,7 @@ public partial class MainPage : FlyoutPage
         [typeof(ScreenshotPage)] = () => new ScreenshotPage(),
         [typeof(PreferencesPage)] = () => new PreferencesPage(),
         [typeof(FilePickerPage)] = () => new FilePickerPage(),
+        [typeof(MediaPickerPage)] = () => new MediaPickerPage(),
         // Settings
         [typeof(ThemePage)] = () => new ThemePage(),
         // Embedding
@@ -283,6 +284,7 @@ public partial class MainPage : FlyoutPage
             new SampleGroup("Essentials", new List<SampleItem>
             {
                 new("File Picker", "Pick files from the device", typeof(FilePickerPage)),
+                new("Media Picker", "Pick photos and videos from the device", typeof(MediaPickerPage)),
                 new("Preferences", "Key/value storage for app settings", typeof(PreferencesPage)),
                 new("Screenshot", "Capture window screenshots", typeof(ScreenshotPage)),
             }),

--- a/samples/ControlGallery/ControlGallery/Pages/FilePickerPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/FilePickerPage.xaml.cs
@@ -38,13 +38,13 @@ public partial class FilePickerPage : ContentPage
             {
                 if (i > 0)
                     sb.AppendLine().AppendLine("---");
-                await AppendFileDetailsAsync(sb, files[i], index: i + 1, total: files.Count);
+                await FileResultPreview.AppendFileDetailsAsync(sb, files[i], index: i + 1, total: files.Count);
             }
 
             DetailsLabel.Text = sb.ToString();
             StatusLabel.Text = $"Status: {files.Count} file(s) read successfully";
 
-            await TryShowPreviewAsync(files[0]);
+            PreviewImage.Source = await FileResultPreview.TryLoadImagePreviewAsync(files[0]);
         }
         catch (Exception ex)
         {
@@ -57,80 +57,5 @@ public partial class FilePickerPage : ContentPage
     {
         var single = await FilePicker.Default.PickAsync(options);
         return single is null ? null : [single];
-    }
-
-    private static async Task AppendFileDetailsAsync(StringBuilder sb, FileResult file, int index, int total)
-    {
-        sb.AppendLine($"[{index}/{total}] {file.FileName}");
-        sb.AppendLine($"  Type:        {file.GetType().Name}");
-        sb.AppendLine($"  FileName:    {file.FileName}");
-        sb.AppendLine($"  FullPath:    {file.FullPath}");
-        sb.AppendLine($"  ContentType: {file.ContentType}");
-
-        try
-        {
-            await using var stream = await file.OpenReadAsync();
-            long length;
-            try
-            {
-                length = stream.Length;
-            }
-            catch (NotSupportedException)
-            {
-                // Some streams (e.g. browser-backed) may not report Length; copy to count.
-                using var counter = new CountingStream();
-                await stream.CopyToAsync(counter);
-                length = counter.BytesWritten;
-            }
-
-            sb.AppendLine($"  StreamType:  {stream.GetType().Name}");
-            sb.AppendLine($"  Size:        {length:N0} bytes");
-            sb.AppendLine($"  CanRead:     {stream.CanRead}");
-            sb.AppendLine($"  CanSeek:     {stream.CanSeek}");
-        }
-        catch (Exception ex)
-        {
-            sb.AppendLine($"  OpenReadAsync FAILED: {ex.GetType().Name}: {ex.Message}");
-        }
-    }
-
-    private async Task TryShowPreviewAsync(FileResult file)
-    {
-        if (!IsImageContentType(file.ContentType))
-            return;
-
-        try
-        {
-            // Buffer the contents so the ImageSource has its own copy of the data.
-            using var source = await file.OpenReadAsync();
-            var ms = new MemoryStream();
-            await source.CopyToAsync(ms);
-            ms.Position = 0;
-            var bytes = ms.ToArray();
-            PreviewImage.Source = ImageSource.FromStream(() => new MemoryStream(bytes, writable: false));
-        }
-        catch
-        {
-            PreviewImage.Source = null;
-        }
-    }
-
-    private static bool IsImageContentType(string? contentType)
-        => contentType is not null && contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase);
-
-    private sealed class CountingStream : Stream
-    {
-        public long BytesWritten { get; private set; }
-        public override bool CanRead => false;
-        public override bool CanSeek => false;
-        public override bool CanWrite => true;
-        public override long Length => BytesWritten;
-        public override long Position { get => BytesWritten; set => throw new NotSupportedException(); }
-        public override void Flush() { }
-        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
-        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
-        public override void SetLength(long value) => throw new NotSupportedException();
-        public override void Write(byte[] buffer, int offset, int count) => BytesWritten += count;
-        public override void Write(ReadOnlySpan<byte> buffer) => BytesWritten += buffer.Length;
     }
 }

--- a/samples/ControlGallery/ControlGallery/Pages/FileResultPreview.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/FileResultPreview.cs
@@ -1,0 +1,83 @@
+using System.Text;
+
+namespace ControlGallery.Pages;
+
+/// <summary>
+/// Shared helpers used by the FilePicker / MediaPicker sample pages to render
+/// <see cref="FileResult"/> details and produce image-preview byte buffers.
+/// </summary>
+internal static class FileResultPreview
+{
+    public static async Task AppendFileDetailsAsync(StringBuilder sb, FileResult file, int index, int total)
+    {
+        sb.AppendLine($"[{index}/{total}] {file.FileName}");
+        sb.AppendLine($"  Type:        {file.GetType().Name}");
+        sb.AppendLine($"  FileName:    {file.FileName}");
+        sb.AppendLine($"  FullPath:    {file.FullPath}");
+        sb.AppendLine($"  ContentType: {file.ContentType}");
+
+        try
+        {
+            await using var stream = await file.OpenReadAsync();
+            long length;
+            try
+            {
+                length = stream.Length;
+            }
+            catch (NotSupportedException)
+            {
+                using var counter = new CountingStream();
+                await stream.CopyToAsync(counter);
+                length = counter.BytesWritten;
+            }
+
+            sb.AppendLine($"  StreamType:  {stream.GetType().Name}");
+            sb.AppendLine($"  Size:        {length:N0} bytes");
+            sb.AppendLine($"  CanRead:     {stream.CanRead}");
+            sb.AppendLine($"  CanSeek:     {stream.CanSeek}");
+        }
+        catch (Exception ex)
+        {
+            sb.AppendLine($"  OpenReadAsync FAILED: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    public static async Task<ImageSource?> TryLoadImagePreviewAsync(FileResult file)
+    {
+        if (!IsImageContentType(file.ContentType))
+            return null;
+
+        try
+        {
+            // Buffer the contents so the ImageSource has its own copy of the data.
+            using var source = await file.OpenReadAsync();
+            using var ms = new MemoryStream();
+            await source.CopyToAsync(ms);
+            var bytes = ms.ToArray();
+            return ImageSource.FromStream(() => new MemoryStream(bytes, writable: false));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    static bool IsImageContentType(string? contentType)
+        => contentType is not null && contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase);
+
+    sealed class CountingStream : Stream
+    {
+        public long BytesWritten { get; private set; }
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => BytesWritten;
+        public override long Position { get => BytesWritten; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => BytesWritten += count;
+        public override void Write(ReadOnlySpan<byte> buffer) => BytesWritten += buffer.Length;
+    }
+}

--- a/samples/ControlGallery/ControlGallery/Pages/MediaPickerPage.xaml
+++ b/samples/ControlGallery/ControlGallery/Pages/MediaPickerPage.xaml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="ControlGallery.Pages.MediaPickerPage"
+             Title="MediaPicker">
+    <ScrollView>
+        <VerticalStackLayout Padding="20"
+                             Spacing="20">
+
+            <!-- Pick Media -->
+            <Border Stroke="Gray"
+                    Padding="10">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10"/>
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Pick Media"
+                           FontAttributes="Bold"/>
+                    <Label x:Name="CaptureLabel"
+                           Text="IsCaptureSupported: ?"
+                           FontAttributes="Italic"/>
+                    <Button Text="Pick Photo"
+                            Clicked="OnPickPhotoClicked"/>
+                    <Button Text="Pick Photos"
+                            Clicked="OnPickPhotosClicked"/>
+                    <Button Text="Pick Video"
+                            Clicked="OnPickVideoClicked"/>
+                    <Button Text="Pick Videos"
+                            Clicked="OnPickVideosClicked"/>
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- File Details -->
+            <Border Stroke="Gray"
+                    Padding="10">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="10"/>
+                </Border.StrokeShape>
+                <VerticalStackLayout Spacing="6">
+                    <Label Text="File Details"
+                           FontAttributes="Bold"/>
+                    <Label x:Name="StatusLabel"
+                           Text="Status: idle"
+                           FontAttributes="Italic"/>
+                    <Label x:Name="DetailsLabel"
+                           Text="No file selected."
+                           FontFamily="Courier New"/>
+                    <Label Text="Image Preview:"
+                           FontAttributes="Bold"
+                           Margin="0,10,0,0"/>
+                    <Image x:Name="PreviewImage"
+                           HeightRequest="200"
+                           Aspect="AspectFit"/>
+                </VerticalStackLayout>
+            </Border>
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/samples/ControlGallery/ControlGallery/Pages/MediaPickerPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/MediaPickerPage.xaml.cs
@@ -1,0 +1,161 @@
+using System.Text;
+
+namespace ControlGallery.Pages;
+
+public partial class MediaPickerPage : ContentPage
+{
+    public MediaPickerPage()
+    {
+        InitializeComponent();
+        CaptureLabel.Text = $"IsCaptureSupported: {MediaPicker.Default.IsCaptureSupported}";
+    }
+
+    private async void OnPickPhotoClicked(object? sender, EventArgs e)
+        => await PickAndDescribeAsync(() => PickPhotoAsListAsync(), kind: "photo");
+
+    private async void OnPickPhotosClicked(object? sender, EventArgs e)
+        => await PickAndDescribeAsync(() => PickPhotosAsListAsync(), kind: "photos");
+
+    private async void OnPickVideoClicked(object? sender, EventArgs e)
+        => await PickAndDescribeAsync(() => PickVideoAsListAsync(), kind: "video");
+
+    private async void OnPickVideosClicked(object? sender, EventArgs e)
+        => await PickAndDescribeAsync(() => PickVideosAsListAsync(), kind: "videos");
+
+    private async Task PickAndDescribeAsync(Func<Task<List<FileResult>?>> pick, string kind)
+    {
+        try
+        {
+            StatusLabel.Text = $"Status: showing {kind} picker…";
+            PreviewImage.Source = null;
+
+            var files = await pick();
+
+            if (files is null || files.Count == 0)
+            {
+                StatusLabel.Text = "Status: cancelled";
+                DetailsLabel.Text = "No file selected.";
+                return;
+            }
+
+            var sb = new StringBuilder();
+            for (var i = 0; i < files.Count; i++)
+            {
+                if (i > 0)
+                    sb.AppendLine().AppendLine("---");
+                await AppendFileDetailsAsync(sb, files[i], index: i + 1, total: files.Count);
+            }
+
+            DetailsLabel.Text = sb.ToString();
+            StatusLabel.Text = $"Status: {files.Count} file(s) read successfully";
+
+            await TryShowPreviewAsync(files[0]);
+        }
+        catch (Exception ex)
+        {
+            StatusLabel.Text = $"Status: error — {ex.GetType().Name}";
+            DetailsLabel.Text = ex.ToString();
+        }
+    }
+
+    private static async Task<List<FileResult>?> PickPhotoAsListAsync()
+    {
+        var single = await MediaPicker.Default.PickPhotoAsync();
+        return single is null ? null : [single];
+    }
+
+    private static async Task<List<FileResult>?> PickVideoAsListAsync()
+    {
+        var single = await MediaPicker.Default.PickVideoAsync();
+        return single is null ? null : [single];
+    }
+
+    private static async Task<List<FileResult>?> PickPhotosAsListAsync()
+    {
+        var picker = MediaPicker.Default as Avalonia.Controls.Maui.Essentials.AvaloniaMediaPicker;
+        if (picker is null)
+            throw new NotSupportedException("Multi-photo picking requires AvaloniaMediaPicker.");
+        return await picker.PickPhotosAsync();
+    }
+
+    private static async Task<List<FileResult>?> PickVideosAsListAsync()
+    {
+        var picker = MediaPicker.Default as Avalonia.Controls.Maui.Essentials.AvaloniaMediaPicker;
+        if (picker is null)
+            throw new NotSupportedException("Multi-video picking requires AvaloniaMediaPicker.");
+        return await picker.PickVideosAsync();
+    }
+
+    private static async Task AppendFileDetailsAsync(StringBuilder sb, FileResult file, int index, int total)
+    {
+        sb.AppendLine($"[{index}/{total}] {file.FileName}");
+        sb.AppendLine($"  Type:        {file.GetType().Name}");
+        sb.AppendLine($"  FileName:    {file.FileName}");
+        sb.AppendLine($"  FullPath:    {file.FullPath}");
+        sb.AppendLine($"  ContentType: {file.ContentType}");
+
+        try
+        {
+            await using var stream = await file.OpenReadAsync();
+            long length;
+            try
+            {
+                length = stream.Length;
+            }
+            catch (NotSupportedException)
+            {
+                using var counter = new CountingStream();
+                await stream.CopyToAsync(counter);
+                length = counter.BytesWritten;
+            }
+
+            sb.AppendLine($"  StreamType:  {stream.GetType().Name}");
+            sb.AppendLine($"  Size:        {length:N0} bytes");
+            sb.AppendLine($"  CanRead:     {stream.CanRead}");
+            sb.AppendLine($"  CanSeek:     {stream.CanSeek}");
+        }
+        catch (Exception ex)
+        {
+            sb.AppendLine($"  OpenReadAsync FAILED: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private async Task TryShowPreviewAsync(FileResult file)
+    {
+        if (!IsImageContentType(file.ContentType))
+            return;
+
+        try
+        {
+            using var source = await file.OpenReadAsync();
+            var ms = new MemoryStream();
+            await source.CopyToAsync(ms);
+            ms.Position = 0;
+            var bytes = ms.ToArray();
+            PreviewImage.Source = ImageSource.FromStream(() => new MemoryStream(bytes, writable: false));
+        }
+        catch
+        {
+            PreviewImage.Source = null;
+        }
+    }
+
+    private static bool IsImageContentType(string? contentType)
+        => contentType is not null && contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase);
+
+    private sealed class CountingStream : Stream
+    {
+        public long BytesWritten { get; private set; }
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => BytesWritten;
+        public override long Position { get => BytesWritten; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => BytesWritten += count;
+        public override void Write(ReadOnlySpan<byte> buffer) => BytesWritten += buffer.Length;
+    }
+}

--- a/samples/ControlGallery/ControlGallery/Pages/MediaPickerPage.xaml.cs
+++ b/samples/ControlGallery/ControlGallery/Pages/MediaPickerPage.xaml.cs
@@ -43,13 +43,13 @@ public partial class MediaPickerPage : ContentPage
             {
                 if (i > 0)
                     sb.AppendLine().AppendLine("---");
-                await AppendFileDetailsAsync(sb, files[i], index: i + 1, total: files.Count);
+                await FileResultPreview.AppendFileDetailsAsync(sb, files[i], index: i + 1, total: files.Count);
             }
 
             DetailsLabel.Text = sb.ToString();
             StatusLabel.Text = $"Status: {files.Count} file(s) read successfully";
 
-            await TryShowPreviewAsync(files[0]);
+            PreviewImage.Source = await FileResultPreview.TryLoadImagePreviewAsync(files[0]);
         }
         catch (Exception ex)
         {
@@ -84,78 +84,5 @@ public partial class MediaPickerPage : ContentPage
         if (picker is null)
             throw new NotSupportedException("Multi-video picking requires AvaloniaMediaPicker.");
         return await picker.PickVideosAsync();
-    }
-
-    private static async Task AppendFileDetailsAsync(StringBuilder sb, FileResult file, int index, int total)
-    {
-        sb.AppendLine($"[{index}/{total}] {file.FileName}");
-        sb.AppendLine($"  Type:        {file.GetType().Name}");
-        sb.AppendLine($"  FileName:    {file.FileName}");
-        sb.AppendLine($"  FullPath:    {file.FullPath}");
-        sb.AppendLine($"  ContentType: {file.ContentType}");
-
-        try
-        {
-            await using var stream = await file.OpenReadAsync();
-            long length;
-            try
-            {
-                length = stream.Length;
-            }
-            catch (NotSupportedException)
-            {
-                using var counter = new CountingStream();
-                await stream.CopyToAsync(counter);
-                length = counter.BytesWritten;
-            }
-
-            sb.AppendLine($"  StreamType:  {stream.GetType().Name}");
-            sb.AppendLine($"  Size:        {length:N0} bytes");
-            sb.AppendLine($"  CanRead:     {stream.CanRead}");
-            sb.AppendLine($"  CanSeek:     {stream.CanSeek}");
-        }
-        catch (Exception ex)
-        {
-            sb.AppendLine($"  OpenReadAsync FAILED: {ex.GetType().Name}: {ex.Message}");
-        }
-    }
-
-    private async Task TryShowPreviewAsync(FileResult file)
-    {
-        if (!IsImageContentType(file.ContentType))
-            return;
-
-        try
-        {
-            using var source = await file.OpenReadAsync();
-            var ms = new MemoryStream();
-            await source.CopyToAsync(ms);
-            ms.Position = 0;
-            var bytes = ms.ToArray();
-            PreviewImage.Source = ImageSource.FromStream(() => new MemoryStream(bytes, writable: false));
-        }
-        catch
-        {
-            PreviewImage.Source = null;
-        }
-    }
-
-    private static bool IsImageContentType(string? contentType)
-        => contentType is not null && contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase);
-
-    private sealed class CountingStream : Stream
-    {
-        public long BytesWritten { get; private set; }
-        public override bool CanRead => false;
-        public override bool CanSeek => false;
-        public override bool CanWrite => true;
-        public override long Length => BytesWritten;
-        public override long Position { get => BytesWritten; set => throw new NotSupportedException(); }
-        public override void Flush() { }
-        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
-        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
-        public override void SetLength(long value) => throw new NotSupportedException();
-        public override void Write(byte[] buffer, int offset, int count) => BytesWritten += count;
-        public override void Write(ReadOnlySpan<byte> buffer) => BytesWritten += buffer.Length;
     }
 }

--- a/src/Avalonia.Controls.Maui.Essentials/MediaPicker/AvaloniaMediaPicker.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/MediaPicker/AvaloniaMediaPicker.cs
@@ -57,11 +57,7 @@ public class AvaloniaMediaPicker : IMediaPicker
     /// <returns>A FileResult representing the selected photo, or <see langword="null"/> if the user cancelled the dialog.</returns>
     public async Task<FileResult?> PickPhotoAsync(MediaPickerOptions? options = null)
     {
-        var topLevel = _platformProvider.GetTopLevel()
-            ?? throw new InvalidOperationException("Unable to get Avalonia TopLevel. Ensure the application has been fully initialized.");
-
-        var pickerOptions = CreatePhotoPickerOptions(options);
-        var results = await topLevel.StorageProvider.OpenFilePickerAsync(pickerOptions).ConfigureAwait(false);
+        var results = await OpenFilePickerAsync(CreatePhotoPickerOptions(options)).ConfigureAwait(false);
 
         if (results.Count == 0)
             return null;
@@ -76,11 +72,7 @@ public class AvaloniaMediaPicker : IMediaPicker
     /// <returns>A list of FileResult objects representing the selected photos, or an empty list if the user cancelled the dialog.</returns>
     public async Task<List<FileResult>> PickPhotosAsync(MediaPickerOptions? options = null)
     {
-        var topLevel = _platformProvider.GetTopLevel()
-            ?? throw new InvalidOperationException("Unable to get Avalonia TopLevel. Ensure the application has been fully initialized.");
-
-        var pickerOptions = CreatePhotoPickerOptions(options, allowMultiple: true);
-        var results = await topLevel.StorageProvider.OpenFilePickerAsync(pickerOptions).ConfigureAwait(false);
+        var results = await OpenFilePickerAsync(CreatePhotoPickerOptions(options, allowMultiple: true)).ConfigureAwait(false);
 
         var fileResults = new List<FileResult>(results.Count);
         foreach (var result in results)
@@ -96,11 +88,7 @@ public class AvaloniaMediaPicker : IMediaPicker
     /// <returns>A FileResult representing the selected video, or <see langword="null"/> if the user cancelled the dialog.</returns>
     public async Task<FileResult?> PickVideoAsync(MediaPickerOptions? options = null)
     {
-        var topLevel = _platformProvider.GetTopLevel()
-            ?? throw new InvalidOperationException("Unable to get Avalonia TopLevel. Ensure the application has been fully initialized.");
-
-        var pickerOptions = CreateVideoPickerOptions(options);
-        var results = await topLevel.StorageProvider.OpenFilePickerAsync(pickerOptions).ConfigureAwait(false);
+        var results = await OpenFilePickerAsync(CreateVideoPickerOptions(options)).ConfigureAwait(false);
 
         if (results.Count == 0)
             return null;
@@ -115,17 +103,20 @@ public class AvaloniaMediaPicker : IMediaPicker
     /// <returns>A list of FileResult objects representing the selected videos, or an empty list if the user cancelled the dialog.</returns>
     public async Task<List<FileResult>> PickVideosAsync(MediaPickerOptions? options = null)
     {
-        var topLevel = _platformProvider.GetTopLevel()
-            ?? throw new InvalidOperationException("Unable to get Avalonia TopLevel. Ensure the application has been fully initialized.");
-
-        var pickerOptions = CreateVideoPickerOptions(options, allowMultiple: true);
-        var results = await topLevel.StorageProvider.OpenFilePickerAsync(pickerOptions).ConfigureAwait(false);
+        var results = await OpenFilePickerAsync(CreateVideoPickerOptions(options, allowMultiple: true)).ConfigureAwait(false);
 
         var fileResults = new List<FileResult>(results.Count);
         foreach (var result in results)
             fileResults.Add(new AvaloniaFileResult(result));
 
         return fileResults;
+    }
+
+    internal virtual async Task<IReadOnlyList<IStorageFile>> OpenFilePickerAsync(FilePickerOpenOptions options)
+    {
+        var topLevel = _platformProvider.GetTopLevel()
+            ?? throw new InvalidOperationException("Unable to get Avalonia TopLevel. Ensure the application has been fully initialized.");
+        return await topLevel.StorageProvider.OpenFilePickerAsync(options).ConfigureAwait(false);
     }
 
     static FilePickerOpenOptions CreatePhotoPickerOptions(MediaPickerOptions? options, bool allowMultiple = false)

--- a/src/Avalonia.Controls.Maui.Essentials/MediaPicker/AvaloniaMediaPicker.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/MediaPicker/AvaloniaMediaPicker.cs
@@ -8,6 +8,12 @@ namespace Avalonia.Controls.Maui.Essentials;
 /// <summary>
 /// Avalonia implementation of IMediaPicker that uses the StorageProvider file picker for photo and video selection on desktop platforms.
 /// </summary>
+/// <remarks>
+/// The returned <see cref="FileResult"/> instances are <see cref="AvaloniaFileResult"/> wrappers around the
+/// underlying Avalonia <see cref="IStorageFile"/>. Prefer <c>OpenReadAsync()</c> over reading <c>FullPath</c> —
+/// on platforms such as Avalonia.Browser the picked file has no real filesystem path. See
+/// <see cref="AvaloniaFileResult"/> for the full rationale.
+/// </remarks>
 public class AvaloniaMediaPicker : IMediaPicker
 {
     readonly IAvaloniaEssentialsPlatformProvider _platformProvider;
@@ -60,8 +66,7 @@ public class AvaloniaMediaPicker : IMediaPicker
         if (results.Count == 0)
             return null;
 
-        var path = results[0].TryGetLocalPath();
-        return path is not null ? new FileResult(path) : null;
+        return new AvaloniaFileResult(results[0]);
     }
 
     /// <summary>
@@ -77,13 +82,9 @@ public class AvaloniaMediaPicker : IMediaPicker
         var pickerOptions = CreatePhotoPickerOptions(options, allowMultiple: true);
         var results = await topLevel.StorageProvider.OpenFilePickerAsync(pickerOptions).ConfigureAwait(false);
 
-        var fileResults = new List<FileResult>();
+        var fileResults = new List<FileResult>(results.Count);
         foreach (var result in results)
-        {
-            var path = result.TryGetLocalPath();
-            if (path is not null)
-                fileResults.Add(new FileResult(path));
-        }
+            fileResults.Add(new AvaloniaFileResult(result));
 
         return fileResults;
     }
@@ -104,8 +105,7 @@ public class AvaloniaMediaPicker : IMediaPicker
         if (results.Count == 0)
             return null;
 
-        var path = results[0].TryGetLocalPath();
-        return path is not null ? new FileResult(path) : null;
+        return new AvaloniaFileResult(results[0]);
     }
 
     /// <summary>
@@ -121,13 +121,9 @@ public class AvaloniaMediaPicker : IMediaPicker
         var pickerOptions = CreateVideoPickerOptions(options, allowMultiple: true);
         var results = await topLevel.StorageProvider.OpenFilePickerAsync(pickerOptions).ConfigureAwait(false);
 
-        var fileResults = new List<FileResult>();
+        var fileResults = new List<FileResult>(results.Count);
         foreach (var result in results)
-        {
-            var path = result.TryGetLocalPath();
-            if (path is not null)
-                fileResults.Add(new FileResult(path));
-        }
+            fileResults.Add(new AvaloniaFileResult(result));
 
         return fileResults;
     }

--- a/tests/Avalonia.Controls.Maui.Essentials.Tests/AvaloniaMediaPickerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Essentials.Tests/AvaloniaMediaPickerTests.cs
@@ -1,5 +1,8 @@
+using System.Text;
 using Avalonia.Controls;
 using Avalonia.Controls.Maui.Essentials;
+using Avalonia.Platform.Storage;
+using Microsoft.Maui.Storage;
 using NSubstitute;
 
 namespace Avalonia.Controls.Maui.Tests.Services;
@@ -81,5 +84,130 @@ public class AvaloniaMediaPickerTests
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => picker.PickVideosAsync());
+    }
+
+    [Fact]
+    public async Task PickPhotoAsync_ReturnsAvaloniaFileResult_ForPathlessStorageFile()
+    {
+        var file = CreatePathlessStorageFile("photo.png");
+        var picker = new StubMediaPicker(file);
+
+        var result = await picker.PickPhotoAsync();
+
+        var avaloniaResult = Assert.IsType<AvaloniaFileResult>(result);
+        Assert.Same(file, avaloniaResult.StorageFile);
+        Assert.Equal("photo.png", avaloniaResult.FileName);
+        Assert.Equal("photo.png", avaloniaResult.FullPath);
+        Assert.Equal("image/png", avaloniaResult.ContentType);
+    }
+
+    [Fact]
+    public async Task PickPhotoAsync_OpenReadAsync_DelegatesToStorageFile()
+    {
+        var payload = "photo bytes"u8.ToArray();
+        var file = CreatePathlessStorageFile("photo.png");
+        file.OpenReadAsync().Returns(_ => Task.FromResult<Stream>(new MemoryStream(payload, writable: false)));
+        var picker = new StubMediaPicker(file);
+
+        var result = await picker.PickPhotoAsync();
+
+        Assert.NotNull(result);
+        await using var stream = await result.OpenReadAsync();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var text = await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal("photo bytes", text);
+        await file.Received(1).OpenReadAsync();
+    }
+
+    [Fact]
+    public async Task PickPhotoAsync_ReturnsNull_WhenStorageProviderReturnsNoResults()
+    {
+        var picker = new StubMediaPicker();
+
+        var result = await picker.PickPhotoAsync();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task PickPhotosAsync_WrapsEveryResultAsAvaloniaFileResult()
+    {
+        var first = CreatePathlessStorageFile("a.png");
+        var second = CreatePathlessStorageFile("b.png");
+        var picker = new StubMediaPicker(first, second);
+
+        var results = await picker.PickPhotosAsync();
+
+        Assert.Equal(2, results.Count);
+        Assert.Same(first, Assert.IsType<AvaloniaFileResult>(results[0]).StorageFile);
+        Assert.Same(second, Assert.IsType<AvaloniaFileResult>(results[1]).StorageFile);
+    }
+
+    [Fact]
+    public async Task PickVideoAsync_ReturnsAvaloniaFileResult_ForPathlessStorageFile()
+    {
+        var file = CreatePathlessStorageFile("clip.mp4");
+        var picker = new StubMediaPicker(file);
+
+        var result = await picker.PickVideoAsync();
+
+        var avaloniaResult = Assert.IsType<AvaloniaFileResult>(result);
+        Assert.Same(file, avaloniaResult.StorageFile);
+        Assert.Equal("video/mp4", avaloniaResult.ContentType);
+    }
+
+    [Fact]
+    public async Task PickVideoAsync_OpenReadAsync_DelegatesToStorageFile()
+    {
+        var payload = new byte[] { 1, 2, 3, 4 };
+        var file = CreatePathlessStorageFile("clip.mp4");
+        var underlying = new MemoryStream(payload, writable: false);
+        file.OpenReadAsync().Returns(Task.FromResult<Stream>(underlying));
+        var picker = new StubMediaPicker(file);
+
+        var result = await picker.PickVideoAsync();
+
+        Assert.NotNull(result);
+        await using var stream = await result.OpenReadAsync();
+        Assert.Same(underlying, stream);
+        await file.Received(1).OpenReadAsync();
+    }
+
+    [Fact]
+    public async Task PickVideosAsync_WrapsEveryResultAsAvaloniaFileResult()
+    {
+        var first = CreatePathlessStorageFile("a.mp4");
+        var second = CreatePathlessStorageFile("b.mp4");
+        var picker = new StubMediaPicker(first, second);
+
+        var results = await picker.PickVideosAsync();
+
+        Assert.Equal(2, results.Count);
+        Assert.Same(first, Assert.IsType<AvaloniaFileResult>(results[0]).StorageFile);
+        Assert.Same(second, Assert.IsType<AvaloniaFileResult>(results[1]).StorageFile);
+    }
+
+    static IStorageFile CreatePathlessStorageFile(string name)
+    {
+        // Browser-style URI that has no local path representation.
+        var file = Substitute.For<IStorageFile>();
+        file.Name.Returns(name);
+        file.Path.Returns(new Uri("blob:https://example.test/" + Guid.NewGuid()));
+        return file;
+    }
+
+    sealed class StubMediaPicker : AvaloniaMediaPicker
+    {
+        readonly IReadOnlyList<IStorageFile> _results;
+
+        public StubMediaPicker(params IStorageFile[] results)
+            : base(Substitute.For<IAvaloniaEssentialsPlatformProvider>())
+        {
+            _results = results;
+        }
+
+        internal override Task<IReadOnlyList<IStorageFile>> OpenFilePickerAsync(FilePickerOpenOptions options)
+            => Task.FromResult(_results);
     }
 }


### PR DESCRIPTION
Copilot Generated stuff
---

This pull request adds support for picking photos and videos using the `MediaPicker` API on Avalonia platforms, updates the documentation to reflect the current implementation status, and introduces a sample page in the Control Gallery to demonstrate and test the new functionality. The implementation uses `AvaloniaFileResult` to wrap picked files, ensuring compatibility with platforms that do not provide a local filesystem path (e.g., Avalonia.Browser).

**MediaPicker API Implementation and Behavior:**

- Marked all `MediaPicker` pick methods (`PickPhotoAsync`, `PickPhotosAsync`, `PickVideoAsync`, `PickVideosAsync`) and the `IsCaptureSupported` property as implemented in `STATUS-ESSENTIALS.md`. The `CapturePhotoAsync` and `CaptureVideoAsync` methods are marked as not applicable, with documentation explaining that capture is not supported on Avalonia platforms. (`[STATUS-ESSENTIALS.mdL476-R495](diffhunk://#diff-b7d31c41fd1179cffb5ab6ddd020d074e8b88a93d94e16b963d0047c90e115c2L476-R495)`)
- Updated `AvaloniaMediaPicker` to always return `AvaloniaFileResult` instances for picked files, ensuring `OpenReadAsync()` works even when no local path is available. (`[[1]](diffhunk://#diff-ad96fa47d71e32ba4b72aa4e8ce5f4e5d3916bfe46dc72645baaa006b9466d00L63-R69)`, `[[2]](diffhunk://#diff-ad96fa47d71e32ba4b72aa4e8ce5f4e5d3916bfe46dc72645baaa006b9466d00L80-R87)`, `[[3]](diffhunk://#diff-ad96fa47d71e32ba4b72aa4e8ce5f4e5d3916bfe46dc72645baaa006b9466d00L107-R108)`, `[[4]](diffhunk://#diff-ad96fa47d71e32ba4b72aa4e8ce5f4e5d3916bfe46dc72645baaa006b9466d00L124-R126)`)
- Added remarks to the `AvaloniaMediaPicker` class explaining the rationale for using `AvaloniaFileResult` and guidance for consuming code. (`[src/Avalonia.Controls.Maui.Essentials/MediaPicker/AvaloniaMediaPicker.csR11-R16](diffhunk://#diff-ad96fa47d71e32ba4b72aa4e8ce5f4e5d3916bfe46dc72645baaa006b9466d00R11-R16)`)

**Sample Application Enhancements:**

- Added a new `MediaPickerPage` (XAML and code-behind) to the Control Gallery sample app, allowing users to pick photos and videos, view file details, and preview images. (`[[1]](diffhunk://#diff-b53b226c4dc30f290c2a1923dc0f7f9491ac4cfc88c4b976acaec15a9194eea2R1-R59)`, `[[2]](diffhunk://#diff-f7ff43040c23d6ee1088b14c93183c1532df041d2d1d128c95a6cb2cef149ba3R1-R161)`)
- Registered the new `MediaPickerPage` in the sample app navigation and sample groups, making it accessible from the UI. (`[[1]](diffhunk://#diff-394aa639a42d8d39aed8ff23d166d7f54b2d914a885b60018eeb5900d498d4e5R107)`, `[[2]](diffhunk://#diff-394aa639a42d8d39aed8ff23d166d7f54b2d914a885b60018eeb5900d498d4e5R287)`)