### PR TITLE
Bump MAUI to 11.0.0-preview.5.26304.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,7 +51,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <MicrosoftExtensionsVersion>11.0.0-preview.4.26230.115</MicrosoftExtensionsVersion>
+        <MicrosoftExtensionsVersion>11.0.0-preview.5.26302.115</MicrosoftExtensionsVersion>
     </PropertyGroup>
 
     <!--
@@ -79,7 +79,7 @@
     </Target>
 
     <PropertyGroup Condition="'$(DotNetTfm)' == 'net11.0'">
-        <MauiVersion>11.0.0-preview.4.26230.3</MauiVersion>
+        <MauiVersion>11.0.0-preview.5.26304.4</MauiVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(DotNetTfm)' == 'net10.0'">

--- a/src/Avalonia.Controls.Maui/Extensions/MauiAppBuilderExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/MauiAppBuilderExtensions.cs
@@ -121,7 +121,7 @@ public static class MauiAppBuilderExtensions
         builder.Services.RemoveAll<ITicker>();
         builder.Services.AddSingleton<ITicker>(svcs => new AvaloniaTicker());
 
-        builder.Services.AddSingleton<Microsoft.Maui.Controls.Platform.AlertManager.IAlertManagerSubscription, AlertManager.AlertRequestHelper>();
+        builder.Services.AddSingleton<Microsoft.Maui.Controls.Platform.IAlertManagerSubscription, AlertManager.AlertRequestHelper>();
 
         return builder
             .ConfigureMauiHandlers(handlers =>

--- a/src/Avalonia.Controls.Maui/Handlers/ViewHandlerOfT.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ViewHandlerOfT.cs
@@ -323,15 +323,15 @@ public abstract partial class ViewHandler<TVirtualView, TPlatformView> : ViewHan
     private static class VisualElementLifecycle
     {
         [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "SendLoaded")]
-        private static extern void SendLoaded(VisualElement element);
+        private static extern void SendLoaded(VisualElement element, bool updateWiring);
 
         [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "SendUnloaded")]
-        private static extern void SendUnloaded(VisualElement element);
+        private static extern void SendUnloaded(VisualElement element, bool updateWiring);
 
         public static void TrySendLoaded(VisualElement element) =>
-            SendLoaded(element);
+            SendLoaded(element, false);
 
         public static void TrySendUnloaded(VisualElement element) =>
-            SendUnloaded(element);
+            SendUnloaded(element, false);
     }
 }

--- a/src/Avalonia.Controls.Maui/Platform/AlertManager.cs
+++ b/src/Avalonia.Controls.Maui/Platform/AlertManager.cs
@@ -8,7 +8,7 @@ namespace Avalonia.Controls.Maui.Platform;
 
 internal class AlertManager
 {
-    internal class AlertRequestHelper : Microsoft.Maui.Controls.Platform.AlertManager.IAlertManagerSubscription
+    internal class AlertRequestHelper : Microsoft.Maui.Controls.Platform.IAlertManagerSubscription
     {
         readonly Dictionary<Control, OverlayHelper> _helpers = new();
 


### PR DESCRIPTION
Copilot stuff below
----

This pull request updates dependencies and corrects interface usage for alert management in the Avalonia MAUI integration. The most important changes are grouped below:

Dependency version updates:

* Updated the `MicrosoftExtensionsVersion` property to `11.0.0-preview.5.26302.115` in `Directory.Build.props`.
* Updated the `MauiVersion` property for `.NET 11.0` to `11.0.0-preview.5.26304.4` in `Directory.Build.props`.

Alert manager interface corrections:

* Changed the registration and implementation of `AlertRequestHelper` to use the correct `Microsoft.Maui.Controls.Platform.IAlertManagerSubscription` interface instead of the previous (now incorrect) `Microsoft.Maui.Controls.Platform.AlertManager.IAlertManagerSubscription` in both `MauiAppBuilderExtensions.cs` and `AlertManager.cs`. [[1]](diffhunk://#diff-985eaa9d3faf086fb4acfe3c89e804229afdbfdb73015806b341e7fc3e23423cL124-R124) [[2]](diffhunk://#diff-8fd0af10342dce10ec516c8f5e422ab7e4f248693491764314a25959bf3eee62L11-R11)