### PR TITLE
Fix OnStart lifecycle not firing on MAUI Application in Avalonia bridge

### DIFF
--- a/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaApplication.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaApplication.cs
@@ -106,6 +106,10 @@ public abstract class MauiAvaloniaApplication : Application, IPlatformApplicatio
         // Connect the MAUI Application to its handler
         this.SetApplicationHandler(Application, ApplicationContext);
 
+        // Fire OnStart lifecycle — the Avalonia bridge does not call it automatically
+        if (this.Application is Microsoft.Maui.Controls.Application startApp)
+            startApp.SendStart();
+
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             var avaloniaWindow = CreatePlatformWindow();

--- a/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaApplication.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiAvaloniaApplication.cs
@@ -106,10 +106,6 @@ public abstract class MauiAvaloniaApplication : Application, IPlatformApplicatio
         // Connect the MAUI Application to its handler
         this.SetApplicationHandler(Application, ApplicationContext);
 
-        // Fire OnStart lifecycle — the Avalonia bridge does not call it automatically
-        if (this.Application is Microsoft.Maui.Controls.Application startApp)
-            startApp.SendStart();
-
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             var avaloniaWindow = CreatePlatformWindow();
@@ -121,6 +117,10 @@ public abstract class MauiAvaloniaApplication : Application, IPlatformApplicatio
             var content = CreatePlatformContent();
             singleView.MainView = content;
         }
+
+        // Fire OnStart lifecycle AFTER window creation to match standard MAUI lifecycle order
+        if (this.Application is Microsoft.Maui.Controls.Application startApp)
+            startApp.SendStart();
 
         Services.InvokeLifecycleEvents<AvaloniaLifecycle.OnLaunched>(del => del(this, args));
 


### PR DESCRIPTION
## Problem

`MauiAvaloniaApplication.OnFrameworkInitializationCompleted()` sets up the MAUI `Application` handler via `SetApplicationHandler()` but never calls `SendStart()` on the MAUI `Application` instance. This means `Application.OnStart()` overrides in user code never fire on any Avalonia target (browser, desktop).

In the standard MAUI platform (Android/iOS), the platform-specific application calls `Application.SendStart()` after initialization. The Avalonia bridge's `MauiAvaloniaApplication` is the equivalent class but is missing this call.

## Fix

Add a call to `SendStart()` after `SetApplicationHandler()` in `MauiAvaloniaApplication.OnFrameworkInitializationCompleted()`:

```csharp
this.SetApplicationHandler(Application, ApplicationContext);
if (this.Application is Microsoft.Maui.Controls.Application startApp)
    startApp.SendStart();
```

## Impact

Fixes `Application.OnStart()` lifecycle firing on all Avalonia targets including browser (WASM), enabling common startup patterns like token restore, service initialization, and state restoration.

Closes #216