### PR TITLE
Fix gesture recognizers not reconnecting after navigation pop

### DIFF
--- a/src/Avalonia.Controls.Maui/Platform/GestureManager.cs
+++ b/src/Avalonia.Controls.Maui/Platform/GestureManager.cs
@@ -82,6 +82,14 @@ internal class GestureManager : IDisposable
         if (handler == null ||
             (_didHaveWindow && _view.Window == null))
         {
+            // Navigation pop temporarily detaches views from the visual tree.
+            // Don't disconnect when handler is valid but window is null during transition —
+            // keep existing gesture handlers connected so they work when re-attached.
+            if (handler != null && _view.Window == null)
+            {
+                _didHaveWindow = false;
+                return;
+            }
             DisconnectGestures();
             return;
         }


### PR DESCRIPTION
## Problem

`GestureManager.SetupGestureManager()` disconnects gesture handlers when `_didHaveWindow` is `true` and `_view.Window` is `null`:

```csharp
if (handler == null || (_didHaveWindow && _view.Window == null))
{
    DisconnectGestures();
    return; // permanently disconnects gestures, never reconnects
}
```

During navigation pop, CollectionView item containers are temporarily detached from the visual tree. `WindowChanged` fires with null window, `_didHaveWindow` is true, so `DisconnectGestures()` runs and `SetupGestureManager()` returns early. After the pop completes and items are re-attached, the gesture handlers remain permanently disconnected.

**Impact:** All gesture recognizers inside CollectionView DataTemplate items (TapGestureRecognizer, SwipeGestureRecognizer, etc.) stop working after navigate+pop. Page-level gesture recognizers are not affected because they go through a full page reconstruction cycle, while CollectionView recycles existing item containers.

## Fix

When the handler is valid but the window is null during a navigation transition, do not disconnect gesture handlers. Reset `_didHaveWindow` so the gesture manager can fully reconnect when the view is re-attached to the visual tree.

```csharp
if (handler != null && _view.Window == null)
{
    // Navigation transition — keep existing gesture handlers connected
    _didHaveWindow = false;
    return;
}
```

Closes #218