### PR TITLE
Implement IWindow Lifecycle

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,6 +188,32 @@ Embedding mode also enables wrapping Avalonia controls into .NET MAUI views, wit
 
 `MauiAvaloniaApplication` listens to Avalonia's `ActualThemeVariantChanged` event and calls `Application.ThemeChanged()` on the .NET MAUI application when it fires. This keeps .NET MAUI's theme system in sync with the Avalonia theme.
 
+### Window and application lifecycle
+
+.NET MAUI's application lifecycle is window-driven: a platform host calls the `IWindow` lifecycle methods, which cascade to the `Application`. `IWindow.Created()` calls `Application.SendStart()` (`OnStart`), `IWindow.Resumed()` calls `SendResume()` (`OnResume`), and `IWindow.Stopped()` calls `SendSleep()` (`OnSleep`); `Activated`/`Deactivated`/`Destroying` raise the corresponding `Window` events.
+
+`WindowHandler` bridges this through `MauiWindowLifecycleManager`, which subscribes to the Avalonia window and forwards to the MAUI `IWindow`:
+
+| Avalonia window event | MAUI `IWindow` call | Application effect |
+|---|---|---|
+| `Opened` | `Created()` | `OnStart` |
+| `Activated` | `Activated()` | — |
+| `Deactivated` | `Deactivated()` | — |
+| `WindowState` → `Minimized` | `Stopped()` | `OnSleep` |
+| `WindowState` → restored from `Minimized` | `Resumed()` | `OnResume` |
+| `Closed` | `Destroying()` | window removed; handler disconnected |
+
+The manager tracks state so the calls stay well-ordered and idempotent (the MAUI methods throw on invalid transitions, such as activating an already-activated window). The Avalonia `Activated`/`Deactivated` events are not raised by the headless platform, so those forwards are exercised in tests through the manager's internal seam.
+
+Single-view lifetimes (for example browser) have no Avalonia `Window`, so there is no open/close or minimize/restore signal. `SingleViewWindowHandler` instead bridges through `MauiSingleViewLifecycleManager`, which subscribes to the root content control's `Loaded`/`Unloaded` events:
+
+| Avalonia control event | MAUI `IWindow` call | Application effect |
+|---|---|---|
+| `Loaded` | `Created()` | `OnStart` |
+| `Unloaded` | `Destroying()` | window removed; handler disconnected |
+
+Resume/sleep transitions (for example browser tab visibility) are not wired for single-view. Both managers share the same state machine and `IWindow`-forwarding logic in the `MauiWindowLifecycleDispatcher` base class; only the platform-event subscriptions differ.
+
 ### Lifecycle events
 
 `Avalonia.Controls.Maui` defines custom lifecycle events through `AvaloniaLifecycle` that can be subscribed to via `ConfigureLifecycleEvents`.
@@ -213,7 +239,7 @@ builder.ConfigureLifecycleEvents(events =>
 
 Additional delegates (`OnActivated`, `OnClosed`, `OnVisibilityChanged`, `OnResumed`, `OnPlatformMessage`) are defined in `AvaloniaLifecycle` but are not currently raised by the bootstrap/window pipeline in this repository.
 
-For single-view lifetimes (for example browser), `OnWindowCreated` is not raised because there is no `Window` instance, only a root `Control`.
+For single-view lifetimes (for example browser), this `AvaloniaLifecycle.OnWindowCreated` builder event is not raised because there is no `Window` instance, only a root `Control`. (This is distinct from the MAUI `IWindow.Created` lifecycle, which *is* bridged for single-view via the content control's `Loaded` event — see [Window and application lifecycle](#window-and-application-lifecycle) above.)
 
 ## Font system
 

--- a/src/Avalonia.Controls.Maui/Handlers/SingleViewWindowHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/SingleViewWindowHandler.cs
@@ -18,6 +18,12 @@ public partial class SingleViewWindowHandler : ElementHandler<IWindow, Avalonia.
 {
     static readonly AlertManager s_alertManager = new();
     ModalAnimationTrackingNavigation? _modalTracker;
+    MauiSingleViewLifecycleManager? _lifecycleManager;
+
+    /// <summary>
+    /// Gets the lifecycle manager for the <see cref="IWindow"/> MAUI lifecycle.
+    /// </summary>
+    internal MauiSingleViewLifecycleManager? LifecycleManager => _lifecycleManager;
 
     /// <summary>
     /// Property mapper for <see cref="SingleViewWindowHandler"/>.
@@ -74,6 +80,9 @@ public partial class SingleViewWindowHandler : ElementHandler<IWindow, Avalonia.
     {
         base.ConnectHandler(platformView);
 
+        // Bridge the single-view content lifecycle to the MAUI IWindow (and Application) lifecycle.
+        _lifecycleManager = new MauiSingleViewLifecycleManager(VirtualView, platformView);
+
         if (VirtualView is Microsoft.Maui.Controls.Window window)
         {
             window.AlertManager.Subscribe();
@@ -91,6 +100,9 @@ public partial class SingleViewWindowHandler : ElementHandler<IWindow, Avalonia.
     /// <inheritdoc/>
     protected override void DisconnectHandler(Avalonia.Controls.ContentControl platformView)
     {
+        _lifecycleManager?.Dispose();
+        _lifecycleManager = null;
+
         if (VirtualView is Microsoft.Maui.Controls.Window window)
         {
             window.AlertManager.Unsubscribe();

--- a/src/Avalonia.Controls.Maui/Handlers/WindowHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/WindowHandler.cs
@@ -21,6 +21,12 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
 {
     static readonly AlertManager s_alertManager = new();
     ModalAnimationTrackingNavigation? _modalTracker;
+    MauiWindowLifecycleManager? _lifecycleManager;
+
+    /// <summary>
+    /// Gets the lifecycle manager for the <see cref="IWindow"/> MAUI lifecycle.
+    /// </summary>
+    internal MauiWindowLifecycleManager? LifecycleManager => _lifecycleManager;
 
     /// <summary>
     /// Property mapper for <see cref="WindowHandler"/>.
@@ -98,6 +104,8 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
         platformView.Resized += OnAvaloniaWindowResized;
         platformView.PositionChanged += OnAvaloniaWindowPositionChanged;
 
+        _lifecycleManager = new MauiWindowLifecycleManager(VirtualView, platformView);
+
         if (VirtualView is Microsoft.Maui.Controls.Window window)
         {
             window.AlertManager.Subscribe();
@@ -119,6 +127,9 @@ public partial class WindowHandler : ElementHandler<IWindow, Avalonia.Controls.W
 
         platformView.Resized -= OnAvaloniaWindowResized;
         platformView.PositionChanged -= OnAvaloniaWindowPositionChanged;
+
+        _lifecycleManager?.Dispose();
+        _lifecycleManager = null;
 
         if (VirtualView is Microsoft.Maui.Controls.Window window)
         {

--- a/src/Avalonia.Controls.Maui/Platform/MauiSingleViewLifecycleManager.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiSingleViewLifecycleManager.cs
@@ -1,0 +1,53 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Microsoft.Maui;
+
+namespace Avalonia.Controls.Maui.Platform;
+
+/// <summary>
+/// Bridges a single-view (browser/embedded) Avalonia <see cref="Control"/>'s lifecycle to the MAUI
+/// <see cref="IWindow"/> lifecycle.
+/// </summary>
+/// <remarks>
+/// Single-view lifetimes have no Avalonia <see cref="Window"/>, so there is no open/close or minimize/restore
+/// signal. Instead the root content's <see cref="Control.Loaded"/>/<see cref="Control.Unloaded"/> events are used:
+/// loading the view maps to <see cref="IWindow.Created"/> (which starts the MAUI application) and unloading maps to
+/// <see cref="IWindow.Destroying"/>. Resume/sleep transitions (for example browser tab visibility) are not wired,
+/// State tracking and ordering live in <see cref="MauiWindowLifecycleDispatcher"/>.
+/// </remarks>
+internal sealed class MauiSingleViewLifecycleManager : MauiWindowLifecycleDispatcher
+{
+    private readonly Control _platformView;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MauiSingleViewLifecycleManager"/> class and subscribes
+    /// to the lifecycle events of the supplied single-view content control.
+    /// </summary>
+    /// <param name="virtualView">The MAUI window to forward lifecycle calls to.</param>
+    /// <param name="platformView">The single-view content control whose lifecycle drives the MAUI window.</param>
+    public MauiSingleViewLifecycleManager(IWindow virtualView, Control platformView)
+        : base(virtualView)
+    {
+        _platformView = platformView;
+
+        platformView.Loaded += OnLoaded;
+        platformView.Unloaded += OnUnloaded;
+
+        // The handler may connect after the content is already loaded; treat that as creation.
+        if (platformView.IsLoaded)
+        {
+            NotifyCreated();
+        }
+    }
+
+    private void OnLoaded(object? sender, RoutedEventArgs e) => NotifyCreated();
+
+    private void OnUnloaded(object? sender, RoutedEventArgs e) => NotifyDestroying();
+
+    /// <inheritdoc/>
+    public override void Dispose()
+    {
+        _platformView.Loaded -= OnLoaded;
+        _platformView.Unloaded -= OnUnloaded;
+    }
+}

--- a/src/Avalonia.Controls.Maui/Platform/MauiWindowLifecycleDispatcher.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiWindowLifecycleDispatcher.cs
@@ -1,0 +1,132 @@
+using Microsoft.Maui;
+using System;
+
+namespace Avalonia.Controls.Maui.Platform;
+
+/// <summary>
+/// Shared state machine that forwards platform lifecycle transitions to a MAUI <see cref="IWindow"/>.
+/// </summary>
+/// <remarks>
+/// MAUI's window lifecycle methods drive both the MAUI window events and the MAUI
+/// <see cref="Microsoft.Maui.Controls.Application"/> lifecycle: <see cref="IWindow.Created"/> calls
+/// <c>OnStart</c>, <see cref="IWindow.Resumed"/> calls <c>OnResume</c> and <see cref="IWindow.Stopped"/>
+/// calls <c>OnSleep</c>. Those methods throw when invoked in an invalid order (for example activating an
+/// already-activated window), so this base tracks state to keep the calls well-ordered and idempotent.
+/// Subclasses subscribe to a concrete platform view and translate its events into the <c>Notify*</c> calls.
+/// </remarks>
+internal abstract class MauiWindowLifecycleDispatcher : IDisposable
+{
+    private readonly IWindow _virtualView;
+    private bool _isCreated;
+    private bool _isActivated;
+    private bool _isDestroyed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MauiWindowLifecycleDispatcher"/> class.
+    /// </summary>
+    /// <param name="virtualView">The MAUI window to forward lifecycle calls to.</param>
+    protected MauiWindowLifecycleDispatcher(IWindow virtualView)
+    {
+        _virtualView = virtualView;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="IWindow.Created"/> has been raised.
+    /// </summary>
+    protected bool IsCreated => _isCreated;
+
+    /// <summary>
+    /// Raises <see cref="IWindow.Created"/> once, which also starts the MAUI application.
+    /// </summary>
+    internal void NotifyCreated()
+    {
+        if (_isCreated)
+        {
+            return;
+        }
+
+        _isCreated = true;
+        _virtualView.Created();
+    }
+
+    /// <summary>
+    /// Raises <see cref="IWindow.Activated"/>, ensuring the window has been created first.
+    /// </summary>
+    internal void NotifyActivated()
+    {
+        if (_isActivated || _isDestroyed)
+        {
+            return;
+        }
+
+        NotifyCreated();
+        _isActivated = true;
+        _virtualView.Activated();
+    }
+
+    /// <summary>
+    /// Raises <see cref="IWindow.Deactivated"/> when the window is currently activated.
+    /// </summary>
+    internal void NotifyDeactivated()
+    {
+        if (!_isActivated)
+        {
+            return;
+        }
+
+        _isActivated = false;
+        _virtualView.Deactivated();
+    }
+
+    /// <summary>
+    /// Raises <see cref="IWindow.Stopped"/>, which puts the MAUI application to sleep.
+    /// </summary>
+    internal void NotifyStopped()
+    {
+        if (!_isCreated || _isDestroyed)
+        {
+            return;
+        }
+
+        _virtualView.Stopped();
+    }
+
+    /// <summary>
+    /// Raises <see cref="IWindow.Resumed"/>, which resumes the MAUI application.
+    /// </summary>
+    internal void NotifyResumed()
+    {
+        if (!_isCreated || _isDestroyed)
+        {
+            return;
+        }
+
+        _virtualView.Resumed();
+    }
+
+    /// <summary>
+    /// Raises <see cref="IWindow.Destroying"/> once, deactivating the window first if needed.
+    /// </summary>
+    internal void NotifyDestroying()
+    {
+        if (_isDestroyed)
+        {
+            return;
+        }
+
+        _isDestroyed = true;
+
+        if (_isActivated)
+        {
+            _isActivated = false;
+            _virtualView.Deactivated();
+        }
+
+        _virtualView.Destroying();
+    }
+
+    /// <summary>
+    /// Unsubscribes from the platform view's lifecycle events.
+    /// </summary>
+    public abstract void Dispose();
+}

--- a/src/Avalonia.Controls.Maui/Platform/MauiWindowLifecycleManager.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiWindowLifecycleManager.cs
@@ -1,0 +1,81 @@
+using Avalonia.Controls;
+using Microsoft.Maui;
+using System;
+
+namespace Avalonia.Controls.Maui.Platform;
+
+/// <summary>
+/// Bridges an Avalonia <see cref="Window"/>'s lifecycle to the MAUI <see cref="IWindow"/> lifecycle.
+/// </summary>
+internal sealed class MauiWindowLifecycleManager : MauiWindowLifecycleDispatcher
+{
+    private readonly Window _platformView;
+    private bool _isMinimized;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MauiWindowLifecycleManager"/> class and subscribes
+    /// to the lifecycle events of the supplied Avalonia window.
+    /// </summary>
+    /// <param name="virtualView">The MAUI window to forward lifecycle calls to.</param>
+    /// <param name="platformView">The Avalonia window whose lifecycle drives the MAUI window.</param>
+    public MauiWindowLifecycleManager(IWindow virtualView, Window platformView)
+        : base(virtualView)
+    {
+        _platformView = platformView;
+        _isMinimized = platformView.WindowState == WindowState.Minimized;
+
+        platformView.Opened += OnOpened;
+        platformView.Activated += OnActivated;
+        platformView.Deactivated += OnDeactivated;
+        platformView.Closed += OnClosed;
+        platformView.PropertyChanged += OnPlatformPropertyChanged;
+
+        // The handler may connect after the window is already shown; treat that as creation.
+        if (platformView.IsVisible)
+        {
+            NotifyCreated();
+        }
+    }
+
+    private void OnOpened(object? sender, EventArgs e) => NotifyCreated();
+
+    private void OnActivated(object? sender, EventArgs e) => NotifyActivated();
+
+    private void OnDeactivated(object? sender, EventArgs e) => NotifyDeactivated();
+
+    private void OnClosed(object? sender, EventArgs e) => NotifyDestroying();
+
+    private void OnPlatformPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.Property != Window.WindowStateProperty)
+        {
+            return;
+        }
+
+        var minimized = e.GetNewValue<WindowState>() == WindowState.Minimized;
+        if (minimized == _isMinimized)
+        {
+            return;
+        }
+
+        _isMinimized = minimized;
+        if (minimized)
+        {
+            NotifyStopped();
+        }
+        else
+        {
+            NotifyResumed();
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void Dispose()
+    {
+        _platformView.Opened -= OnOpened;
+        _platformView.Activated -= OnActivated;
+        _platformView.Deactivated -= OnDeactivated;
+        _platformView.Closed -= OnClosed;
+        _platformView.PropertyChanged -= OnPlatformPropertyChanged;
+    }
+}

--- a/src/Avalonia.Controls.Maui/Platform/MauiWindowLifecycleManager.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiWindowLifecycleManager.cs
@@ -33,11 +33,26 @@ internal sealed class MauiWindowLifecycleManager : MauiWindowLifecycleDispatcher
         // The handler may connect after the window is already shown; treat that as creation.
         if (platformView.IsVisible)
         {
-            NotifyCreated();
+            HandleShown();
         }
     }
 
-    private void OnOpened(object? sender, EventArgs e) => NotifyCreated();
+    private void OnOpened(object? sender, EventArgs e) => HandleShown();
+
+    private void HandleShown()
+    {
+        var firstCreate = !IsCreated;
+        NotifyCreated();
+
+        // A window that opens while already minimized must still go through Stopped so that a later
+        // restore produces a matching Resumed (MAUI raises Resumed/Stopped without ordering guards,
+        // but emitting Resumed with no preceding Stopped would be an asymmetric lifecycle). Gate on
+        // the first creation so the Stopped is not re-sent if HandleShown runs again.
+        if (firstCreate && _isMinimized)
+        {
+            NotifyStopped();
+        }
+    }
 
     private void OnActivated(object? sender, EventArgs e) => NotifyActivated();
 

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/SingleViewLifecycleTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/SingleViewLifecycleTests.cs
@@ -94,6 +94,7 @@ public class SingleViewLifecycleTests : HandlerTestBase
             harness.Window.Destroying += (_, _) => destroying++;
 
             host.Content = null;
+            Dispatcher.UIThread.RunJobs();
 
             Assert.Equal(1, destroying);
 
@@ -114,6 +115,7 @@ public class SingleViewLifecycleTests : HandlerTestBase
 
             // Detach and reattach the content; Created/OnStart must not fire again.
             host.Content = null;
+            Dispatcher.UIThread.RunJobs();
             host.Content = harness.Content;
             Dispatcher.UIThread.RunJobs();
 

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/SingleViewLifecycleTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/SingleViewLifecycleTests.cs
@@ -1,0 +1,126 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Maui.Platform;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Maui;
+using MauiApplication = Microsoft.Maui.Controls.Application;
+using MauiContentPage = Microsoft.Maui.Controls.ContentPage;
+using MauiWindow = Microsoft.Maui.Controls.Window;
+using SingleViewWindowHandler = Avalonia.Controls.Maui.Handlers.SingleViewWindowHandler;
+
+namespace Avalonia.Controls.Maui.Tests.Handlers;
+
+/// <summary>
+/// Verifies that the single-view (browser/embedded) content lifecycle is bridged to MAUI's
+/// <see cref="IWindow"/> lifecycle, which in turn drives the MAUI application lifecycle.
+/// </summary>
+public class SingleViewLifecycleTests : HandlerTestBase
+{
+    private sealed class LifecycleTestApplication : MauiApplication
+    {
+        public int StartCount { get; private set; }
+
+        protected override void OnStart() => StartCount++;
+    }
+
+    private sealed class LifecycleHarness
+    {
+        public required SingleViewWindowHandler Handler { get; init; }
+        public required MauiWindow Window { get; init; }
+        public required MauiAvaloniaContent Content { get; init; }
+        public required LifecycleTestApplication App { get; init; }
+    }
+
+    private LifecycleHarness CreateHarness()
+    {
+        var app = new LifecycleTestApplication();
+        var page = new MauiContentPage();
+        var window = new MauiWindow(page);
+
+        // Window.Application resolves from the logical parent; parenting the window to the
+        // application is what lets IWindow.Created() cascade to the app.
+        window.Parent = app;
+
+        var handler = new SingleViewWindowHandler();
+        handler.SetMauiContext(MauiContext);
+        window.Handler = handler;
+        handler.SetVirtualView(window);
+
+        var content = (MauiAvaloniaContent)handler.PlatformView!;
+
+        return new LifecycleHarness
+        {
+            Handler = handler,
+            Window = window,
+            Content = content,
+            App = app,
+        };
+    }
+
+    [AvaloniaFact(DisplayName = "Loading the single-view content raises Window.Created and Application.OnStart")]
+    public async Task LoadingContentRaisesCreatedAndStart()
+    {
+        await InvokeOnMainThreadAsync(() =>
+        {
+            var harness = CreateHarness();
+            var created = 0;
+            harness.Window.Created += (_, _) => created++;
+
+            // Attach the single-view content to a live visual tree so Loaded fires.
+            var host = new Window { Width = 400, Height = 300, Content = harness.Content };
+            host.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(1, created);
+            Assert.Equal(1, harness.App.StartCount);
+
+            host.Content = null;
+            host.Close();
+        });
+    }
+
+    [AvaloniaFact(DisplayName = "Unloading the single-view content raises Window.Destroying")]
+    public async Task UnloadingContentRaisesDestroying()
+    {
+        await InvokeOnMainThreadAsync(() =>
+        {
+            var harness = CreateHarness();
+
+            var host = new Window { Width = 400, Height = 300, Content = harness.Content };
+            host.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var destroying = 0;
+            harness.Window.Destroying += (_, _) => destroying++;
+
+            host.Content = null;
+
+            Assert.Equal(1, destroying);
+
+            host.Close();
+        });
+    }
+
+    [AvaloniaFact(DisplayName = "Application.OnStart is only raised once when the content reloads")]
+    public async Task StartIsRaisedOnce()
+    {
+        await InvokeOnMainThreadAsync(() =>
+        {
+            var harness = CreateHarness();
+
+            var host = new Window { Width = 400, Height = 300, Content = harness.Content };
+            host.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            // Detach and reattach the content; Created/OnStart must not fire again.
+            host.Content = null;
+            host.Content = harness.Content;
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(1, harness.App.StartCount);
+
+            host.Content = null;
+            host.Close();
+        });
+    }
+}

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/WindowLifecycleTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/WindowLifecycleTests.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Controls.Maui.Platform;
 using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
 using Microsoft.Maui;
 using MauiApplication = Microsoft.Maui.Controls.Application;
 using MauiContentPage = Microsoft.Maui.Controls.ContentPage;
@@ -70,6 +71,7 @@ public class WindowLifecycleTests : HandlerTestBase
             harness.Window.Created += (_, _) => created++;
 
             harness.Platform.Show();
+            Dispatcher.UIThread.RunJobs();
 
             Assert.Equal(1, created);
             Assert.Equal(1, harness.App.StartCount);
@@ -85,6 +87,7 @@ public class WindowLifecycleTests : HandlerTestBase
         {
             var harness = CreateHarness();
             harness.Platform.Show();
+            Dispatcher.UIThread.RunJobs();
 
             var stopped = 0;
             harness.Window.Stopped += (_, _) => stopped++;
@@ -105,6 +108,7 @@ public class WindowLifecycleTests : HandlerTestBase
         {
             var harness = CreateHarness();
             harness.Platform.Show();
+            Dispatcher.UIThread.RunJobs();
             harness.Platform.WindowState = WindowState.Minimized;
 
             var resumed = 0;
@@ -126,6 +130,7 @@ public class WindowLifecycleTests : HandlerTestBase
         {
             var harness = CreateHarness();
             harness.Platform.Show();
+            Dispatcher.UIThread.RunJobs();
 
             var destroying = 0;
             harness.Window.Destroying += (_, _) => destroying++;
@@ -133,6 +138,38 @@ public class WindowLifecycleTests : HandlerTestBase
             harness.Platform.Close();
 
             Assert.Equal(1, destroying);
+        });
+    }
+
+    [AvaloniaFact(DisplayName = "A window opened while minimized raises Stopped so a later restore is symmetric")]
+    public async Task WindowOpenedWhileMinimizedRaisesStoppedThenResumed()
+    {
+        await InvokeOnMainThreadAsync(() =>
+        {
+            var harness = CreateHarness();
+
+            var stopped = 0;
+            var resumed = 0;
+            harness.Window.Stopped += (_, _) => stopped++;
+            harness.Window.Resumed += (_, _) => resumed++;
+
+            // Open the window already minimized; Created must be followed by a Stopped so that the
+            // later restore produces a matching Resumed rather than an orphaned one.
+            harness.Platform.WindowState = WindowState.Minimized;
+            harness.Platform.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(1, stopped);
+            Assert.Equal(1, harness.App.SleepCount);
+            Assert.Equal(0, resumed);
+
+            harness.Platform.WindowState = WindowState.Normal;
+
+            Assert.Equal(1, resumed);
+            Assert.Equal(1, harness.App.ResumeCount);
+            Assert.Equal(1, stopped);
+
+            harness.Platform.Close();
         });
     }
 

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/WindowLifecycleTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/WindowLifecycleTests.cs
@@ -1,0 +1,188 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Maui.Platform;
+using Avalonia.Headless.XUnit;
+using Microsoft.Maui;
+using MauiApplication = Microsoft.Maui.Controls.Application;
+using MauiContentPage = Microsoft.Maui.Controls.ContentPage;
+using MauiWindow = Microsoft.Maui.Controls.Window;
+using WindowHandler = Avalonia.Controls.Maui.Handlers.WindowHandler;
+
+namespace Avalonia.Controls.Maui.Tests.Handlers;
+
+/// <summary>
+/// Verifies that the Avalonia window lifecycle is bridged to MAUI's <see cref="IWindow"/> lifecycle,
+/// which in turn drives the MAUI <see cref="MauiApplication"/> lifecycle (OnStart/OnResume/OnSleep).
+/// </summary>
+public class WindowLifecycleTests : HandlerTestBase
+{
+    private sealed class LifecycleTestApplication : MauiApplication
+    {
+        public int StartCount { get; private set; }
+        public int ResumeCount { get; private set; }
+        public int SleepCount { get; private set; }
+
+        protected override void OnStart() => StartCount++;
+        protected override void OnResume() => ResumeCount++;
+        protected override void OnSleep() => SleepCount++;
+    }
+
+    private sealed class LifecycleHarness
+    {
+        public required WindowHandler Handler { get; init; }
+        public required MauiWindow Window { get; init; }
+        public required MauiAvaloniaWindow Platform { get; init; }
+        public required LifecycleTestApplication App { get; init; }
+    }
+
+    private LifecycleHarness CreateHarness()
+    {
+        var app = new LifecycleTestApplication();
+        var page = new MauiContentPage();
+        var window = new MauiWindow(page) { Width = 400, Height = 300 };
+
+        // Window.Application resolves from the logical parent; parenting the window to the
+        // application is what lets IWindow.Created()/Stopped()/Resumed() cascade to the app.
+        window.Parent = app;
+
+        var handler = new WindowHandler();
+        handler.SetMauiContext(MauiContext);
+        window.Handler = handler;
+        handler.SetVirtualView(window);
+
+        var platform = (MauiAvaloniaWindow)handler.PlatformView!;
+
+        return new LifecycleHarness
+        {
+            Handler = handler,
+            Window = window,
+            Platform = platform,
+            App = app,
+        };
+    }
+
+    [AvaloniaFact(DisplayName = "Opening the window raises Window.Created and Application.OnStart")]
+    public async Task OpeningWindowRaisesCreatedAndStart()
+    {
+        await InvokeOnMainThreadAsync(() =>
+        {
+            var harness = CreateHarness();
+            var created = 0;
+            harness.Window.Created += (_, _) => created++;
+
+            harness.Platform.Show();
+
+            Assert.Equal(1, created);
+            Assert.Equal(1, harness.App.StartCount);
+
+            harness.Platform.Close();
+        });
+    }
+
+    [AvaloniaFact(DisplayName = "Minimizing the window raises Window.Stopped and Application.OnSleep")]
+    public async Task MinimizingWindowRaisesStoppedAndSleep()
+    {
+        await InvokeOnMainThreadAsync(() =>
+        {
+            var harness = CreateHarness();
+            harness.Platform.Show();
+
+            var stopped = 0;
+            harness.Window.Stopped += (_, _) => stopped++;
+
+            harness.Platform.WindowState = WindowState.Minimized;
+
+            Assert.Equal(1, stopped);
+            Assert.Equal(1, harness.App.SleepCount);
+
+            harness.Platform.Close();
+        });
+    }
+
+    [AvaloniaFact(DisplayName = "Restoring a minimized window raises Window.Resumed and Application.OnResume")]
+    public async Task RestoringWindowRaisesResumedAndResume()
+    {
+        await InvokeOnMainThreadAsync(() =>
+        {
+            var harness = CreateHarness();
+            harness.Platform.Show();
+            harness.Platform.WindowState = WindowState.Minimized;
+
+            var resumed = 0;
+            harness.Window.Resumed += (_, _) => resumed++;
+
+            harness.Platform.WindowState = WindowState.Normal;
+
+            Assert.Equal(1, resumed);
+            Assert.Equal(1, harness.App.ResumeCount);
+
+            harness.Platform.Close();
+        });
+    }
+
+    [AvaloniaFact(DisplayName = "Closing the window raises Window.Destroying")]
+    public async Task ClosingWindowRaisesDestroying()
+    {
+        await InvokeOnMainThreadAsync(() =>
+        {
+            var harness = CreateHarness();
+            harness.Platform.Show();
+
+            var destroying = 0;
+            harness.Window.Destroying += (_, _) => destroying++;
+
+            harness.Platform.Close();
+
+            Assert.Equal(1, destroying);
+        });
+    }
+
+    // Avalonia's headless platform does not raise Activated/Deactivated focus events, so these
+    // are driven through the lifecycle manager seam that the real platform events also call.
+    [AvaloniaFact(DisplayName = "Activation forwards to Window.Activated and Window.Deactivated")]
+    public async Task ActivationForwardsToWindow()
+    {
+        await InvokeOnMainThreadAsync(() =>
+        {
+            var harness = CreateHarness();
+            harness.Platform.Show();
+
+            var activated = 0;
+            var deactivated = 0;
+            harness.Window.Activated += (_, _) => activated++;
+            harness.Window.Deactivated += (_, _) => deactivated++;
+
+            var manager = harness.Handler.LifecycleManager!;
+
+            manager.NotifyActivated();
+            Assert.Equal(1, activated);
+            Assert.True(harness.Window.IsActivated);
+
+            manager.NotifyDeactivated();
+            Assert.Equal(1, deactivated);
+            Assert.False(harness.Window.IsActivated);
+
+            harness.Platform.Close();
+        });
+    }
+
+    [AvaloniaFact(DisplayName = "Repeated activation does not raise Window.Activated twice")]
+    public async Task RepeatedActivationIsIdempotent()
+    {
+        await InvokeOnMainThreadAsync(() =>
+        {
+            var harness = CreateHarness();
+            harness.Platform.Show();
+
+            var activated = 0;
+            harness.Window.Activated += (_, _) => activated++;
+
+            var manager = harness.Handler.LifecycleManager!;
+            manager.NotifyActivated();
+            manager.NotifyActivated();
+
+            Assert.Equal(1, activated);
+
+            harness.Platform.Close();
+        });
+    }
+}


### PR DESCRIPTION
Fixes #216 

The `IWindow` lifecycle was not implemented for Avalonia Windows and the Single-View Lifecycle. This implements the calls so the IWindow interface should be respected and call those lifecycle events. It should also handle the linked issue, since the base MAUI IWindow implementation calls the [internal Application methods](https://github.com/dotnet/maui/blob/bb4e7040aeac43502dc7d07133f615cee8e51dc3/src/Controls/src/Core/Window/Window.cs#L509-L520) as part of the Window lifecycle.