### PR TITLE
Loosen AvaloniaContentPage to AvaloniaPage for TabbedPage/StackedNavigation

### DIFF
--- a/src/Avalonia.Controls.Maui/Extensions/TabbedPageExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/TabbedPageExtensions.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Platform;
-using AvaloniaContentPage = Avalonia.Controls.ContentPage;
 using AvaloniaImage = Avalonia.Controls.Image;
 using AvaloniaPage = Avalonia.Controls.Page;
 using AvaloniaTabbedPage = Avalonia.Controls.TabbedPage;
@@ -115,7 +114,7 @@ public static class TabbedPageExtensions
 
         foreach (var page in mauiTabbedPage.Children)
         {
-            var wrappedPage = (AvaloniaContentPage)page.ToPlatform(mauiContext);
+            var wrappedPage = (AvaloniaPage)page.ToPlatform(mauiContext);
             wrappedPage.Header = CreateTabHeader(page);
             pages.Add(wrappedPage);
             pagesToLoadIcons.Add((wrappedPage, page));

--- a/src/Avalonia.Controls.Maui/Handlers/Shell/ShellStackNavigationManager.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shell/ShellStackNavigationManager.cs
@@ -3,7 +3,7 @@ using Avalonia.Controls.Maui.Animations;
 using Avalonia.Controls.Maui.Platform;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
-using AvaloniaContentPage = Avalonia.Controls.ContentPage;
+using AvaloniaPage = Avalonia.Controls.Page;
 using AvaloniaNavigationPage = Avalonia.Controls.NavigationPage;
 using MauiShell = Microsoft.Maui.Controls.Shell;
 
@@ -37,7 +37,7 @@ internal class ShellStackNavigationManager : StackNavigationManager
     }
 
     /// <inheritdoc/>
-    protected override AvaloniaContentPage WrapPage(IView mauiPage)
+    protected override AvaloniaPage WrapPage(IView mauiPage)
     {
         var page = base.WrapPage(mauiPage);
         // Shell manages the nav bar; hide it on individual pages.

--- a/src/Avalonia.Controls.Maui/Platform/StackNavigationManager.cs
+++ b/src/Avalonia.Controls.Maui/Platform/StackNavigationManager.cs
@@ -617,7 +617,15 @@ public class StackNavigationManager
     /// </remarks>
     protected virtual AvaloniaPage WrapPage(IView mauiPage)
     {
-        return (AvaloniaPage)mauiPage.ToPlatform(MauiContext);
+        var platformPage = (AvaloniaPage)mauiPage.ToPlatform(MauiContext);
+
+        // The NavigationPage title bar binds to CurrentPage.Header. ContentPage gets its Header
+        // set from Title by PageHandler.MapTitle, but other page types don't map Title -> Header, so fall back to the MAUI Title here to avoid
+        // a blank navigation title.
+        if (platformPage.Header is null && mauiPage is MauiPage { Title.Length: > 0 } page)
+            platformPage.Header = page.Title;
+
+        return platformPage;
     }
 
     /// <summary>

--- a/src/Avalonia.Controls.Maui/Platform/StackNavigationManager.cs
+++ b/src/Avalonia.Controls.Maui/Platform/StackNavigationManager.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using AvaloniaContentPage = Avalonia.Controls.ContentPage;
+using AvaloniaPage = Avalonia.Controls.Page;
 using AvaloniaNavigationPage = Avalonia.Controls.NavigationPage;
 using MauiPage = Microsoft.Maui.Controls.Page;
 using MauiElement = Microsoft.Maui.Controls.Element;
@@ -410,11 +411,11 @@ public class StackNavigationManager
         if (_navigationPage == null) return;
 
         // Build the target list of wrapped pages
-        var targetWrapped = new List<AvaloniaContentPage>(targetMauiStack.Count);
+        var targetWrapped = new List<AvaloniaPage>(targetMauiStack.Count);
         for (int i = 0; i < targetMauiStack.Count; i++)
             targetWrapped.Add(WrapPage(targetMauiStack[i]));
 
-        var targetSet = new HashSet<AvaloniaContentPage>(targetWrapped);
+        var targetSet = new HashSet<AvaloniaPage>(targetWrapped);
 
         var avaloniaStack = _navigationPage.NavigationStack;
         var avaloniaTop = avaloniaStack.Count > 0 ? avaloniaStack[^1] : null;
@@ -606,13 +607,17 @@ public class StackNavigationManager
     }
 
     /// <summary>
-    /// Wraps a MAUI page as an Avalonia ContentPage. Override to customize page setup (e.g. hiding the navigation bar).
+    /// Wraps a MAUI page as an Avalonia page. Override to customize page setup (e.g. hiding the navigation bar).
     /// </summary>
     /// <param name="mauiPage">The MAUI page to wrap.</param>
-    /// <returns>The Avalonia ContentPage.</returns>
-    protected virtual AvaloniaContentPage WrapPage(IView mauiPage)
+    /// <returns>The Avalonia page.</returns>
+    /// <remarks>
+    /// A navigation stack may hold any <see cref="MauiPage"/> (ContentPage, TabbedPage, nested NavigationPage, ...),
+    /// so the platform view is returned as the base <see cref="AvaloniaPage"/> rather than assuming a ContentPage.
+    /// </remarks>
+    protected virtual AvaloniaPage WrapPage(IView mauiPage)
     {
-        return (AvaloniaContentPage)mauiPage.ToPlatform(MauiContext);
+        return (AvaloniaPage)mauiPage.ToPlatform(MauiContext);
     }
 
     /// <summary>

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/NavigationPageHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/NavigationPageHandlerTests.cs
@@ -458,7 +458,12 @@ namespace Avalonia.Controls.Maui.Tests.Handlers
 
                 Assert.Equal(2, navigationPage.Navigation.NavigationStack.Count);
                 Assert.Equal(tabbedPage, navigationPage.CurrentPage);
-                Assert.IsType<AvaloniaTabbedPage>(handler.PlatformView.NavigationStack[^1]);
+
+                var platformTop = handler.PlatformView.NavigationStack[^1];
+                Assert.IsType<AvaloniaTabbedPage>(platformTop);
+                // The nav bar title binds to CurrentPage.Header; a non-ContentPage must still
+                // carry its Title there so the title isn't blank.
+                Assert.Equal("Tabs", platformTop.Header);
             });
         }
 

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/NavigationPageHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/NavigationPageHandlerTests.cs
@@ -6,8 +6,10 @@ using Avalonia.Media;
 using MauiColors = Microsoft.Maui.Graphics.Colors;
 using MauiContentPage = Microsoft.Maui.Controls.ContentPage;
 using MauiNavigationPage = Microsoft.Maui.Controls.NavigationPage;
+using MauiTabbedPage = Microsoft.Maui.Controls.TabbedPage;
 using MauiFlyoutPage = Microsoft.Maui.Controls.FlyoutPage;
 using AvaloniaNavigationPage = Avalonia.Controls.NavigationPage;
+using AvaloniaTabbedPage = Avalonia.Controls.TabbedPage;
 
 namespace Avalonia.Controls.Maui.Tests.Handlers
 {
@@ -435,6 +437,44 @@ namespace Avalonia.Controls.Maui.Tests.Handlers
                 // MAUI stack should be synced back to 1
                 Assert.Single(navigationPage.Navigation.NavigationStack);
                 Assert.Equal(rootPage, navigationPage.CurrentPage);
+            });
+        }
+
+        [AvaloniaFact(DisplayName = "Push TabbedPage Onto Stack Does Not Throw")]
+        public async Task Push_TabbedPage_Onto_Stack_Does_Not_Throw()
+        {
+            var rootPage = new PageStub { Title = "Root" };
+            var navigationPage = new MauiNavigationPage(rootPage);
+
+            var handler = await CreateHandlerAsync<NavigationViewHandler>(navigationPage);
+
+            await InvokeOnMainThreadAsync(async () =>
+            {
+                var tabbedPage = new MauiTabbedPage { Title = "Tabs" };
+                tabbedPage.Children.Add(new MauiContentPage { Title = "Tab 1" });
+
+                // A NavigationPage stack may hold any Page, not just ContentPage.
+                await navigationPage.PushAsync(tabbedPage);
+
+                Assert.Equal(2, navigationPage.Navigation.NavigationStack.Count);
+                Assert.Equal(tabbedPage, navigationPage.CurrentPage);
+                Assert.IsType<AvaloniaTabbedPage>(handler.PlatformView.NavigationStack[^1]);
+            });
+        }
+
+        [AvaloniaFact(DisplayName = "NavigationPage With TabbedPage Root Wraps As TabbedPage")]
+        public async Task NavigationPage_With_TabbedPage_Root_Wraps_As_TabbedPage()
+        {
+            var tabbedRoot = new MauiTabbedPage { Title = "Tabs" };
+            tabbedRoot.Children.Add(new MauiContentPage { Title = "Tab 1" });
+            var navigationPage = new MauiNavigationPage(tabbedRoot);
+
+            var handler = await CreateHandlerAsync<NavigationViewHandler>(navigationPage);
+
+            await InvokeOnMainThreadAsync(() =>
+            {
+                Assert.Single(navigationPage.Navigation.NavigationStack);
+                Assert.IsType<AvaloniaTabbedPage>(handler.PlatformView.NavigationStack[^1]);
             });
         }
 

--- a/tests/Avalonia.Controls.Maui.Tests/Handlers/TabbedPageHandlerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Handlers/TabbedPageHandlerTests.cs
@@ -8,11 +8,13 @@ using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using AvaloniaImage = Avalonia.Controls.Image;
 using AvaloniaTabbedPage = Avalonia.Controls.TabbedPage;
+using AvaloniaNavigationPage = Avalonia.Controls.NavigationPage;
 using AvaloniaStackPanel = Avalonia.Controls.StackPanel;
 using AvaloniaTextBlock = Avalonia.Controls.TextBlock;
 using AvaloniaWindow = Avalonia.Controls.Window;
 using MauiTabbedPage = Microsoft.Maui.Controls.TabbedPage;
 using MauiContentPage = Microsoft.Maui.Controls.ContentPage;
+using MauiNavigationPage = Microsoft.Maui.Controls.NavigationPage;
 using MauiPage = Microsoft.Maui.Controls.Page;
 
 namespace Avalonia.Controls.Maui.Tests.Handlers;
@@ -278,6 +280,71 @@ public class TabbedPageHandlerTests : HandlerTestBase<TabbedPageHandler, TabbedP
             Assert.Equal("Tab 1", stub.Children[0].Title);
             Assert.Equal("Tab 2", stub.Children[1].Title);
             Assert.Equal("Tab 3", stub.Children[2].Title);
+        });
+    }
+
+    [AvaloniaFact(DisplayName = "NavigationPage Child Creates Navigation Platform Page")]
+    public async Task NavigationPage_Child_Creates_Navigation_Platform_Page()
+    {
+        EnsureHandlerCreated();
+
+        await InvokeOnMainThreadAsync(() =>
+        {
+            var stub = new TabbedPageStub();
+            stub.Children.Add(new MauiNavigationPage(new MauiContentPage { Title = "Root" }) { Title = "Nav" });
+
+            var handler = CreateHandler<TabbedPageHandler>(stub);
+
+            var platformPage = handler.PlatformView.Pages!.Single();
+            Assert.IsType<AvaloniaNavigationPage>(platformPage);
+            Assert.Equal("Nav", platformPage.Header);
+        });
+    }
+
+    [AvaloniaFact(DisplayName = "Nested TabbedPage Child Creates TabbedPage Platform Page")]
+    public async Task Nested_TabbedPage_Child_Creates_TabbedPage_Platform_Page()
+    {
+        EnsureHandlerCreated();
+
+        await InvokeOnMainThreadAsync(() =>
+        {
+            var nested = new MauiTabbedPage { Title = "Tabs" };
+            nested.Children.Add(new MauiContentPage { Title = "Inner A" });
+            nested.Children.Add(new MauiContentPage { Title = "Inner B" });
+
+            var stub = new TabbedPageStub();
+            stub.Children.Add(nested);
+
+            var handler = CreateHandler<TabbedPageHandler>(stub);
+
+            var platformPage = handler.PlatformView.Pages!.Single();
+            Assert.IsType<AvaloniaTabbedPage>(platformPage);
+            Assert.Equal("Tabs", platformPage.Header);
+        });
+    }
+
+    [AvaloniaFact(DisplayName = "Mixed Page Type Children Create Pages Of Matching Types")]
+    public async Task Mixed_Page_Type_Children_Create_Pages_Of_Matching_Types()
+    {
+        EnsureHandlerCreated();
+
+        await InvokeOnMainThreadAsync(() =>
+        {
+            var nested = new MauiTabbedPage { Title = "Tabs" };
+            nested.Children.Add(new MauiContentPage { Title = "Inner A" });
+
+            var stub = new TabbedPageStub();
+            stub.Children.Add(new MauiContentPage { Title = "Content" });
+            stub.Children.Add(new MauiNavigationPage(new MauiContentPage { Title = "Root" }) { Title = "Nav" });
+            stub.Children.Add(nested);
+
+            var handler = CreateHandler<TabbedPageHandler>(stub);
+
+            var pages = handler.PlatformView.Pages!.ToList();
+            Assert.Equal(3, pages.Count);
+            Assert.IsType<Avalonia.Controls.ContentPage>(pages[0]);
+            Assert.IsType<AvaloniaNavigationPage>(pages[1]);
+            Assert.IsType<AvaloniaTabbedPage>(pages[2]);
         });
     }
 


### PR DESCRIPTION
Fixes #215 

TabbedPage and StackedNavigation were too strict in guarding what was supported. It should be a base-level `AvaloniaPage`. 

