### PR TITLE
Bump to 12.1, add Avalonia.WinUI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
     <PropertyGroup>
         <!-- <AvaloniaVersion>9999.0.0-localbuild</AvaloniaVersion> -->
         <IsPackable>false</IsPackable>
-        <AvaloniaVersion Condition="'$(AvaloniaVersion)' == ''">12.0.3</AvaloniaVersion>
+        <AvaloniaVersion Condition="'$(AvaloniaVersion)' == ''">12.1.0</AvaloniaVersion>
         <AvaloniaWebViewVersion Condition="'$(AvaloniaWebViewVersion)' == ''">12.0.0</AvaloniaWebViewVersion>
         <DotNetTfm Condition="'$(DotNetTfm)' == ''">net11.0</DotNetTfm>
         <MauiSrcDirectory>$(MSBuildThisFileDirectory)/src/</MauiSrcDirectory>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,7 @@ The practical support story is split between full hosting and embedding:
 | Android (`net*-android`) | Yes | Overlap with MAUI native target; not the primary path yet | Yes |
 | iOS (`net*-ios`) | Yes | Overlap with MAUI native target; not the primary path yet | Yes |
 | Mac Catalyst (`net*-maccatalyst`) | Yes | Overlap with MAUI native target; not the primary path yet | Yes |
-| Windows WinUI (`net*-windows`) | Yes | WinUI path currently includes stub handlers | No (current handler is stub) |
+| Windows WinUI (`net*-windows`) | Yes | WinUI full hosting currently includes stub handlers | Yes (via `Avalonia.WinUI` swap chain panel) |
 | Desktop generic (`net*` + `Avalonia.Desktop`) | No | Yes (Windows/macOS/Linux via Avalonia) | N/A |
 | Browser (`net*-browser`) | No | Yes (`useSingleViewLifetime: true`) | N/A |
 

--- a/docs/config-and-setup.md
+++ b/docs/config-and-setup.md
@@ -53,7 +53,7 @@ public static class MauiProgram
 builder.UseAvaloniaApp(useSingleViewLifetime: true);
 ```
 
-On current source state, the `net*-windows` WinUI path is not production-ready. For Avalonia on Windows, prefer the base desktop TFM (`net11.0`) with full hosting.
+On current source state, the `net*-windows` WinUI path does not support full hosting. For full-hosting Avalonia on Windows, prefer the base desktop TFM (`net11.0`); to place Avalonia content inside a MAUI WinUI app, use `UseAvaloniaEmbedding` on the `net*-windows` TFM.
 
 > [!IMPORTANT]
 > In full-hosting mode, call `UseAvaloniaApp` before optional package extensions such as `UseAvaloniaCompatibility`, `UseAvaloniaEssentials`, or `UseAvaloniaSkiaSharp`.
@@ -68,7 +68,7 @@ builder
     .UseAvaloniaEmbedding<AvaloniaApp>();
 ```
 
-Use embedding when incrementally adopting Avalonia in a MAUI-native app. On current source state, Windows embedding is a stub path and should not be treated as production-ready.
+Use embedding when incrementally adopting Avalonia in a MAUI-native app. On Windows, embedding is backed by the `Avalonia.WinUI` package: the `AvaloniaView` content renders into a WinUI 3 `SwapChainPanel` with input, IME, cursor, and drag-and-drop bridged to Avalonia.
 
 ### UseAvaloniaCompatibility
 

--- a/docs/config-and-setup.md
+++ b/docs/config-and-setup.md
@@ -53,7 +53,7 @@ public static class MauiProgram
 builder.UseAvaloniaApp(useSingleViewLifetime: true);
 ```
 
-On current source state, the `net*-windows` WinUI path does not support full hosting. For full-hosting Avalonia on Windows, prefer the base desktop TFM (`net11.0`); to place Avalonia content inside a MAUI WinUI app, use `UseAvaloniaEmbedding` on the `net*-windows` TFM.
+The `net*-windows` WinUI path does not currently support full hosting. For full-hosting Avalonia on Windows, prefer the base desktop TFM (`net11.0`); to place Avalonia content inside a MAUI WinUI app, use `UseAvaloniaEmbedding` on the `net*-windows` TFM.
 
 > [!IMPORTANT]
 > In full-hosting mode, call `UseAvaloniaApp` before optional package extensions such as `UseAvaloniaCompatibility`, `UseAvaloniaEssentials`, or `UseAvaloniaSkiaSharp`.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -5,7 +5,6 @@
 - Blazor Hybrid is not yet implemented.
 - Some `Microsoft.Maui.Essentials` APIs, such as [`MainThread`](https://github.com/dotnet/maui/blob/6c123d72970865ccb1312e118f5098ef6c44e892/src/Essentials/src/MainThread/MainThread.netstandard.cs), cannot be directly overridden. Code that calls them will fall through to the .NET Standard stub and throw `NotSupportedOrImplementedException`. Use alternative APIs such as the .NET MAUI `Dispatcher` as a workaround while support is being added.
 - Avalonia controls can be embedded into .NET MAUI native UI apps, but native UI elements cannot be embedded directly into `Avalonia.Controls.Maui` apps.
-- WinUI embedding of Avalonia and `Avalonia.Controls.Maui` views is not yet supported.
 - Accessibility bridging between .NET MAUI and Avalonia is currently limited.
 - `VerticalTextAlignment` is not supported in Avalonia and is a no-op. Text using this property will appear top-aligned.
 - `IWindowOverlay` is not supported.

--- a/src/Avalonia.Controls.Maui.Compatibility/Extensions/TableViewExtensions.cs
+++ b/src/Avalonia.Controls.Maui.Compatibility/Extensions/TableViewExtensions.cs
@@ -2,6 +2,8 @@ using Microsoft.Maui.Controls;
 
 namespace Avalonia.Controls.Maui.Compatibility;
 
+using TableView = Microsoft.Maui.Controls.TableView;
+
 /// <summary>
 /// Extension methods for mapping TableView properties to Avalonia MauiTableView.
 /// </summary>

--- a/src/Avalonia.Controls.Maui.Compatibility/Handlers/TableViewHandler.cs
+++ b/src/Avalonia.Controls.Maui.Compatibility/Handlers/TableViewHandler.cs
@@ -4,6 +4,8 @@ using Microsoft.Maui.Controls;
 
 namespace Avalonia.Controls.Maui.Compatibility.Handlers;
 
+using TableView = Microsoft.Maui.Controls.TableView;
+
 /// <summary>
 /// Avalonia handler for <see cref="TableView"/>.
 /// </summary>

--- a/src/Avalonia.Controls.Maui/Avalonia.Controls.Maui.csproj
+++ b/src/Avalonia.Controls.Maui/Avalonia.Controls.Maui.csproj
@@ -63,6 +63,11 @@
     <PackageReference Include="Avalonia.Browser" Version="$(AvaloniaVersion)" />
   </ItemGroup>
 
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+    <PackageReference Include="Avalonia.WinUI" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.HarfBuzz" Version="$(AvaloniaVersion)" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Include="../Avalonia.Controls.Maui.targets" Pack="true" PackagePath="build/Avalonia.Controls.Maui.targets" />
     <None Include="../Avalonia.Controls.Maui.targets" Pack="true" PackagePath="buildTransitive/Avalonia.Controls.Maui.targets" />

--- a/src/Avalonia.Controls.Maui/Extensions/MauiAppBuilderExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/MauiAppBuilderExtensions.cs
@@ -63,6 +63,8 @@ public static class MauiAppBuilderExtensions
         avaloniaBuilder.UseAndroid();
 #elif IOS || MACCATALYST
         avaloniaBuilder.UseiOS();
+#elif WINDOWS
+        avaloniaBuilder.UseWin32().UseHarfBuzz().UseSkia();
 #endif
         customizeBuilder?.Invoke(avaloniaBuilder);
 

--- a/src/Avalonia.Controls.Maui/Handlers/AvaloniaControlHandler.Windows.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/AvaloniaControlHandler.Windows.cs
@@ -1,30 +1,31 @@
+using Avalonia.Layout;
+using Avalonia.Controls.Maui.Platforms.Windows.Handlers;
 using Microsoft.Maui;
 
 namespace Avalonia.Controls.Maui.Handlers
 {
     /// <summary>
-    /// Windows stub partial for <see cref="AvaloniaControlHandler{TVirtualView, TControl}"/>.
-    /// Windows/WinUI is not currently supported; this provides a minimal implementation
-    /// so the project compiles for the Windows target framework.
+    /// Windows platform partial for <see cref="AvaloniaControlHandler{TVirtualView, TControl}"/>.
+    /// Hosts the Avalonia control in a WinUI 3 swap chain panel.
     /// </summary>
-    public partial class AvaloniaControlHandler<TVirtualView, TControl> : Microsoft.Maui.Handlers.ViewHandler<TVirtualView, Microsoft.UI.Xaml.Controls.Grid>
+    public partial class AvaloniaControlHandler<TVirtualView, TControl> : Microsoft.Maui.Handlers.ViewHandler<TVirtualView, AvaloniaControlHostView>
         where TVirtualView : class, IView
         where TControl : Avalonia.Controls.Control, new()
     {
         /// <summary>
-        /// Creates a stub platform view for Windows.
+        /// Creates the Windows platform host view.
         /// </summary>
-        /// <returns>An empty <see cref="Microsoft.UI.Xaml.Controls.Grid"/>.</returns>
-        protected override Microsoft.UI.Xaml.Controls.Grid CreatePlatformView()
+        /// <returns>A new <see cref="AvaloniaControlHostView"/> for Windows.</returns>
+        protected override AvaloniaControlHostView CreatePlatformView()
         {
-            return new Microsoft.UI.Xaml.Controls.Grid();
+            return new AvaloniaControlHostView();
         }
 
         /// <summary>
-        /// Connects the handler. Calls <see cref="InitializeControl"/> to set up the Avalonia control.
+        /// Connects the handler and initializes the Avalonia control.
         /// </summary>
         /// <param name="platformView">The Windows platform view.</param>
-        protected override void ConnectHandler(Microsoft.UI.Xaml.Controls.Grid platformView)
+        protected override void ConnectHandler(AvaloniaControlHostView platformView)
         {
             base.ConnectHandler(platformView);
             InitializeControl();
@@ -34,10 +35,29 @@ namespace Avalonia.Controls.Maui.Handlers
         /// Disconnects the handler and cleans up the Avalonia control.
         /// </summary>
         /// <param name="platformView">The Windows platform view.</param>
-        protected override void DisconnectHandler(Microsoft.UI.Xaml.Controls.Grid platformView)
+        protected override void DisconnectHandler(AvaloniaControlHostView platformView)
         {
             CleanupControl();
             base.DisconnectHandler(platformView);
+        }
+
+        /// <summary>
+        /// Gets the desired size by measuring the hosted Avalonia control.
+        /// </summary>
+        /// <param name="widthConstraint">The maximum width constraint.</param>
+        /// <param name="heightConstraint">The maximum height constraint.</param>
+        /// <returns>The desired size of the hosted control.</returns>
+        public override Microsoft.Maui.Graphics.Size GetDesiredSize(double widthConstraint, double heightConstraint)
+        {
+            if (AvaloniaControl is Layoutable control)
+            {
+                control.Measure(new Size(widthConstraint, heightConstraint));
+                var size = new Size(control.DesiredSize.Width, control.DesiredSize.Height);
+                base.GetDesiredSize(size.Width, size.Height);
+                return new Microsoft.Maui.Graphics.Size(size.Width, size.Height);
+            }
+
+            return base.GetDesiredSize(widthConstraint, heightConstraint);
         }
     }
 }

--- a/src/Avalonia.Controls.Maui/Handlers/NativeAvaloniaViewHandler.Windows.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/NativeAvaloniaViewHandler.Windows.cs
@@ -1,39 +1,108 @@
-using Avalonia.Controls.Maui.Controls;
+using Avalonia.Layout;
+using Avalonia.Controls.Maui.Platforms.Windows.Handlers;
+using AvaloniaView = Avalonia.Controls.Maui.Controls.AvaloniaView;
 
 namespace Avalonia.Controls.Maui.Handlers
 {
     /// <summary>
-    /// Windows stub partial for <see cref="NativeAvaloniaViewHandler"/>.
-    /// Windows/WinUI is not currently supported; this provides a minimal implementation
-    /// so the project compiles for the Windows target framework.
+    /// A handler that connects the AvaloniaView control to its Windows platform-specific implementation,
+    /// allowing Avalonia content to be hosted within a .NET MAUI application on Windows (WinUI 3).
     /// </summary>
-    public partial class NativeAvaloniaViewHandler : Microsoft.Maui.Handlers.ViewHandler<AvaloniaView, Microsoft.UI.Xaml.Controls.Grid>
+    public partial class NativeAvaloniaViewHandler : Microsoft.Maui.Handlers.ViewHandler<AvaloniaView, MauiAvaloniaView>
     {
         /// <summary>
-        /// Creates a stub platform view for Windows.
+        /// Creates the platform-specific view for Windows. This method is called when the handler is
+        /// initialized and is responsible for creating an instance of the MauiAvaloniaView, which hosts
+        /// the Avalonia content in a WinUI 3 swap chain panel.
         /// </summary>
-        /// <returns>An empty <see cref="Microsoft.UI.Xaml.Controls.Grid"/>.</returns>
-        protected override Microsoft.UI.Xaml.Controls.Grid CreatePlatformView()
+        /// <returns>The platform-specific view for Windows.</returns>
+        protected override MauiAvaloniaView CreatePlatformView()
         {
-            return new Microsoft.UI.Xaml.Controls.Grid();
+            return new MauiAvaloniaView(VirtualView);
         }
 
         /// <summary>
-        /// Maps the Content property. No-op on Windows.
+        /// Connects the handler to the platform-specific view and pushes the current content into it.
         /// </summary>
-        /// <param name="handler">The handler instance.</param>
-        /// <param name="view">The AvaloniaView instance.</param>
+        /// <param name="platformView">The platform-specific view for Windows.</param>
+        protected override void ConnectHandler(MauiAvaloniaView platformView)
+        {
+            base.ConnectHandler(platformView);
+
+            platformView.UpdateContent();
+        }
+
+        /// <summary>
+        /// Disconnects the handler from the platform-specific view, detaching the hosted Avalonia
+        /// content so it can be re-used. Swap chain resources are released by the panel itself when
+        /// it is unloaded from the WinUI visual tree.
+        /// </summary>
+        /// <param name="platformView">The platform-specific view for Windows.</param>
+        protected override void DisconnectHandler(MauiAvaloniaView platformView)
+        {
+            platformView.ClearContent();
+            base.DisconnectHandler(platformView);
+        }
+
+        /// <summary>
+        /// Maps the Content property from the AvaloniaView to the MauiAvaloniaView.
+        /// </summary>
+        /// <param name="handler">The handler that manages the connection between the AvaloniaView and the MauiAvaloniaView.</param>
+        /// <param name="view">The AvaloniaView instance whose content is being mapped.</param>
         public static void MapContent(NativeAvaloniaViewHandler handler, AvaloniaView view)
         {
+            handler.PlatformView?.UpdateContent();
         }
 
         /// <summary>
-        /// Maps the Background property. No-op on Windows.
+        /// Maps the Background property from the AvaloniaView to the Avalonia content area background.
+        /// Converts MAUI's <see cref="Microsoft.Maui.Controls.Brush"/> to an Avalonia brush.
         /// </summary>
-        /// <param name="handler">The handler instance.</param>
-        /// <param name="view">The AvaloniaView instance.</param>
+        /// <param name="handler">The handler that manages the connection between the AvaloniaView and the MauiAvaloniaView.</param>
+        /// <param name="view">The AvaloniaView instance whose background is being mapped.</param>
         public static void MapBackground(NativeAvaloniaViewHandler handler, AvaloniaView view)
         {
+            if (handler.PlatformView is null)
+                return;
+
+            var mauiColor = view.BackgroundColor;
+            if (mauiColor is not null)
+            {
+                var avBrush = new Avalonia.Media.SolidColorBrush(
+                    new Avalonia.Media.Color(
+                        (byte)(mauiColor.Alpha * 255),
+                        (byte)(mauiColor.Red * 255),
+                        (byte)(mauiColor.Green * 255),
+                        (byte)(mauiColor.Blue * 255)));
+                handler.PlatformView.UpdateBackground(avBrush);
+            }
+            else
+            {
+                handler.PlatformView.UpdateBackground(null);
+            }
+        }
+
+        /// <summary>
+        /// Gets the desired size of the platform-specific view based on the content of the AvaloniaView.
+        /// Measures the Avalonia content so MAUI layout can accommodate it properly.
+        /// </summary>
+        /// <param name="widthConstraint">The maximum width that the view can occupy.</param>
+        /// <param name="heightConstraint">The maximum height that the view can occupy.</param>
+        /// <returns>The desired size of the platform-specific view.</returns>
+        public override Microsoft.Maui.Graphics.Size GetDesiredSize(double widthConstraint, double heightConstraint)
+        {
+            if (VirtualView.Content is Layoutable control)
+            {
+                control.Measure(new Size(widthConstraint, heightConstraint));
+
+                base.GetDesiredSize(control.DesiredSize.Width, control.DesiredSize.Height);
+
+                return new Microsoft.Maui.Graphics.Size(control.DesiredSize.Width, control.DesiredSize.Height);
+            }
+            else
+            {
+                return base.GetDesiredSize(widthConstraint, heightConstraint);
+            }
         }
     }
 }

--- a/src/Avalonia.Controls.Maui/Handlers/NativeAvaloniaViewHandler.Windows.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/NativeAvaloniaViewHandler.Windows.cs
@@ -55,8 +55,9 @@ namespace Avalonia.Controls.Maui.Handlers
         }
 
         /// <summary>
-        /// Maps the Background property from the AvaloniaView to the Avalonia content area background.
-        /// Converts MAUI's <see cref="Microsoft.Maui.Controls.Brush"/> to an Avalonia brush.
+        /// Maps the BackgroundColor property from the AvaloniaView to the Avalonia content area background.
+        /// Converts MAUI's <see cref="Microsoft.Maui.Graphics.Color"/> to an Avalonia
+        /// <see cref="Avalonia.Media.SolidColorBrush"/>.
         /// </summary>
         /// <param name="handler">The handler that manages the connection between the AvaloniaView and the MauiAvaloniaView.</param>
         /// <param name="view">The AvaloniaView instance whose background is being mapped.</param>

--- a/src/Avalonia.Controls.Maui/Platform/Windows/AvaloniaControlHostView.Windows.cs
+++ b/src/Avalonia.Controls.Maui/Platform/Windows/AvaloniaControlHostView.Windows.cs
@@ -1,0 +1,34 @@
+using Avalonia.Controls.Maui.Handlers;
+
+namespace Avalonia.Controls.Maui.Platforms.Windows.Handlers
+{
+    /// <summary>
+    /// Windows platform host view that renders an Avalonia control inside a .NET MAUI handler.
+    /// Inherits from <see cref="Avalonia.WinUI.AvaloniaSwapChainPanel"/> and wraps the control
+    /// in a <see cref="Avalonia.Controls.Border"/> for background support.
+    /// </summary>
+    public partial class AvaloniaControlHostView : Avalonia.WinUI.AvaloniaSwapChainPanel, IAvaloniaControlHost
+    {
+        readonly Avalonia.Controls.Border _backgroundBorder = new();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AvaloniaControlHostView"/> class.
+        /// </summary>
+        public AvaloniaControlHostView()
+        {
+            Content = _backgroundBorder;
+        }
+
+        /// <inheritdoc/>
+        public void SetControl(Avalonia.Controls.Control? control)
+        {
+            _backgroundBorder.Child = control;
+        }
+
+        /// <inheritdoc/>
+        public void UpdateBackground(Avalonia.Media.IBrush? brush)
+        {
+            _backgroundBorder.Background = brush;
+        }
+    }
+}

--- a/src/Avalonia.Controls.Maui/Platform/Windows/MauiAvaloniaView.Windows.cs
+++ b/src/Avalonia.Controls.Maui/Platform/Windows/MauiAvaloniaView.Windows.cs
@@ -1,0 +1,52 @@
+using Avalonia.Controls.Maui.Controls;
+
+namespace Avalonia.Controls.Maui.Platforms.Windows.Handlers
+{
+    /// <summary>
+    /// A platform-specific view for Windows that hosts Avalonia content within a .NET MAUI application.
+    /// Inherits from <see cref="Avalonia.WinUI.AvaloniaSwapChainPanel"/>, which renders the Avalonia
+    /// content into a WinUI 3 swap chain and bridges input, IME, cursors and drag-and-drop.
+    /// </summary>
+    public partial class MauiAvaloniaView : Avalonia.WinUI.AvaloniaSwapChainPanel
+    {
+        readonly AvaloniaView _mauiView;
+        readonly Avalonia.Controls.Border _backgroundBorder = new();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MauiAvaloniaView"/> class.
+        /// </summary>
+        /// <param name="mauiView">The Avalonia view to host within the .NET MAUI application.</param>
+        public MauiAvaloniaView(AvaloniaView mauiView)
+        {
+            _mauiView = mauiView;
+            Content = _backgroundBorder;
+        }
+
+        /// <summary>
+        /// Updates the content of the Avalonia view. This method sets the hosted content to the
+        /// content of the AvaloniaView, allowing the Avalonia content to be displayed within the
+        /// WinUI visual tree.
+        /// </summary>
+        public void UpdateContent()
+        {
+            _backgroundBorder.Child = _mauiView.Content as Avalonia.Controls.Control;
+        }
+
+        /// <summary>
+        /// Detaches the hosted Avalonia content so it can be re-parented elsewhere.
+        /// </summary>
+        public void ClearContent()
+        {
+            _backgroundBorder.Child = null;
+        }
+
+        /// <summary>
+        /// Updates the background of the Avalonia content area.
+        /// </summary>
+        /// <param name="brush">The Avalonia brush to use as the background, or <see langword="null"/> to use the default theme background.</param>
+        public void UpdateBackground(Avalonia.Media.IBrush? brush)
+        {
+            _backgroundBorder.Background = brush;
+        }
+    }
+}

--- a/tests/Avalonia.Controls.Maui.RenderTests/Infrastructure/RenderTestBase.cs
+++ b/tests/Avalonia.Controls.Maui.RenderTests/Infrastructure/RenderTestBase.cs
@@ -22,9 +22,14 @@ public class RenderTestBase : IAsyncDisposable
         if (_isCreated) return;
         _isCreated = true;
 
-        // Use invariant culture for consistent rendering across locales
+        // Use invariant culture for consistent rendering across locales.
+        // Also set the process-wide defaults: since Avalonia 12.1, controls such as
+        // DatePicker read CultureInfo.CurrentCulture from the dispatcher thread,
+        // which is not necessarily the thread running this method.
         CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
         CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+        CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+        CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
 
         var appBuilder = MauiApp.CreateBuilder();
         appBuilder.ConfigureTestBuilder();

--- a/tests/Avalonia.Controls.Maui.RenderTests/Tests/TableViewRenderTests.cs
+++ b/tests/Avalonia.Controls.Maui.RenderTests/Tests/TableViewRenderTests.cs
@@ -5,6 +5,9 @@ using MauiTextAlignment = Microsoft.Maui.TextAlignment;
 
 namespace Avalonia.Controls.Maui.RenderTests.Tests;
 
+// Inside the namespace so it wins over Avalonia.Controls.TableView (added in Avalonia 12.1).
+using TableView = Microsoft.Maui.Controls.TableView;
+
 public class TableViewRenderTests : RenderTestBase
 {
     [AvaloniaFact]

--- a/tests/Avalonia.Controls.Maui.Tests/Gestures/DragDropGestureTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Gestures/DragDropGestureTests.cs
@@ -35,20 +35,28 @@ namespace Avalonia.Controls.Maui.Tests.Gestures
             // PresentationSource, so the platform view must be hosted in a shown window.
             var window = new Avalonia.Controls.Window { Content = platformView, Width = 300, Height = 300 };
             window.Show();
-            Avalonia.Threading.Dispatcher.UIThread.RunJobs();
 
-            // Press at (10,10)
-            var pressed = CreatePointerPressedEventArgs(platformView, new Point(10, 10));
-            platformView.RaiseEvent(pressed);
+            try
+            {
+                Avalonia.Threading.Dispatcher.UIThread.RunJobs();
 
-            // Move past threshold (5px) to (20, 10) - distance = 10px
-            var moved = CreatePointerMovedEventArgs(platformView, new Point(20, 10));
-            platformView.RaiseEvent(moved);
+                // Press at (10,10)
+                var pressed = CreatePointerPressedEventArgs(platformView, new Point(10, 10));
+                platformView.RaiseEvent(pressed);
 
-            // Allow async drag initiation to run
-            await Task.Delay(50);
+                // Move past threshold (5px) to (20, 10) - distance = 10px
+                var moved = CreatePointerMovedEventArgs(platformView, new Point(20, 10));
+                platformView.RaiseEvent(moved);
 
-            Assert.True(dragStartingFired, "DragStarting should have fired after moving past threshold");
+                // Allow async drag initiation to run
+                await Task.Delay(50);
+
+                Assert.True(dragStartingFired, "DragStarting should have fired after moving past threshold");
+            }
+            finally
+            {
+                window.Close();
+            }
         }
 
         [AvaloniaFact(DisplayName = "DragGesture does not fire on simple tap")]

--- a/tests/Avalonia.Controls.Maui.Tests/Gestures/DragDropGestureTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Gestures/DragDropGestureTests.cs
@@ -31,6 +31,12 @@ namespace Avalonia.Controls.Maui.Tests.Gestures
             var handler = await CreateHandlerAsync(label);
             var platformView = handler.PlatformView!;
 
+            // Since Avalonia 12.1, PointerEventArgs.GetPosition requires the visual to have a
+            // PresentationSource, so the platform view must be hosted in a shown window.
+            var window = new Avalonia.Controls.Window { Content = platformView, Width = 300, Height = 300 };
+            window.Show();
+            Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
             // Press at (10,10)
             var pressed = CreatePointerPressedEventArgs(platformView, new Point(10, 10));
             platformView.RaiseEvent(pressed);

--- a/tests/Avalonia.Controls.Maui.Tests/Gestures/GestureManagerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Gestures/GestureManagerTests.cs
@@ -80,6 +80,12 @@ namespace Avalonia.Controls.Maui.Tests.Gestures
             var handler = await CreateHandlerAsync(label);
             var platformView = handler.PlatformView!;
 
+            // Since Avalonia 12.1, PointerEventArgs.GetPosition requires the visual to have a
+            // PresentationSource, so the platform view must be hosted in a shown window.
+            var window = new Avalonia.Controls.Window { Content = platformView, Width = 300, Height = 300 };
+            window.Show();
+            Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
             // Simulate Swipe Right: Press at 10,10 -> Release at 110,10
             var pressed = CreatePointerPressedEventArgs(platformView, new Point(10, 10));
             platformView.RaiseEvent(pressed);

--- a/tests/Avalonia.Controls.Maui.Tests/Gestures/GestureManagerTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Gestures/GestureManagerTests.cs
@@ -84,17 +84,25 @@ namespace Avalonia.Controls.Maui.Tests.Gestures
             // PresentationSource, so the platform view must be hosted in a shown window.
             var window = new Avalonia.Controls.Window { Content = platformView, Width = 300, Height = 300 };
             window.Show();
-            Avalonia.Threading.Dispatcher.UIThread.RunJobs();
 
-            // Simulate Swipe Right: Press at 10,10 -> Release at 110,10
-            var pressed = CreatePointerPressedEventArgs(platformView, new Point(10, 10));
-            platformView.RaiseEvent(pressed);
+            try
+            {
+                Avalonia.Threading.Dispatcher.UIThread.RunJobs();
 
-            var released = CreatePointerReleasedEventArgs(platformView, new Point(110, 10)); // +100 X
-            platformView.RaiseEvent(released);
+                // Simulate Swipe Right: Press at 10,10 -> Release at 110,10
+                var pressed = CreatePointerPressedEventArgs(platformView, new Point(10, 10));
+                platformView.RaiseEvent(pressed);
 
-            Assert.True(swiped, "Swipe Right should have fired");
-            Assert.Equal(Microsoft.Maui.SwipeDirection.Right, direction);
+                var released = CreatePointerReleasedEventArgs(platformView, new Point(110, 10)); // +100 X
+                platformView.RaiseEvent(released);
+
+                Assert.True(swiped, "Swipe Right should have fired");
+                Assert.Equal(Microsoft.Maui.SwipeDirection.Right, direction);
+            }
+            finally
+            {
+                window.Close();
+            }
         }
 
         [AvaloniaFact(DisplayName = "PanGestureRecognizer triggers PanUpdated events")]

--- a/tests/Avalonia.Controls.Maui.Tests/Stubs/TableViewStub.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Stubs/TableViewStub.cs
@@ -4,6 +4,9 @@ using System;
 
 namespace Avalonia.Controls.Maui.Tests.Stubs;
 
+// Inside the namespace so it wins over Avalonia.Controls.TableView (added in Avalonia 12.1).
+using TableView = Microsoft.Maui.Controls.TableView;
+
 /// <summary>
 /// TableView test stub implementing minimal requirements for handler testing.
 /// </summary>


### PR DESCRIPTION
This PR bumps Avalonia to 12.1 and adds Avalonia.WinUI embedding support.

** Copilot stuff below **

This pull request adds production-ready support for hosting Avalonia controls inside .NET MAUI applications on Windows (WinUI 3), using the `Avalonia.WinUI` swap chain panel. It replaces previous stub implementations with real handlers and platform views, updates documentation to reflect the new Windows embedding capabilities, and makes supporting changes to project files and tests.

**Windows platform embedding and handlers:**

* Implements real Windows platform handlers for `AvaloniaControlHandler` and `NativeAvaloniaViewHandler`, using new `AvaloniaControlHostView` and `MauiAvaloniaView` classes that host Avalonia content in a WinUI 3 swap chain panel and bridge input, background, and layout. Stub code is removed. [[1]](diffhunk://#diff-5a0d24e5ff2425e31fe038da88ef3a8fa4b766138b2070be21ac3529afe7efb4R1-R28) [[2]](diffhunk://#diff-5c6085b4a5d010100fc452a197bd00712e3cb2fa8da77d5c81e49672679111f3L1-R105) [[3]](diffhunk://#diff-b1708da2d498c4f2669f6a49b1d0e65228099d779ce161cb23bf0a82227f3433R1-R34) [[4]](diffhunk://#diff-f1393dae0aae143fa63fcea586730453982b9af66520a8bd8310e20c34663ef3R1-R52)
* Updates Windows-specific handler methods to measure Avalonia content for proper MAUI layout and map background properties. [[1]](diffhunk://#diff-5a0d24e5ff2425e31fe038da88ef3a8fa4b766138b2070be21ac3529afe7efb4L37-R61) [[2]](diffhunk://#diff-5c6085b4a5d010100fc452a197bd00712e3cb2fa8da77d5c81e49672679111f3L1-R105)

**Project and platform configuration:**

* Adds `Avalonia.WinUI` and `Avalonia.HarfBuzz` as dependencies for Windows targets, and configures the builder to use them. [[1]](diffhunk://#diff-dd942569f80df2a6ac4632ff93aeba6746fd0d1fd915d58d1366f78f9400188fR66-R70) [[2]](diffhunk://#diff-985eaa9d3faf086fb4acfe3c89e804229afdbfdb73015806b341e7fc3e23423cR66-R67)
* Updates the Avalonia version to 12.1.0 for all targets.

**Documentation improvements:**

* Updates architecture and setup docs to clarify that Windows WinUI embedding is now supported and describes how to use full hosting versus embedding. Removes the known issue about lack of WinUI embedding. [[1]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L40-R40) [[2]](diffhunk://#diff-d2f6edaa06bcb2b7d3a038ccdd8be57bd3d4173f3275930e240b64ec0fea2d64L56-R56) [[3]](diffhunk://#diff-d2f6edaa06bcb2b7d3a038ccdd8be57bd3d4173f3275930e240b64ec0fea2d64L71-R71) [[4]](diffhunk://#diff-ab850bbacf01a93fe03d0d87d0ed5d2db2f1e1d1d27c7057eb556e63b084c4e7L8)

**Test and compatibility fixes:**

* Updates tests to ensure platform views are hosted in visible windows for pointer events, and sets process-wide culture defaults for consistent rendering with Avalonia 12.1. [[1]](diffhunk://#diff-40d97e830b77aab5ed4187cbcac46938fc6d8c7addb973ffd7547c001ddd3261R34-R39) [[2]](diffhunk://#diff-556cfcb6574ba3dd8592bde8ff4f03ad1705586bb43aca40bb565d9977393f1dL25-R32)
* Resolves `TableView` type conflicts due to new Avalonia 12.1 types. [[1]](diffhunk://#diff-9b2c45a0c240f2c372d3ce6ed1486c1eac8eb4ce2487a7783f100ee61dd358a9R5-R6) [[2]](diffhunk://#diff-63b244eecbda351342c620fcb1bf446dc1d36cc3051a96ca7ce2b2543dd7ddb9R7-R8) [[3]](diffhunk://#diff-46cd88299057e38bc456924f4c0f1e10d24152501b0f39c0ff18ef591b246d5cR8-R10)

