### PR TITLE
Use control-specific Dispatcher instead of global UIThread

### DIFF
--- a/src/Avalonia.Controls.Maui.Essentials/Screenshot/AvaloniaScreenshot.cs
+++ b/src/Avalonia.Controls.Maui.Essentials/Screenshot/AvaloniaScreenshot.cs
@@ -35,7 +35,7 @@ public class AvaloniaScreenshot : IScreenshot
         var topLevel = _platformProvider.GetTopLevel()
             ?? throw new InvalidOperationException("Unable to get Avalonia TopLevel. Ensure the application has been fully initialized.");
 
-        return await Dispatcher.UIThread.InvokeAsync(() =>
+        return await topLevel.Dispatcher.InvokeAsync(() =>
         {
             var scaling = topLevel.RenderScaling;
             var clientSize = topLevel.ClientSize;

--- a/src/Avalonia.Controls.Maui.SkiaSharp.Views/Controls/SKCanvasViewControl.cs
+++ b/src/Avalonia.Controls.Maui.SkiaSharp.Views/Controls/SKCanvasViewControl.cs
@@ -59,7 +59,7 @@ public class SKCanvasViewControl : Control
     /// </summary>
     public void InvalidateCanvas()
     {
-        Threading.Dispatcher.UIThread.Post(() =>
+        this.Dispatcher.Post(() =>
         {
             base.InvalidateVisual();
         });

--- a/src/Avalonia.Controls.Maui.SkiaSharp.Views/Controls/SKGLViewControl.cs
+++ b/src/Avalonia.Controls.Maui.SkiaSharp.Views/Controls/SKGLViewControl.cs
@@ -105,7 +105,7 @@ public class SKGLViewControl : Control
     /// </summary>
     public void InvalidateCanvas()
     {
-        Threading.Dispatcher.UIThread.Post(() =>
+        this.Dispatcher.Post(() =>
         {
             base.InvalidateVisual();
         });

--- a/src/Avalonia.Controls.Maui/Controls/CollectionView/MauiCollectionView.cs
+++ b/src/Avalonia.Controls.Maui/Controls/CollectionView/MauiCollectionView.cs
@@ -1444,7 +1444,7 @@ public class MauiCollectionView : TemplatedControl
         if (_itemsControl == null || _scrollViewer == null)
             return;
 
-        Dispatcher.UIThread.Post(() =>
+        this.Dispatcher.Post(() =>
         {
             if (!IsGrouped &&
                 group == null &&
@@ -1474,7 +1474,7 @@ public class MauiCollectionView : TemplatedControl
         if (_itemsControl == null || _scrollViewer == null)
             return;
 
-        Dispatcher.UIThread.Post(() =>
+        this.Dispatcher.Post(() =>
         {
             if (!IsGrouped &&
                 groupIndex < 0 &&

--- a/src/Avalonia.Controls.Maui/Controls/Shell/ShellSearchControl.cs
+++ b/src/Avalonia.Controls.Maui/Controls/Shell/ShellSearchControl.cs
@@ -635,7 +635,7 @@ namespace Avalonia.Controls.Maui.Handlers.Shell
                 var controller = (ISearchHandlerController?)_mauiSearchHandler;
                 controller?.ItemSelected(selectedItem);
 
-                Avalonia.Threading.Dispatcher.UIThread.Post(() => 
+                this.Dispatcher.Post(() => 
                 {
                     if (_resultsList != null) _resultsList.SelectedItem = null;
                     if (_resultsList != null) _resultsList.SelectedItem = null;

--- a/src/Avalonia.Controls.Maui/Controls/Shell/ShellSearchControl.cs
+++ b/src/Avalonia.Controls.Maui/Controls/Shell/ShellSearchControl.cs
@@ -638,7 +638,6 @@ namespace Avalonia.Controls.Maui.Handlers.Shell
                 this.Dispatcher.Post(() => 
                 {
                     if (_resultsList != null) _resultsList.SelectedItem = null;
-                    if (_resultsList != null) _resultsList.SelectedItem = null;
                     if (_searchBar != null)
                     {
                         _searchBar.IsEnabled = true;

--- a/src/Avalonia.Controls.Maui/Controls/SwipeView/Swipe.cs
+++ b/src/Avalonia.Controls.Maui/Controls/SwipeView/Swipe.cs
@@ -549,7 +549,7 @@ public class Swipe : Grid
         else
         {
             // If bounds are not ready, defer to next render pass.
-            Dispatcher.UIThread.Post(transformAction, DispatcherPriority.Render);
+            this.Dispatcher.Post(transformAction, DispatcherPriority.Render);
         }
 
     }
@@ -849,7 +849,7 @@ public class Swipe : Grid
 
         if (!animated)
         {
-            Dispatcher.UIThread.Post(() =>
+            this.Dispatcher.Post(() =>
             {
                 _transition.Duration = originalDuration;
             }, DispatcherPriority.Render);

--- a/src/Avalonia.Controls.Maui/Extensions/PageExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/PageExtensions.cs
@@ -46,7 +46,7 @@ public static class PageExtensions
                             
                             if (bitmap != null)
                             {
-                                await Threading.Dispatcher.UIThread.InvokeAsync(() =>
+                                await platformView.Dispatcher.InvokeAsync(() =>
                                 {
                                     platformView.Background = new global::Avalonia.Media.ImageBrush
                                     {

--- a/src/Avalonia.Controls.Maui/Extensions/ShellExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/ShellExtensions.cs
@@ -308,6 +308,7 @@ public static class ShellExtensions
         if (handler._flyoutPaneContainer == null || shell == null || handler.MauiContext == null)
             return;
 
+        var dispatcher = handler._flyoutPaneContainer.Dispatcher;
         var backgroundImage = shell.FlyoutBackgroundImage;
 
         if (backgroundImage != null)
@@ -323,7 +324,7 @@ public static class ShellExtensions
                     {
                         var result = await avaloniaService.GetImageAsync(backgroundImage, 1.0f);
                         
-                        await Threading.Dispatcher.UIThread.InvokeAsync(() =>
+                        await dispatcher.InvokeAsync(() =>
                         {
                             if (result != null)
                             {
@@ -365,7 +366,7 @@ public static class ShellExtensions
             }
         }
 
-        await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+        await dispatcher.InvokeAsync(() =>
         {
             handler.UpdateFlyoutBackground(shell);
         });

--- a/src/Avalonia.Controls.Maui/Extensions/ViewExtensions.cs
+++ b/src/Avalonia.Controls.Maui/Extensions/ViewExtensions.cs
@@ -21,7 +21,7 @@ public static class ViewExtensions
     /// to handle all transformation properties from the .NET MAUI view.</remarks>
     public static void UpdateTransformation(this PlatformView control, IView view)
     {
-        Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+        control.Dispatcher.InvokeAsync(() =>
         {
             if (control.RenderTransform is not global::Avalonia.Media.TransformGroup group)
             {

--- a/src/Avalonia.Controls.Maui/Handlers/CarouselViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/CarouselViewHandler.cs
@@ -419,7 +419,7 @@ public class CarouselViewHandler : ViewHandler<CarouselView, PlatformView>
 
     private void OnItemsSourceCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        global::Avalonia.Threading.Dispatcher.UIThread.Post(RefreshItemsSourceAfterCollectionChanged);
+        PlatformViewOrNull?.Dispatcher.Post(RefreshItemsSourceAfterCollectionChanged);
     }
 
     private void RefreshItemsSourceAfterCollectionChanged()

--- a/src/Avalonia.Controls.Maui/Handlers/CollectionViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/CollectionViewHandler.cs
@@ -133,7 +133,7 @@ public class CollectionViewHandler : ViewHandler<CollectionView, MauiCollectionV
         var selectedItem = PlatformView.SelectedItem;
         var selectedItems = PlatformView.SelectedItems?.Cast<object>().ToList();
 
-        Dispatcher.UIThread.Post(() =>
+        PlatformView.Dispatcher.Post(() =>
         {
             if (VirtualView == null || PlatformView == null || _isUpdatingSelection)
                 return;
@@ -200,7 +200,7 @@ public class CollectionViewHandler : ViewHandler<CollectionView, MauiCollectionV
 
     private void OnRemainingItemsThresholdReached(object? sender, EventArgs e)
     {
-        Dispatcher.UIThread.Post(() =>
+        PlatformViewOrNull?.Dispatcher.Post(() =>
         {
             // Use MAUI's built-in method which fires both the event and command
             VirtualView?.SendRemainingItemsThresholdReached();

--- a/src/Avalonia.Controls.Maui/Handlers/IndicatorViewHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/IndicatorViewHandler.cs
@@ -83,7 +83,7 @@ public partial class IndicatorViewHandler : ViewHandler<IIndicatorView, Platform
 
         // Property mappers fire before the control template is applied, so pip containers do not
         // exist yet. Defer size and selection sync to after the first layout pass.
-        Dispatcher.UIThread.Post(() =>
+        pv.Dispatcher.Post(() =>
         {
             pv.UpdatePipSize(VirtualView);
             pv.ForceSelection(VirtualView);

--- a/src/Avalonia.Controls.Maui/Handlers/Shell/ShellHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/Shell/ShellHandler.cs
@@ -282,7 +282,7 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
         {
             if (VirtualView != null)
             {
-                Threading.Dispatcher.UIThread.Post(() =>
+                PlatformViewOrNull?.Dispatcher.Post(() =>
                 {
                     this.UpdateFlyoutItemsAppearance(VirtualView);
                 }, Threading.DispatcherPriority.Render);
@@ -488,7 +488,7 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
             TrackCurrentPage();
 
 
-            Threading.Dispatcher.UIThread.Post(() =>
+            PlatformViewOrNull?.Dispatcher.Post(() =>
             {
                 if (VirtualView != null)
                 {
@@ -604,7 +604,7 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
         if (VirtualView != null)
         {
             VirtualView.FlyoutIsPresented = true;
-            Threading.Dispatcher.UIThread.Post(() =>
+            PlatformViewOrNull?.Dispatcher.Post(() =>
             {
                 if (VirtualView != null)
                 {
@@ -645,7 +645,7 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
                 _currentItemHandler?.UpdateTabBarVisibility(VirtualView.CurrentItem);
 
             // Force focus clear on page change to ensure navigation settles cleanly
-            Threading.Dispatcher.UIThread.Post(() => 
+            PlatformViewOrNull?.Dispatcher.Post(() => 
             {
                 var topLevel = _mainContainer != null ? TopLevel.GetTopLevel(_mainContainer) : null;
                 topLevel?.FocusManager?.Focus(null);
@@ -1250,7 +1250,7 @@ public partial class ShellHandler : ViewHandler<MauiShell, AvaloniaControl>
     {
         if (e.PropertyName == SearchHandler.SearchBoxVisibilityProperty.PropertyName)
         {
-            Threading.Dispatcher.UIThread.Post(() => 
+            PlatformViewOrNull?.Dispatcher.Post(() => 
             {
                 if (VirtualView != null)
                 {

--- a/src/Avalonia.Controls.Maui/Handlers/TabbedPageHandler.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/TabbedPageHandler.cs
@@ -161,7 +161,7 @@ public partial class TabbedPageHandler : ViewHandler<MauiTabbedPage, AvaloniaTab
                     : null;
                 var preservedIconImageSource = page.IconImageSource;
 
-                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                platformView.Dispatcher.Post(() =>
                 {
                     if (((IElementHandler)this).VirtualView == virtualView &&
                         ((IElementHandler)this).PlatformView == platformView)

--- a/src/Avalonia.Controls.Maui/Handlers/ViewHandlerOfT.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ViewHandlerOfT.cs
@@ -34,7 +34,7 @@ public abstract partial class ViewHandler<TVirtualView, TPlatformView> : Element
     {
     }
 
-    PlatformView? PlatformViewOrNull => (PlatformView?)((IElementHandler)this).PlatformView;
+    private protected PlatformView? PlatformViewOrNull => (PlatformView?)((IElementHandler)this).PlatformView;
 
     IView? VirtualViewOrNull => (IView?)((IElementHandler)this).VirtualView;
 
@@ -178,13 +178,13 @@ public abstract partial class ViewHandler<TVirtualView, TPlatformView> : Element
         // and carries the margin. Measure the outermost view for correct sizing.
         var viewToMeasure = ContainerView ?? platformView;
 
-        if (Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+        if (viewToMeasure.Dispatcher.CheckAccess())
         {
             return MeasureCore(viewToMeasure, widthConstraint, heightConstraint);
         }
         else
         {
-            return Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+            return viewToMeasure.Dispatcher.InvokeAsync(() =>
             {
                 return MeasureCore(viewToMeasure, widthConstraint, heightConstraint);
             }).GetAwaiter().GetResult();
@@ -215,10 +215,11 @@ public abstract partial class ViewHandler<TVirtualView, TPlatformView> : Element
     /// <inheritdoc/>
     public virtual void PlatformArrange(Microsoft.Maui.Graphics.Rect frame)
     {
-        if (Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+        var dispatcher = PlatformViewOrNull?.Dispatcher ?? Avalonia.Threading.Dispatcher.UIThread;
+        if (dispatcher.CheckAccess())
             Arrange(frame);
         else
-            Avalonia.Threading.Dispatcher.UIThread.Invoke(() => Arrange(frame));
+            dispatcher.Invoke(() => Arrange(frame));
     }
 
     /// <summary>

--- a/src/Avalonia.Controls.Maui/Platform/AlertManager.cs
+++ b/src/Avalonia.Controls.Maui/Platform/AlertManager.cs
@@ -227,7 +227,7 @@ internal class AlertManager
 
             public void SetBusy(bool busy)
             {
-                 Dispatcher.UIThread.InvokeAsync(() =>
+                 _host.Dispatcher.InvokeAsync(() =>
                  {
                      EnsureOverlay();
                      _busyCount = Math.Max(0, busy ? _busyCount + 1 : _busyCount - 1);
@@ -242,7 +242,7 @@ internal class AlertManager
             {
                  Grid? dialogContainer = null;
 
-                 await Dispatcher.UIThread.InvokeAsync(() =>
+                 await _host.Dispatcher.InvokeAsync(() =>
                  {
                      EnsureOverlay();
 
@@ -266,7 +266,7 @@ internal class AlertManager
                  });
 
                  // Trigger fade-in after the container is in the visual tree
-                 await Dispatcher.UIThread.InvokeAsync(() =>
+                 await _host.Dispatcher.InvokeAsync(() =>
                  {
                      if (dialogContainer != null)
                          dialogContainer.Opacity = 1;
@@ -279,7 +279,7 @@ internal class AlertManager
                  finally
                  {
                      // Trigger fade-out
-                     await Dispatcher.UIThread.InvokeAsync(() =>
+                     await _host.Dispatcher.InvokeAsync(() =>
                      {
                          if (_dialogGrid?.Children.Count > 0 && _dialogGrid.Children[^1] is Visual top)
                              top.Opacity = 0;
@@ -289,7 +289,7 @@ internal class AlertManager
                      await Task.Delay(DialogAnimationDuration);
 
                      // Remove from tree
-                     await Dispatcher.UIThread.InvokeAsync(() =>
+                     await _host.Dispatcher.InvokeAsync(() =>
                      {
                          if (_dialogGrid?.Children.Count > 0)
                              _dialogGrid.Children.RemoveAt(_dialogGrid.Children.Count - 1);

--- a/src/Avalonia.Controls.Maui/Platform/AvaloniaGesturePlatformManager.cs
+++ b/src/Avalonia.Controls.Maui/Platform/AvaloniaGesturePlatformManager.cs
@@ -233,12 +233,13 @@ internal sealed class AvaloniaGesturePlatformManager : IGesturePlatformManager
             var capturedPoint = point;
             var capturedView = view;
             var capturedRecognizers = singleTapRecognizers.ToList();
+            var dispatcher = _platformView?.Dispatcher;
 
             _ = Task.Delay(DoubleTapDelayMs, cts.Token).ContinueWith(t =>
             {
                 if (!t.IsCanceled)
                 {
-                    Threading.Dispatcher.UIThread.Post(() =>
+                    dispatcher?.Post(() =>
                     {
                         foreach (var recognizer in capturedRecognizers)
                         {

--- a/src/Avalonia.Controls.Maui/Platform/MauiPromptDialog.axaml.cs
+++ b/src/Avalonia.Controls.Maui/Platform/MauiPromptDialog.axaml.cs
@@ -57,7 +57,7 @@ public partial class MauiPromptDialog : UserControl
     {
         base.OnAttachedToVisualTree(e);
         var tb = this.FindControl<TextBox>("InputTextBox");
-        Dispatcher.UIThread.Post(() => 
+        this.Dispatcher.Post(() => 
         {
             tb?.Focus();
             if (!string.IsNullOrEmpty(InputValue))

--- a/src/Avalonia.Controls.Maui/Platform/PlatformGraphicsView.cs
+++ b/src/Avalonia.Controls.Maui/Platform/PlatformGraphicsView.cs
@@ -35,7 +35,7 @@ public class PlatformGraphicsView : Control
     /// </summary>
     public new void InvalidateVisual()
     {
-        Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+        this.Dispatcher.Post(() =>
         {
             base.InvalidateVisual();
         });


### PR DESCRIPTION
Avalonia 12 added a control-specific `Dispatcher` on `AvaloniaObject`. This replaces global `Dispatcher.UIThread` usage with the dispatcher of the control in scope at every site that has one, as suggested in https://github.com/AvaloniaUI/Avalonia.Controls.Maui/pull/171#discussion_r3145392522.

Fixes #188  