### PR TITLE
Route security reports to security@avaloniaui.net

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ Security fixes are applied to the latest release only. Older versions do not rec
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Report vulnerabilities privately using [GitHub's private vulnerability reporting](https://github.com/AvaloniaUI/Avalonia.Controls.Maui/security/advisories/new), or send an email to **tim@avaloniaui.net or javier@avaloniaui.net**.
+Report vulnerabilities privately using [GitHub's private vulnerability reporting](https://github.com/AvaloniaUI/Avalonia.Controls.Maui/security/advisories/new), or send an email to **security@avaloniaui.net**.
 
 Include as much of the following as possible:
 
@@ -22,7 +22,7 @@ Include as much of the following as possible:
 - Steps to reproduce or a proof-of-concept
 - Any suggested mitigations, if known
 
-We aim to acknowledge reports within **5 business days** and to provide a resolution timeline within **14 business days**. We will keep you informed of progress and credit you in the advisory unless you prefer to remain anonymous.
+We will acknowledge reports within **2 business days** and provide a resolution timeline within **10 business days**. We will keep you informed of progress and credit you in the advisory unless you prefer to remain anonymous.
 
 ## Scope
 


### PR DESCRIPTION
## What

- Replaces the personal email addresses (tim@/javier@) in SECURITY.md with **security@avaloniaui.net**, the org-wide security contact monitored under the [CRA incident reporting runbook](https://github.com/AvaloniaUI/Staff-Guide/pull/15).
- Aligns the response commitments with the org default policy (acknowledge within 2 business days, resolution timeline within 10).

## Why

Part of the CRA coordinated vulnerability disclosure rollout (AvaloniaUI/CustomerPortal#377). Personal inboxes are a single point of failure for the Article 14 24-hour reporting clock, which starts when anyone at the company becomes aware of active exploitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)