### PR TITLE
Bump builds to .NET 11 RC1, SkiaSharp 4.x

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,7 +51,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <MicrosoftExtensionsVersion>11.0.0-preview.7.26381.103</MicrosoftExtensionsVersion>
+        <MicrosoftExtensionsVersion>11.0.0-rc.1.26425.128</MicrosoftExtensionsVersion>
     </PropertyGroup>
 
     <!--
@@ -63,7 +63,7 @@
         items, which the SDK defines after this file is imported.
     -->
     <PropertyGroup>
-        <NativeAotPackVersion>11.0.0-preview.7.26381.103</NativeAotPackVersion>
+        <NativeAotPackVersion>11.0.0-rc.1.26425.128</NativeAotPackVersion>
     </PropertyGroup>
 
     <!--
@@ -91,7 +91,7 @@
     </Target>
 
     <PropertyGroup Condition="'$(DotNetTfm)' == 'net11.0'">
-        <MauiVersion>11.0.0-preview.7.26406.9</MauiVersion>
+        <MauiVersion>11.0.0-rc.1.26451.6</MauiVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(DotNetTfm)' == 'net10.0'">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
     <PropertyGroup>
         <!-- <AvaloniaVersion>9999.0.0-localbuild</AvaloniaVersion> -->
         <IsPackable>false</IsPackable>
-        <AvaloniaVersion Condition="'$(AvaloniaVersion)' == ''">12.1.0</AvaloniaVersion>
+        <AvaloniaVersion Condition="'$(AvaloniaVersion)' == ''">12.1.2</AvaloniaVersion>
         <AvaloniaWebViewVersion Condition="'$(AvaloniaWebViewVersion)' == ''">12.0.0</AvaloniaWebViewVersion>
         <DotNetTfm Condition="'$(DotNetTfm)' == ''">net11.0</DotNetTfm>
         <MauiSrcDirectory>$(MSBuildThisFileDirectory)/src/</MauiSrcDirectory>
@@ -78,6 +78,16 @@
         <HarfBuzzSharpVersion>$([System.Text.RegularExpressions.Regex]::Match('$(_AvaloniaPackagesPropsContent)', 'Include="HarfBuzzSharp" Version="([^"]+)"').Groups[1].Value)</HarfBuzzSharpVersion>
         <MicroComVersion>$([System.Text.RegularExpressions.Regex]::Match('$(_AvaloniaPackagesPropsContent)', 'Include="MicroCom\.Runtime" Version="([^"]+)"').Groups[1].Value)</MicroComVersion>
         <_AvaloniaPackagesPropsContent />
+    </PropertyGroup>
+    <!--
+        NuGet builds: pin SkiaSharp/HarfBuzzSharp explicitly instead of taking the transitive
+        versions from Avalonia.Skia (3.119.4 / 8.3.1.3 as of Avalonia 12.1). SkiaSharp 4.151.0 is the
+        first release that ships Emscripten 5.0.6 WebAssembly static libraries for net11.0, and
+        HarfBuzzSharp 14.2.1.102 is the matching HarfBuzzSharp release with the same net11.0 support.
+    -->
+    <PropertyGroup Condition="'$(AvaloniaSourcePath)' == ''">
+        <SkiaSharpVersion Condition="'$(SkiaSharpVersion)' == ''">4.151.0</SkiaSharpVersion>
+        <HarfBuzzSharpVersion Condition="'$(HarfBuzzSharpVersion)' == ''">14.2.1.102</HarfBuzzSharpVersion>
     </PropertyGroup>
     <Target Name="_ValidateAvaloniaSourceVersions"
             BeforeTargets="PrepareForBuild"

--- a/src/Avalonia.Controls.Maui.SkiaSharp.Views/Avalonia.Controls.Maui.SkiaSharp.Views.csproj
+++ b/src/Avalonia.Controls.Maui.SkiaSharp.Views/Avalonia.Controls.Maui.SkiaSharp.Views.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Microsoft.Maui.Core" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-    <PackageReference Include="SkiaSharp.Views.Maui.Core" Version="3.119.3-preview.1.1" />
-    <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="3.119.3-preview.1.1" />
+    <PackageReference Include="SkiaSharp.Views.Maui.Core" Version="$(SkiaSharpVersion)" />
+    <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="$(SkiaSharpVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Avalonia.Controls.Maui.targets
+++ b/src/Avalonia.Controls.Maui.targets
@@ -56,6 +56,24 @@
     </ItemGroup>
   </Target>
 
+  <!-- SkiaSharp 4.151+ and HarfBuzzSharp 14.2.1.102+ ship Emscripten 5.0.6 static libraries for
+       net11.0+ and select them from their own buildTransitive targets. Avalonia.Browser.targets
+       (12.1.x) predates that and still adds the Emscripten 3.1.56 archives for every TFM >= net9.0,
+       so on net11.0 both sets would be handed to the linker. Drop the stale 3.1.56 archives so only
+       the ones SkiaSharp/HarfBuzzSharp picked for this TFM are linked. -->
+  <Target Name="_AvMauiRemoveLegacyEmscriptenNativeRefs"
+          BeforeTargets="_PrepareForBrowserWasmBuildNative;_CoreCLRPrepareForNativeBuild"
+          Condition="'$(_AvMauiTargetPlatformId)' == 'browser' And '$(TargetFrameworkVersion)' != '' And $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '11.0'))">
+    <ItemGroup>
+      <_AvMauiLegacyNativeRef Include="@(NativeFileReference)"
+          Condition="$([System.String]::Copy('%(FullPath)').Replace('\', '/').Contains('/3.1.56/')) And ($([System.String]::Copy('%(FullPath)').Contains('libSkiaSharp.a')) Or $([System.String]::Copy('%(FullPath)').Contains('libHarfBuzzSharp.a')))" />
+      <NativeFileReference Remove="@(_AvMauiLegacyNativeRef)" />
+    </ItemGroup>
+    <Message Importance="high"
+             Text="Avalonia.Controls.Maui: removed Emscripten 3.1.56 native references superseded by the net11.0 SkiaSharp/HarfBuzzSharp libraries: @(_AvMauiLegacyNativeRef)"
+             Condition="'@(_AvMauiLegacyNativeRef)' != ''" />
+  </Target>
+
   <Target Name="ConvertMauiImagesToAvaloniaResources"
           BeforeTargets="AddAvaloniaResources"
           DependsOnTargets="ResizetizeImages;_ReadResizetizeImagesOutputs">

--- a/src/Avalonia.Controls.Maui/Avalonia.Controls.Maui.csproj
+++ b/src/Avalonia.Controls.Maui/Avalonia.Controls.Maui.csproj
@@ -40,6 +40,22 @@
     <PackageReference Include="Microsoft.Maui.Graphics.Skia" Version="$(MauiVersion)" />
   </ItemGroup>
 
+  <!-- Explicit SkiaSharp/HarfBuzzSharp pins (NuGet builds only; source builds get these from
+       SourceBuild.targets). Direct references override the older transitive versions that
+       Avalonia.Skia declares. The Linux and WebAssembly native asset packages are listed
+       explicitly because the SkiaSharp/HarfBuzzSharp packages themselves only pull in the
+       macOS/Windows/mobile native assets, so without these the Linux and WASM native
+       libraries would stay at the Avalonia.Skia transitive version and mismatch the managed
+       assemblies. -->
+  <ItemGroup Condition="'$(AvaloniaSourcePath)' == ''">
+    <PackageReference Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="$(SkiaSharpVersion)" />
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" Version="$(SkiaSharpVersion)" />
+    <PackageReference Include="HarfBuzzSharp" Version="$(HarfBuzzSharpVersion)" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="$(HarfBuzzSharpVersion)" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="$(HarfBuzzSharpVersion)" />
+  </ItemGroup>
+
   <!-- Source generator -->
   <ItemGroup>
     <ProjectReference Include="../Avalonia.Controls.Maui.SourceGenerators/Avalonia.Controls.Maui.SourceGenerators.csproj"

--- a/src/Avalonia.Controls.Maui/Handlers/ViewHandlerOfT.cs
+++ b/src/Avalonia.Controls.Maui/Handlers/ViewHandlerOfT.cs
@@ -182,14 +182,17 @@ public abstract partial class ViewHandler<TVirtualView, TPlatformView> : Element
         {
             return MeasureCore(viewToMeasure, widthConstraint, heightConstraint);
         }
-        else
-        {
-            return viewToMeasure.Dispatcher.InvokeAsync(() =>
-            {
-                return MeasureCore(viewToMeasure, widthConstraint, heightConstraint);
-            }).GetAwaiter().GetResult();
-        }
+
+        return MeasureOnDispatcher(viewToMeasure, widthConstraint, heightConstraint);
     }
+
+    // Separate and not inlined so the closure is only allocated on the cross-thread path:
+    // captured locals are hoisted at method entry, so an inline lambda would allocate on
+    // every measure including the same-thread fast path.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Microsoft.Maui.Graphics.Size MeasureOnDispatcher(PlatformView viewToMeasure, double widthConstraint, double heightConstraint) =>
+        viewToMeasure.Dispatcher.InvokeAsync(
+            () => MeasureCore(viewToMeasure, widthConstraint, heightConstraint)).GetAwaiter().GetResult();
 
     /// <summary>
     /// Performs the core measurement of the platform view against the given constraints.
@@ -219,8 +222,13 @@ public abstract partial class ViewHandler<TVirtualView, TPlatformView> : Element
         if (dispatcher.CheckAccess())
             Arrange(frame);
         else
-            dispatcher.Invoke(() => Arrange(frame));
+            ArrangeOnDispatcher(dispatcher, frame);
     }
+
+    // See MeasureOnDispatcher: keeps the closure off the same-thread fast path.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ArrangeOnDispatcher(Avalonia.Threading.Dispatcher dispatcher, Microsoft.Maui.Graphics.Rect frame) =>
+        dispatcher.Invoke(() => Arrange(frame));
 
     /// <summary>
     /// Arranges the platform view within the specified frame, compensating for MAUI/Avalonia margin differences.

--- a/tests/Avalonia.Controls.Maui.RenderTests/Tests/ButtonRenderTests.cs
+++ b/tests/Avalonia.Controls.Maui.RenderTests/Tests/ButtonRenderTests.cs
@@ -20,7 +20,7 @@ public class ButtonRenderTests : RenderTestBase
 
         await RenderToFile(button);
         // Text rendering differs slightly between platforms
-        CompareImages(tolerance: 0.045);
+        CompareImages(tolerance: 0.05);
     }
 }
 

--- a/tests/Avalonia.Controls.Maui.RenderTests/Tests/TableViewRenderTests.cs
+++ b/tests/Avalonia.Controls.Maui.RenderTests/Tests/TableViewRenderTests.cs
@@ -45,6 +45,6 @@ public class TableViewRenderTests : RenderTestBase
         };
 
         await RenderToFile(control);
-        CompareImages(tolerance: 0.06);
+        CompareImages(tolerance: 0.07);
     }
 }

--- a/tests/Avalonia.Controls.Maui.RenderTests/Tests/VisualElementRenderTests.cs
+++ b/tests/Avalonia.Controls.Maui.RenderTests/Tests/VisualElementRenderTests.cs
@@ -52,7 +52,7 @@ public class VisualElementRenderTests : RenderTestBase
         };
 
         await RenderToFile(control);
-        CompareImages(tolerance: 0.06);
+        CompareImages(tolerance: 0.07);
     }
 
     private sealed class InheritedVisualElementModel(string title)

--- a/tests/Avalonia.Controls.Maui.Tests/Services/AvaloniaUriImageSourceServiceTests.cs
+++ b/tests/Avalonia.Controls.Maui.Tests/Services/AvaloniaUriImageSourceServiceTests.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Avalonia.Controls.Maui.Services;
 using Avalonia.Controls.Maui.Tests;
 using Avalonia;
+using Avalonia.Headless.XUnit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
@@ -15,13 +16,7 @@ public class AvaloniaUriImageSourceServiceTests
     private static readonly byte[] PngBytes = Convert.FromBase64String(
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z/C/HwAFgwJ/lkVfoQAAAABJRU5ErkJggg==");
 
-    static AvaloniaUriImageSourceServiceTests()
-    {
-        // Ensure Avalonia platform services are available for Bitmap creation
-        TestAppBuilder.BuildAvaloniaApp().SetupWithoutStarting();
-    }
-
-    [Fact(DisplayName = "Default URI image service sets no User-Agent")]
+    [AvaloniaFact(DisplayName = "Default URI image service sets no User-Agent")]
     public void DefaultRequestSendsNoUserAgent()
     {
         using var client = new HttpClient(new CountingHandler(PngBytes));
@@ -31,7 +26,7 @@ public class AvaloniaUriImageSourceServiceTests
         Assert.Equal(string.Empty, client.DefaultRequestHeaders.UserAgent.ToString());
     }
 
-    [Fact(DisplayName = "URI image service preserves supplied HttpClient User-Agent")]
+    [AvaloniaFact(DisplayName = "URI image service preserves supplied HttpClient User-Agent")]
     public void SuppliedHttpClientUserAgentIsPreserved()
     {
         using var client = new HttpClient(new CountingHandler(PngBytes));
@@ -42,7 +37,7 @@ public class AvaloniaUriImageSourceServiceTests
         Assert.Equal("Existing.Client/2.0", client.DefaultRequestHeaders.UserAgent.ToString());
     }
 
-    [Fact(DisplayName = "Default image source registration sets no URI image User-Agent")]
+    [AvaloniaFact(DisplayName = "Default image source registration sets no URI image User-Agent")]
     public void ConfigureImageSourcesSetsNoUriImageSourceUserAgent()
     {
         var builder = MauiApp.CreateBuilder();
@@ -57,7 +52,7 @@ public class AvaloniaUriImageSourceServiceTests
         Assert.Equal(string.Empty, httpClient.DefaultRequestHeaders.UserAgent.ToString());
     }
 
-    [Fact(DisplayName = "Default image source registration uses registered HttpClient")]
+    [AvaloniaFact(DisplayName = "Default image source registration uses registered HttpClient")]
     public void ConfigureImageSourcesUsesRegisteredHttpClient()
     {
         var builder = MauiApp.CreateBuilder();
@@ -77,7 +72,7 @@ public class AvaloniaUriImageSourceServiceTests
         Assert.Equal("Registered.Client/5.0", httpClient.DefaultRequestHeaders.UserAgent.ToString());
     }
 
-    [Fact(DisplayName = "Uses cached file for subsequent requests", Skip = "https://github.com/AvaloniaUI/Avalonia.Controls.Maui/issues/74")]
+    [AvaloniaFact(DisplayName = "Uses cached file for subsequent requests", Skip = "https://github.com/AvaloniaUI/Avalonia.Controls.Maui/issues/74")]
     public async Task UsesCachedFile()
     {
         var handler = new CountingHandler(PngBytes);
@@ -114,7 +109,7 @@ public class AvaloniaUriImageSourceServiceTests
         }
     }
 
-    [Fact(DisplayName = "Expired cache downloads again", Skip = "https://github.com/AvaloniaUI/Avalonia.Controls.Maui/issues/74")]
+    [AvaloniaFact(DisplayName = "Expired cache downloads again", Skip = "https://github.com/AvaloniaUI/Avalonia.Controls.Maui/issues/74")]
     public async Task ExpiredCacheDownloadsAgain()
     {
         var handler = new CountingHandler(PngBytes);


### PR DESCRIPTION
This PR bumps the dependencies up to .NET 11 RC1 builds. It also fixes #228 with a workaround by bumping SkiaSharp to a 4.x build and Avalonia.Browser changes to allow both to build and work with it.

Copilot stuff below
----

This pull request updates dependencies and improves compatibility for .NET 11.0, while also refactoring some code for efficiency and updating test attributes. The most significant changes are grouped below:

### Dependency updates and compatibility improvements

* Updated `AvaloniaVersion` to 12.1.2, `MicrosoftExtensionsVersion` and `NativeAotPackVersion` to 11.0.0-rc.1.26425.128, and `MauiVersion` to 11.0.0-rc.1.26451.6 in `Directory.Build.props` for improved stability and compatibility. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL29-R29) [[2]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL54-R54) [[3]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL66-R66) [[4]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL94-R104)
* Explicitly pinned `SkiaSharp` to 4.151.0 and `HarfBuzzSharp` to 14.2.1.102 for NuGet builds, ensuring correct native asset versions for Linux and WebAssembly, and updated `SkiaSharp.Views.Maui.*` package references to use the pinned version. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eR82-R91) [[2]](diffhunk://#diff-b028d0b5380a09e9a2e3e9268db95759e00635d11fe5b9cc1d975a02a5a80ad1L19-R20) [[3]](diffhunk://#diff-dd942569f80df2a6ac4632ff93aeba6746fd0d1fd915d58d1366f78f9400188fR43-R58)
* Added a build target in `Avalonia.Controls.Maui.targets` to remove legacy Emscripten 3.1.56 native references when building for net11.0+, preventing conflicts with newer SkiaSharp/HarfBuzzSharp libraries.

### Code refactoring for efficiency

* Refactored dispatcher invocation in `ViewHandlerOfT.cs` to avoid unnecessary closure allocations in the fast path, improving performance for measure and arrange operations. [[1]](diffhunk://#diff-de421a36c420cca159b0188548ba5cba25543d96427aa8b3873dfc010820edffL185-R196) [[2]](diffhunk://#diff-de421a36c420cca159b0188548ba5cba25543d96427aa8b3873dfc010820edffL222-R232)

### Test improvements

* Updated test attributes in `AvaloniaUriImageSourceServiceTests.cs` to use `[AvaloniaFact]` for better Avalonia test integration, and added `Avalonia.Headless.XUnit` import. [[1]](diffhunk://#diff-67ab0d404d1375a8dd2efe2edefe1aa6c519d2cbe29835f14139d2a98d497ba3R6) [[2]](diffhunk://#diff-67ab0d404d1375a8dd2efe2edefe1aa6c519d2cbe29835f14139d2a98d497ba3L18-R19) [[3]](diffhunk://#diff-67ab0d404d1375a8dd2efe2edefe1aa6c519d2cbe29835f14139d2a98d497ba3L34-R29) [[4]](diffhunk://#diff-67ab0d404d1375a8dd2efe2edefe1aa6c519d2cbe29835f14139d2a98d497ba3L45-R40) [[5]](diffhunk://#diff-67ab0d404d1375a8dd2efe2edefe1aa6c519d2cbe29835f14139d2a98d497ba3L60-R55) [[6]](diffhunk://#diff-67ab0d404d1375a8dd2efe2edefe1aa6c519d2cbe29835f14139d2a98d497ba3L80-R75) [[7]](diffhunk://#diff-67ab0d404d1375a8dd2efe2edefe1aa6c519d2cbe29835f14139d2a98d497ba3L117-R112)
* Slightly increased image comparison tolerance in `VisualElementRenderTests.cs` to reduce test flakiness.